### PR TITLE
Collect telemetry metrics from Triton metrics endpoint

### DIFF
--- a/genai-perf/genai_perf/constants.py
+++ b/genai-perf/genai_perf/constants.py
@@ -26,7 +26,7 @@
 
 DEFAULT_HTTP_URL = "localhost:8000"
 DEFAULT_GRPC_URL = "localhost:8001"
-DEFAULT_TRITON_METRICS_URL = "http://0.0.0.0:8002/metrics"
+DEFAULT_TRITON_METRICS_URL = "localhost:8002/metrics"
 
 OPEN_ORCA = "openorca"
 CNN_DAILY_MAIL = "cnn_dailymail"

--- a/genai-perf/genai_perf/main.py
+++ b/genai-perf/genai_perf/main.py
@@ -111,7 +111,8 @@ def report_output(data_parser: ProfileDataParser, args: Namespace) -> None:
         load_level = f"{args.request_rate}"
     else:
         raise GenAIPerfException("No valid infer mode specified")
-
+    
+    #TPA-274 - Integrate telemetry metrics with other metrics for export
     stats = data_parser.get_statistics(infer_mode, load_level)
     reporter = OutputReporter(stats, args)
     reporter.report_output()

--- a/genai-perf/genai_perf/main.py
+++ b/genai-perf/genai_perf/main.py
@@ -111,8 +111,8 @@ def report_output(data_parser: ProfileDataParser, args: Namespace) -> None:
         load_level = f"{args.request_rate}"
     else:
         raise GenAIPerfException("No valid infer mode specified")
-    
-    #TPA-274 - Integrate telemetry metrics with other metrics for export
+
+    # TPA-274 - Integrate telemetry metrics with other metrics for export
     stats = data_parser.get_statistics(infer_mode, load_level)
     reporter = OutputReporter(stats, args)
     reporter.report_output()

--- a/genai-perf/genai_perf/metrics/__init__.py
+++ b/genai-perf/genai_perf/metrics/__init__.py
@@ -27,3 +27,4 @@
 from genai_perf.metrics.llm_metrics import LLMMetrics
 from genai_perf.metrics.metrics import MetricMetadata, Metrics
 from genai_perf.metrics.statistics import Statistics
+from genai_perf.metrics.telemetry_metrics import TelemetryMetrics

--- a/genai-perf/genai_perf/metrics/telemetry_metrics.py
+++ b/genai-perf/genai_perf/metrics/telemetry_metrics.py
@@ -77,7 +77,6 @@ class TelemetryMetrics:
                 attr_strs.append(f"{k}={v}")
         return f"TelemetryMetrics({','.join(attr_strs)})"
 
-
     def __iter__(self):
         for attr, value in self.__dict__.items():
             yield attr, value

--- a/genai-perf/genai_perf/metrics/telemetry_metrics.py
+++ b/genai-perf/genai_perf/metrics/telemetry_metrics.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import List
+
+from genai_perf.metrics.metrics import MetricMetadata
+
+
+class TelemetryMetrics:
+    """
+    A class that contains common telemetry level metrics.
+    Metrics are stored as lists where each inner list corresponds to multiple measurements per GPU.
+    Each measurement is recorded every 1000 ms.
+    """
+
+    TELEMETRY_METRICS = [
+        MetricMetadata("gpu_power_usage", "watts"),
+        MetricMetadata("gpu_power_limit", "watts"),
+        MetricMetadata("energy_consumption", "joules"),
+        MetricMetadata("gpu_utilization", "percentage"),
+        MetricMetadata("total_gpu_memory", "bytes"),
+        MetricMetadata("gpu_memory_used", "bytes"),
+    ]
+
+    def __init__(
+        self,
+        gpu_power_usage: List[List[float]] = [],  # Multiple measurements per GPU
+        gpu_power_limit: List[List[float]] = [],
+        energy_consumption: List[List[float]] = [],
+        gpu_utilization: List[List[float]] = [],
+        total_gpu_memory: List[List[int]] = [],
+        gpu_memory_used: List[List[int]] = [],
+    ) -> None:
+        self.gpu_power_usage = gpu_power_usage
+        self.gpu_power_limit = gpu_power_limit
+        self.energy_consumption = energy_consumption
+        self.gpu_utilization = gpu_utilization
+        self.total_gpu_memory = total_gpu_memory
+        self.gpu_memory_used = gpu_memory_used
+
+    def __repr__(self):
+        attr_strs = []
+        for k, v in self.__dict__.items():
+            if not k.startswith("_"):
+                attr_strs.append(f"{k}={v}")
+        return f"TelemetryMetrics({','.join(attr_strs)})"
+
+    @property
+    def telemetry_metrics(self) -> List[MetricMetadata]:
+        return self.TELEMETRY_METRICS
+
+    @property
+    def data(self) -> dict:
+        """Returns all the metrics."""
+        return {k: v for k, v in self.__dict__.items() if not k.startswith("_")}

--- a/genai-perf/genai_perf/metrics/telemetry_metrics.py
+++ b/genai-perf/genai_perf/metrics/telemetry_metrics.py
@@ -33,9 +33,9 @@ from genai_perf.metrics.metrics import MetricMetadata
 
 class TelemetryMetrics:
     """
-    A class that contains common telemetry level metrics.
+    A class that contains common telemetry metrics.
     Metrics are stored as lists where each inner list corresponds to multiple measurements per GPU.
-    Each measurement is recorded every 1000 ms.
+    Each measurement is recorded every second.
     """
 
     TELEMETRY_METRICS = [
@@ -53,8 +53,8 @@ class TelemetryMetrics:
         gpu_power_limit: List[List[float]] = [],
         energy_consumption: List[List[float]] = [],
         gpu_utilization: List[List[float]] = [],
-        total_gpu_memory: List[List[int]] = [],
-        gpu_memory_used: List[List[int]] = [],
+        total_gpu_memory: List[List[float]] = [],
+        gpu_memory_used: List[List[float]] = [],
     ) -> None:
         self.gpu_power_usage = gpu_power_usage
         self.gpu_power_limit = gpu_power_limit
@@ -63,12 +63,24 @@ class TelemetryMetrics:
         self.total_gpu_memory = total_gpu_memory
         self.gpu_memory_used = gpu_memory_used
 
+    def update_metrics(self, measurement_data: dict) -> None:
+        """Update the metrics with new measurement data"""
+        for metric in self.TELEMETRY_METRICS:
+            metric_key = metric.name
+            if metric_key in measurement_data:
+                getattr(self, metric_key).append(measurement_data[metric_key])
+
     def __repr__(self):
         attr_strs = []
         for k, v in self.__dict__.items():
             if not k.startswith("_"):
                 attr_strs.append(f"{k}={v}")
         return f"TelemetryMetrics({','.join(attr_strs)})"
+
+
+    def __iter__(self):
+        for attr, value in self.__dict__.items():
+            yield attr, value
 
     @property
     def telemetry_metrics(self) -> List[MetricMetadata]:

--- a/genai-perf/genai_perf/metrics/telemetry_metrics.py
+++ b/genai-perf/genai_perf/metrics/telemetry_metrics.py
@@ -77,15 +77,8 @@ class TelemetryMetrics:
                 attr_strs.append(f"{k}={v}")
         return f"TelemetryMetrics({','.join(attr_strs)})"
 
-    def __iter__(self):
-        for attr, value in self.__dict__.items():
-            yield attr, value
 
     @property
     def telemetry_metrics(self) -> List[MetricMetadata]:
         return self.TELEMETRY_METRICS
 
-    @property
-    def data(self) -> dict:
-        """Returns all the metrics."""
-        return {k: v for k, v in self.__dict__.items() if not k.startswith("_")}

--- a/genai-perf/genai_perf/metrics/telemetry_metrics.py
+++ b/genai-perf/genai_perf/metrics/telemetry_metrics.py
@@ -77,8 +77,6 @@ class TelemetryMetrics:
                 attr_strs.append(f"{k}={v}")
         return f"TelemetryMetrics({','.join(attr_strs)})"
 
-
     @property
     def telemetry_metrics(self) -> List[MetricMetadata]:
         return self.TELEMETRY_METRICS
-

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -39,6 +39,7 @@ from genai_perf.constants import (
     DEFAULT_ARTIFACT_DIR,
     DEFAULT_COMPARE_DIR,
     OPEN_ORCA,
+    DEFAULT_TRITON_METRICS_URL,
 )
 from genai_perf.llm_inputs.llm_inputs import (
     LlmInputs,
@@ -766,8 +767,17 @@ def compare_handler(args: argparse.Namespace):
 
 def profile_handler(args, extra_args):
     from genai_perf.wrapper import Profiler
+    from genai_perf.telemetry_data.triton_telemetry_data_collector import (
+        TritonTelemetryDataCollector,
+    )
+    telemetry_data_collector = None
+    if args.service_kind == "triton":
+        # TPA-275: pass server url as a CLI option in non-default case
+        telemetry_data_collector = TritonTelemetryDataCollector(
+            server_metrics_url=DEFAULT_TRITON_METRICS_URL
+        )
 
-    Profiler.run(args=args, extra_args=extra_args)
+    Profiler.run(telemetry_data_collector, args=args, extra_args=extra_args)
 
 
 ### Parser Initialization ###

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -778,7 +778,11 @@ def profile_handler(args, extra_args):
             server_metrics_url=DEFAULT_TRITON_METRICS_URL
         )
 
-    Profiler.run(telemetry_data_collector, args=args, extra_args=extra_args)
+    Profiler.run(
+        args=args,
+        extra_args=extra_args,
+        telemetry_data_collector=telemetry_data_collector,
+    )
 
 
 ### Parser Initialization ###

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -38,8 +38,8 @@ from genai_perf.constants import (
     CNN_DAILY_MAIL,
     DEFAULT_ARTIFACT_DIR,
     DEFAULT_COMPARE_DIR,
-    OPEN_ORCA,
     DEFAULT_TRITON_METRICS_URL,
+    OPEN_ORCA,
 )
 from genai_perf.llm_inputs.llm_inputs import (
     LlmInputs,
@@ -766,10 +766,11 @@ def compare_handler(args: argparse.Namespace):
 
 
 def profile_handler(args, extra_args):
-    from genai_perf.wrapper import Profiler
     from genai_perf.telemetry_data.triton_telemetry_data_collector import (
         TritonTelemetryDataCollector,
     )
+    from genai_perf.wrapper import Profiler
+
     telemetry_data_collector = None
     if args.service_kind == "triton":
         # TPA-275: pass server url as a CLI option in non-default case

--- a/genai-perf/genai_perf/telemetry_data/__init__.py
+++ b/genai-perf/genai_perf/telemetry_data/__init__.py
@@ -24,15 +24,4 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-DEFAULT_HTTP_URL = "localhost:8000"
-DEFAULT_GRPC_URL = "localhost:8001"
-DEFAULT_TRITON_METRICS_URL = "http://0.0.0.0:8002/metrics"
-
-OPEN_ORCA = "openorca"
-CNN_DAILY_MAIL = "cnn_dailymail"
-DEFAULT_INPUT_DATA_JSON = "llm_inputs.json"
-
-
-DEFAULT_ARTIFACT_DIR = "artifacts"
-DEFAULT_COMPARE_DIR = "compare"
-DEFAULT_PARQUET_FILE = "all_data"
+from genai_perf.telemetry_data.telemetry_data_collector import TelemetryDataCollector

--- a/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import threading
+import time
+from abc import ABC, abstractmethod
+from typing import Dict, List
+
+import requests
+from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
+
+
+class TelemetryDataCollector(ABC):
+    def __init__(
+        self, server_metrics_url: str, collection_interval: float = 1.0  # in seconds
+    ) -> None:
+        self._server_metrics_url = server_metrics_url
+        self._collection_interval = collection_interval
+        self._metrics = TelemetryMetrics()
+        self._stop_event = threading.Event()
+        self._thread = None
+
+    def _fetch_metrics(self) -> None:
+        """Fetch the metrics from the metrics endpoint"""
+        response = requests.get(self._server_metrics_url)
+        response.raise_for_status()
+        return response.text
+
+    @abstractmethod
+    def _parse_metrics(self) -> None:
+        """Parse metrics data. This method should be implemented by subclasses."""
+        pass
+
+    def _update_metrics(self, parsed_data) -> None:
+        for metric_name, metric_values in parsed_data.items():
+            if len(metric_values) > len(getattr(self.metrics, metric_name, [])):
+                current_values = getattr(self.metrics, metric_name, [])
+                current_values.append(metric_values)
+                setattr(self.metrics, metric_name, current_values)
+        print(self.metrics)
+
+    def _collect_metrics(self) -> None:
+        while not self._stop_event.is_set():
+            metrics_data = self._fetch_metrics()
+            parsed_data = self._parse_metrics(metrics_data)
+            self._update_metrics(parsed_data)
+
+            self.metrics.gpu_power_usage.append(parsed_data["gpu_power_usage"])
+            self.metrics.gpu_power_limit.append(parsed_data["gpu_power_limit"])
+            self.metrics.energy_consumption.append(parsed_data["energy_consumption"])
+            self.metrics.gpu_utilization.append(parsed_data["gpu_utilization"])
+            self.metrics.total_gpu_memory.append(parsed_data["total_gpu_memory"])
+            self.metrics.gpu_memory_used.append(parsed_data["gpu_memory_used"])
+
+            time.sleep(self._collection_interval)
+
+    def start(self) -> None:
+        """Start the telemetry data collection thread."""
+        if self._thread is None or not self._thread.is_alive():
+            self._stop_event.clear()
+            self._thread = threading.Thread(target=self._collect_metrics)
+            self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the telemetry data collection thread."""
+        if self._thread is not None and self._thread.is_alive():
+            self._stop_event.set()
+            self._thread.join()
+
+    @property
+    def metrics(self) -> TelemetryMetrics:
+        """Return the collected metrics."""
+        return self._metrics

--- a/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
@@ -62,7 +62,6 @@ class TelemetryDataCollector(ABC):
                 current_values = getattr(self.metrics, metric_name, [])
                 current_values.append(metric_values)
                 setattr(self.metrics, metric_name, current_values)
-        print(self.metrics)
 
     def _collect_metrics(self) -> None:
         while not self._stop_event.is_set():

--- a/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
@@ -26,10 +26,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import threading
+
 import time
 from abc import ABC, abstractmethod
-from typing import Dict, List
+from threading import Event, Thread
+from typing import Optional
 
 import requests
 from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
@@ -42,14 +43,14 @@ class TelemetryDataCollector(ABC):
         self._server_metrics_url = server_metrics_url
         self._collection_interval = collection_interval
         self._metrics = TelemetryMetrics()
-        self._stop_event = threading.Event()
-        self._thread = None
+        self._stop_event = Event()
+        self._thread: Optional[Thread] = None
 
     def start(self) -> None:
         """Start the telemetry data collection thread."""
         if self._thread is None or not self._thread.is_alive():
             self._stop_event.clear()
-            self._thread = threading.Thread(target=self._collect_metrics)
+            self._thread = Thread(target=self._collect_metrics)
             self._thread.start()
 
     def stop(self) -> None:
@@ -65,7 +66,7 @@ class TelemetryDataCollector(ABC):
         return response.text
 
     @abstractmethod
-    def _process_and_update_metrics(self) -> None:
+    def _process_and_update_metrics(self, metrics_data: str) -> None:
         """This method should be implemented by subclasses."""
         pass
 

--- a/genai-perf/genai_perf/telemetry_data/triton_telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/triton_telemetry_data_collector.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import re
+from typing import Dict, List
+
+from genai_perf.telemetry_data.telemetry_data_collector import TelemetryDataCollector
+
+
+class TritonTelemetryDataCollector(TelemetryDataCollector):
+    """Class to collect telemetry metrics from Triton server"""
+
+    def _parse_metrics(self, data: str) -> None:
+        # Parsing logic for Prometheus metrics
+        metrics = {
+            "gpu_power_usage": [],
+            "gpu_power_limit": [],
+            "energy_consumption": [],
+            "gpu_utilization": [],
+            "total_gpu_memory": [],
+            "gpu_memory_used": [],
+        }
+
+        for line in data.splitlines():
+            if line.startswith("nv_gpu_power_usage"):
+                self._extract_metric(line, metrics["gpu_power_usage"])
+            elif line.startswith("nv_gpu_power_limit"):
+                self._extract_metric(line, metrics["gpu_power_limit"])
+            elif line.startswith("nv_energy_consumption"):
+                self._extract_metric(line, metrics["energy_consumption"])
+            elif line.startswith("nv_gpu_utilization"):
+                self._extract_metric(line, metrics["gpu_utilization"])
+            elif line.startswith("nv_gpu_memory_total_bytes"):
+                self._extract_metric(line, metrics["total_gpu_memory"])
+            elif line.startswith("nv_gpu_memory_used_bytes"):
+                self._extract_metric(line, metrics["gpu_memory_used"])
+        return metrics
+
+    def _extract_metric(
+        self, metric_line: str, metric_list: List[List[float]]
+    ) -> Dict[str, List[List[float]]]:
+        metric_components = metric_line.split()
+        metric_value = float(metric_components[1])
+        metric_list.append(metric_value)

--- a/genai-perf/genai_perf/telemetry_data/triton_telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/triton_telemetry_data_collector.py
@@ -28,11 +28,12 @@
 
 from typing import Dict, List
 
-from genai_perf.telemetry_data.telemetry_data_collector import TelemetryDataCollector
 import genai_perf.logging as logging
-
+from genai_perf.telemetry_data.telemetry_data_collector import TelemetryDataCollector
 
 logger = logging.getLogger(__name__)
+
+
 class TritonTelemetryDataCollector(TelemetryDataCollector):
     """Class to collect telemetry metrics from Triton server"""
 
@@ -75,23 +76,25 @@ class TritonTelemetryDataCollector(TelemetryDataCollector):
             logger.info("Response from Triton metrics endpoint is empty")
             return
 
-        self.current_measurement_interval = {metric.name: [] for metric in self.metrics.TELEMETRY_METRICS}
-    
+        current_measurement_interval = {
+            metric.name: [] for metric in self.metrics.TELEMETRY_METRICS
+        }  # type: Dict[str, List[float]]
+
         for line in metrics_data.splitlines():
             line = line.strip()
             if not line:
                 continue
-        
+
             parts = line.split()
             if len(parts) < 2:
                 continue
-        
-            triton_metric_key = parts[0].split('{')[0]
+
+            triton_metric_key = parts[0].split("{")[0]
             metric_value = parts[1]
-        
+
             metric_key = self.METRIC_NAME_MAPPING.get(triton_metric_key, None)
-        
-            if metric_key and metric_key in self.current_measurement_interval:
-                self.current_measurement_interval[metric_key].append(float(metric_value))
-    
-        self.metrics.update_metrics(self.current_measurement_interval)
+
+            if metric_key and metric_key in current_measurement_interval:
+                current_measurement_interval[metric_key].append(float(metric_value))
+
+        self.metrics.update_metrics(current_measurement_interval)

--- a/genai-perf/genai_perf/telemetry_data/triton_telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/triton_telemetry_data_collector.py
@@ -27,6 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from typing import Dict, List
+
 from genai_perf.telemetry_data.telemetry_data_collector import TelemetryDataCollector
 
 
@@ -46,9 +47,9 @@ class TritonTelemetryDataCollector(TelemetryDataCollector):
     def _process_and_update_metrics(self, metrics_data: str) -> None:
         """Process the response from Triton metrics endpoint and update metrics.
 
-        This method extracts metric names and values from the raw data. Metric names 
-        are extracted from the start of each line up to the '{' character, as all metrics 
-        follow the format 'metric_name{labels} value'. Only metrics defined in 
+        This method extracts metric names and values from the raw data. Metric names
+        are extracted from the start of each line up to the '{' character, as all metrics
+        follow the format 'metric_name{labels} value'. Only metrics defined in
         METRIC_NAME_MAPPING are processed.
 
         Args:
@@ -68,15 +69,19 @@ class TritonTelemetryDataCollector(TelemetryDataCollector):
             - `nv_energy_consumption` as `energy_consumption`
         """
 
-        current_measurement_data = {metric.name: [] for metric in self.metrics.TELEMETRY_METRICS}
+        current_measurement_data = {
+            metric.name: [] for metric in self.metrics.TELEMETRY_METRICS
+        }  # type: Dict[str, List[float]]
 
         for metric_data in metrics_data.splitlines():
-            triton_metric_key = metric_data.split('{')[0]  # Extract metric name before '{'
-            metric_value = metric_data.split()[1]    # Extract metric value
-            
+            triton_metric_key = metric_data.split("{")[
+                0
+            ]  # Extract metric name before '{'
+            metric_value = metric_data.split()[1]  # Extract metric value
+
             if triton_metric_key in self.METRIC_NAME_MAPPING:
                 metric_key = self.METRIC_NAME_MAPPING[triton_metric_key]
                 if metric_key in current_measurement_data:
                     current_measurement_data[metric_key].append(float(metric_value))
-        
+
         self.metrics.update_metrics(current_measurement_data)

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -30,14 +30,11 @@ from typing import List, Optional
 
 import genai_perf.logging as logging
 import genai_perf.utils as utils
-from genai_perf.constants import (
-    DEFAULT_GRPC_URL,
-    DEFAULT_INPUT_DATA_JSON,
-)
+from genai_perf.constants import DEFAULT_GRPC_URL, DEFAULT_INPUT_DATA_JSON
 from genai_perf.llm_inputs.llm_inputs import OutputFormat
 from genai_perf.telemetry_data.triton_telemetry_data_collector import (
-        TritonTelemetryDataCollector,
-    )
+    TritonTelemetryDataCollector,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +145,11 @@ class Profiler:
         return cmd
 
     @staticmethod
-    def run(telemetry_data_collector: TritonTelemetryDataCollector, args: Namespace, extra_args: Optional[List[str]]) -> None:
+    def run(
+        telemetry_data_collector: TritonTelemetryDataCollector,
+        args: Namespace,
+        extra_args: Optional[List[str]],
+    ) -> None:
         try:
             if telemetry_data_collector is not None:
                 telemetry_data_collector.start()
@@ -161,4 +162,3 @@ class Profiler:
         finally:
             if telemetry_data_collector is not None:
                 telemetry_data_collector.stop()
-

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -33,7 +33,7 @@ import genai_perf.utils as utils
 from genai_perf.constants import DEFAULT_GRPC_URL, DEFAULT_INPUT_DATA_JSON
 from genai_perf.llm_inputs.llm_inputs import OutputFormat
 from genai_perf.telemetry_data.triton_telemetry_data_collector import (
-    TritonTelemetryDataCollector,
+    TelemetryDataCollector,
 )
 
 logger = logging.getLogger(__name__)
@@ -146,9 +146,9 @@ class Profiler:
 
     @staticmethod
     def run(
-        telemetry_data_collector: TritonTelemetryDataCollector,
         args: Namespace,
         extra_args: Optional[List[str]],
+        telemetry_data_collector: Optional[TelemetryDataCollector] = None,
     ) -> None:
         try:
             if telemetry_data_collector is not None:

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -162,4 +162,3 @@ class Profiler:
         finally:
             if telemetry_data_collector is not None:
                 telemetry_data_collector.stop()
-

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -167,5 +167,6 @@ class Profiler:
             if telemetry_data_collector is not None:
                 telemetry_data_collector.stop()
                 metrics = telemetry_data_collector.metrics
+                #This print statement will be removed once the test is in place. 
                 print("Collected Metrics:")
                 print(metrics)

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -162,3 +162,4 @@ class Profiler:
         finally:
             if telemetry_data_collector is not None:
                 telemetry_data_collector.stop()
+

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -33,12 +33,11 @@ import genai_perf.utils as utils
 from genai_perf.constants import (
     DEFAULT_GRPC_URL,
     DEFAULT_INPUT_DATA_JSON,
-    DEFAULT_TRITON_METRICS_URL,
 )
 from genai_perf.llm_inputs.llm_inputs import OutputFormat
 from genai_perf.telemetry_data.triton_telemetry_data_collector import (
-    TritonTelemetryDataCollector,
-)
+        TritonTelemetryDataCollector,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -149,13 +148,9 @@ class Profiler:
         return cmd
 
     @staticmethod
-    def run(args: Namespace, extra_args: Optional[List[str]]) -> None:
-        telemetry_data_collector = None
+    def run(telemetry_data_collector: TritonTelemetryDataCollector, args: Namespace, extra_args: Optional[List[str]]) -> None:
         try:
-            if args.service_kind == "triton":
-                telemetry_data_collector = TritonTelemetryDataCollector(
-                    server_metrics_url=DEFAULT_TRITON_METRICS_URL
-                )
+            if telemetry_data_collector is not None:
                 telemetry_data_collector.start()
             cmd = Profiler.build_cmd(args, extra_args)
             logger.info(f"Running Perf Analyzer : '{' '.join(cmd)}'")
@@ -166,7 +161,4 @@ class Profiler:
         finally:
             if telemetry_data_collector is not None:
                 telemetry_data_collector.stop()
-                metrics = telemetry_data_collector.metrics
-                #This print statement will be removed once the test is in place. 
-                print("Collected Metrics:")
-                print(metrics)
+

--- a/genai-perf/tests/test_telemetry_data_collector.py
+++ b/genai-perf/tests/test_telemetry_data_collector.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+import requests
+from unittest.mock import patch, MagicMock
+from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
+from genai_perf.telemetry_data.telemetry_data_collector import TelemetryDataCollector
+
+class MockTelemetryDataCollector(TelemetryDataCollector):
+    def _process_and_update_metrics(self, metrics_data: str) -> None:
+        pass
+
+class TestTelemetryDataCollector:
+
+    TEST_SERVER_URL = "http://testserver:8080/metrics"
+
+    triton_metrics_response = """\
+            nv_gpu_power_usage{gpu="0",uuid="GPU-1234"} 123.45
+            nv_gpu_power_usage{gpu="1",uuid="GPU-5678"} 234.56
+            nv_gpu_utilization{gpu="0",uuid="GPU-1234"} 76.3
+            nv_gpu_utilization{gpu="1",uuid="GPU-5678"} 88.1
+            nv_gpu_memory_total_bytes{gpu="0",uuid="GPU-1234"} 8589934592
+            nv_gpu_memory_total_bytes{gpu="1",uuid="GPU-5678"} 8589934592
+            nv_gpu_memory_used_bytes{gpu="0",uuid="GPU-1234"} 2147483648
+            nv_gpu_memory_used_bytes{gpu="1",uuid="GPU-5678"} 3221225472
+            """
+
+    @pytest.fixture
+    def collector(self) -> MockTelemetryDataCollector:
+        return MockTelemetryDataCollector(self.TEST_SERVER_URL)
+
+    @patch('genai_perf.telemetry_data.telemetry_data_collector.Thread')
+    def test_start(self, mock_thread_class: MagicMock, collector: MockTelemetryDataCollector) -> None:
+        mock_thread_instance = MagicMock()
+        mock_thread_class.return_value = mock_thread_instance
+
+        collector.start()
+
+        assert collector._thread is not None
+        assert collector._thread.is_alive()
+        mock_thread_class.assert_called_once_with(target=collector._collect_metrics)
+        mock_thread_instance.start.assert_called_once()
+
+    @patch('genai_perf.telemetry_data.telemetry_data_collector.Thread')
+    def test_stop(self, mock_thread_class: MagicMock, collector: MockTelemetryDataCollector) -> None:
+        mock_thread_instance = MagicMock()
+        mock_thread_class.return_value = mock_thread_instance
+        
+        collector.start()
+
+        assert collector._thread is not None
+        assert collector._thread.is_alive()
+        
+        collector.stop()
+        
+        assert collector._stop_event.is_set()
+        mock_thread_instance.join.assert_called_once()
+
+        mock_thread_instance.is_alive.return_value = False
+        assert not collector._thread.is_alive()
+
+    @patch('requests.get')
+    def test_fetch_metrics_success(self, mock_requests_get: MagicMock, collector: MockTelemetryDataCollector) -> None:
+        
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = self.triton_metrics_response
+        mock_requests_get.return_value = mock_response
+    
+        result = collector._fetch_metrics()
+
+        mock_requests_get.assert_called_once_with(self.TEST_SERVER_URL)
+
+        assert result == self.triton_metrics_response
+
+    @patch('requests.get')
+    def test_fetch_metrics_failure(self, mock_requests_get: MagicMock, collector: MockTelemetryDataCollector) -> None:
+        mock_requests_get.side_effect = requests.exceptions.HTTPError("Not Found")
+        
+        with pytest.raises(requests.exceptions.HTTPError):
+            collector._fetch_metrics()
+
+    @patch.object(MockTelemetryDataCollector, '_fetch_metrics')
+    @patch('genai_perf.telemetry_data.telemetry_data_collector.time.sleep')
+    def test_collect_metrics(self, mock_sleep: MagicMock, mock_fetch_metrics: MagicMock, collector: MockTelemetryDataCollector) -> None:
+
+        mock_fetch_metrics.return_value = self.triton_metrics_response
+    
+        collector._process_and_update_metrics = MagicMock()
+    
+        collector._stop_event.is_set = MagicMock(side_effect=[False, True])  # Ensure loop exits immediately
+    
+        collector._collect_metrics()
+    
+        mock_fetch_metrics.assert_called_once()
+    
+        collector._process_and_update_metrics.assert_called_once_with(self.triton_metrics_response)
+        mock_sleep.assert_called_once()
+
+    
+    

--- a/genai-perf/tests/test_telemetry_data_collector.py
+++ b/genai-perf/tests/test_telemetry_data_collector.py
@@ -30,7 +30,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
-from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
 from genai_perf.telemetry_data.telemetry_data_collector import TelemetryDataCollector
 
 

--- a/genai-perf/tests/test_telemetry_metrics.py
+++ b/genai-perf/tests/test_telemetry_metrics.py
@@ -26,9 +26,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import pytest
-from genai_perf.metrics.telemetry_metrics import TelemetryMetrics, MetricMetadata
 from typing import Dict, List, Type
+
+import pytest
+from genai_perf.metrics.telemetry_metrics import MetricMetadata, TelemetryMetrics
+
 
 class TestTelemetryMetrics:
 

--- a/genai-perf/tests/test_telemetry_metrics.py
+++ b/genai-perf/tests/test_telemetry_metrics.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from genai_perf.metrics.telemetry_metrics import TelemetryMetrics, MetricMetadata
+from typing import Dict, List, Type
+
+class TestTelemetryMetrics:
+
+    def test_update_metrics(self) -> None:
+        """Test update_metrics method."""
+        telemetry = TelemetryMetrics()
+        measurement_data: Dict[str, List[float]] = {
+            "gpu_power_usage": [11.1, 11.2],
+            "gpu_power_limit": [101.2, 101.2],
+            "energy_consumption": [1004.0, 1005.0],
+            "gpu_utilization": [85.0, 90.0],
+            "total_gpu_memory": [9000.0, 9000.0],
+            "gpu_memory_used": [4500.0, 4500.0],
+        }
+        telemetry.update_metrics(measurement_data)
+
+        assert telemetry.gpu_power_usage == [[11.1, 11.2]]
+        assert telemetry.gpu_power_limit == [[101.2, 101.2]]
+        assert telemetry.energy_consumption == [[1004.0, 1005.0]]
+        assert telemetry.gpu_utilization == [[85.0, 90.0]]
+        assert telemetry.total_gpu_memory == [[9000.0, 9000.0]]
+        assert telemetry.gpu_memory_used == [[4500.0, 4500.0]]
+
+    def test_telemetry_metrics_property(self) -> None:
+        """Test telemetry_metrics property."""
+        telemetry = TelemetryMetrics()
+        telemetry_metrics: List[MetricMetadata] = telemetry.telemetry_metrics
+
+        assert len(telemetry_metrics) == 6
+        assert telemetry_metrics[0].name == "gpu_power_usage"
+        assert telemetry_metrics[0].unit == "watts"
+        assert telemetry_metrics[1].name == "gpu_power_limit"
+        assert telemetry_metrics[1].unit == "watts"
+        assert telemetry_metrics[2].name == "energy_consumption"
+        assert telemetry_metrics[2].unit == "joules"
+        assert telemetry_metrics[3].name == "gpu_utilization"
+        assert telemetry_metrics[3].unit == "percentage"
+        assert telemetry_metrics[4].name == "total_gpu_memory"
+        assert telemetry_metrics[4].unit == "bytes"
+        assert telemetry_metrics[5].name == "gpu_memory_used"
+        assert telemetry_metrics[5].unit == "bytes"

--- a/genai-perf/tests/test_telemetry_metrics.py
+++ b/genai-perf/tests/test_telemetry_metrics.py
@@ -26,9 +26,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Dict, List, Type
+from typing import Dict, List
 
-import pytest
 from genai_perf.metrics.telemetry_metrics import MetricMetadata, TelemetryMetrics
 
 

--- a/genai-perf/tests/test_triton_telemetry_data_collector.py
+++ b/genai-perf/tests/test_triton_telemetry_data_collector.py
@@ -26,11 +26,14 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from unittest.mock import MagicMock, PropertyMock, patch
+
 import pytest
-from unittest.mock import patch, PropertyMock, MagicMock
-from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
-from genai_perf.telemetry_data.triton_telemetry_data_collector import TritonTelemetryDataCollector
-from genai_perf.metrics.telemetry_metrics import MetricMetadata
+from genai_perf.metrics.telemetry_metrics import MetricMetadata, TelemetryMetrics
+from genai_perf.telemetry_data.triton_telemetry_data_collector import (
+    TritonTelemetryDataCollector,
+)
+
 
 class TestTritonTelemetryDataCollector:
 
@@ -39,7 +42,7 @@ class TestTritonTelemetryDataCollector:
     @pytest.fixture
     def triton_collector(self) -> TritonTelemetryDataCollector:
         return TritonTelemetryDataCollector(self.TEST_SERVER_URL)
-    
+
     @pytest.fixture
     def mock_telemetry_metrics(self) -> MagicMock:
         mock_telemetry_metrics = MagicMock(spec=TelemetryMetrics)
@@ -53,12 +56,12 @@ class TestTritonTelemetryDataCollector:
         ]
         return mock_telemetry_metrics
 
-    @patch.object(TritonTelemetryDataCollector, 'metrics', new_callable=PropertyMock)
+    @patch.object(TritonTelemetryDataCollector, "metrics", new_callable=PropertyMock)
     def test_process_and_update_metrics_single_gpu(
         self,
         mock_metrics: PropertyMock,
         triton_collector: TritonTelemetryDataCollector,
-        mock_telemetry_metrics: MagicMock
+        mock_telemetry_metrics: MagicMock,
     ) -> None:
 
         mock_metrics.return_value = mock_telemetry_metrics
@@ -71,7 +74,7 @@ class TestTritonTelemetryDataCollector:
         nv_gpu_memory_used_bytes{gpu_uuid="GPU-1234"} 4000000000.0"""
 
         triton_collector._process_and_update_metrics(triton_metrics_data)
-    
+
         expected_data = {
             "gpu_power_usage": [35.0],
             "gpu_power_limit": [250.0],
@@ -80,17 +83,17 @@ class TestTritonTelemetryDataCollector:
             "total_gpu_memory": [8000000000.0],
             "gpu_memory_used": [4000000000.0],
         }
-    
+
         mock_metrics.return_value.update_metrics.assert_called_once_with(expected_data)
 
-    @patch.object(TritonTelemetryDataCollector, 'metrics', new_callable=PropertyMock)
+    @patch.object(TritonTelemetryDataCollector, "metrics", new_callable=PropertyMock)
     def test_process_and_update_metrics_multiple_gpus(
         self,
         mock_metrics: PropertyMock,
         triton_collector: TritonTelemetryDataCollector,
-        mock_telemetry_metrics: MagicMock
+        mock_telemetry_metrics: MagicMock,
     ) -> None:
-        
+
         mock_metrics.return_value = mock_telemetry_metrics
 
         triton_metrics_data = """nv_gpu_power_usage{gpu_uuid="GPU-1234"} 35.0
@@ -105,9 +108,9 @@ class TestTritonTelemetryDataCollector:
         nv_gpu_memory_total_bytes{gpu_uuid="GPU-1234"} 9000000000.0
         nv_gpu_memory_used_bytes{gpu_uuid="GPU-1234"} 4000000000.0
         nv_gpu_memory_used_bytes{gpu_uuid="GPU-1234"} 4500000000.0"""
-        
+
         triton_collector._process_and_update_metrics(triton_metrics_data)
-        
+
         expected_data = {
             "gpu_power_usage": [35.0, 40.0],
             "gpu_power_limit": [250.0, 300.0],
@@ -119,19 +122,18 @@ class TestTritonTelemetryDataCollector:
 
         mock_metrics.return_value.update_metrics.assert_called_once_with(expected_data)
 
-    @patch.object(TritonTelemetryDataCollector, 'metrics', new_callable=PropertyMock)
+    @patch.object(TritonTelemetryDataCollector, "metrics", new_callable=PropertyMock)
     def test_process_and_update_metrics_empty_data(
         self,
         mock_metrics: PropertyMock,
         triton_collector: TritonTelemetryDataCollector,
-        mock_telemetry_metrics: MagicMock
+        mock_telemetry_metrics: MagicMock,
     ) -> None:
-       
+
         mock_metrics.return_value = mock_telemetry_metrics
 
         trtion_metrics_data = ""
 
         triton_collector._process_and_update_metrics(trtion_metrics_data)
-        
-        mock_telemetry_metrics.update_metrics.assert_not_called()
 
+        mock_telemetry_metrics.update_metrics.assert_not_called()

--- a/genai-perf/tests/test_triton_telemetry_data_collector.py
+++ b/genai-perf/tests/test_triton_telemetry_data_collector.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from unittest.mock import patch, PropertyMock, MagicMock
+from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
+from genai_perf.telemetry_data.triton_telemetry_data_collector import TritonTelemetryDataCollector
+from genai_perf.metrics.telemetry_metrics import MetricMetadata
+
+class TestTritonTelemetryDataCollector:
+
+    TEST_SERVER_URL: str = "http://tritonserver:8002/metrics"
+
+    @pytest.fixture
+    def triton_collector(self) -> TritonTelemetryDataCollector:
+        return TritonTelemetryDataCollector(self.TEST_SERVER_URL)
+    
+    @pytest.fixture
+    def mock_telemetry_metrics(self) -> MagicMock:
+        mock_telemetry_metrics = MagicMock(spec=TelemetryMetrics)
+        mock_telemetry_metrics.TELEMETRY_METRICS = [
+            MetricMetadata("gpu_power_usage", "watts"),
+            MetricMetadata("gpu_power_limit", "watts"),
+            MetricMetadata("energy_consumption", "joules"),
+            MetricMetadata("gpu_utilization", "percentage"),
+            MetricMetadata("total_gpu_memory", "bytes"),
+            MetricMetadata("gpu_memory_used", "bytes"),
+        ]
+        return mock_telemetry_metrics
+
+    @patch.object(TritonTelemetryDataCollector, 'metrics', new_callable=PropertyMock)
+    def test_process_and_update_metrics_single_gpu(
+        self,
+        mock_metrics: PropertyMock,
+        triton_collector: TritonTelemetryDataCollector,
+        mock_telemetry_metrics: MagicMock
+    ) -> None:
+
+        mock_metrics.return_value = mock_telemetry_metrics
+
+        triton_metrics_data = """nv_gpu_power_usage{gpu_uuid="GPU-1234"} 35.0
+        nv_gpu_power_limit{gpu_uuid="GPU-1234"} 250.0
+        nv_gpu_utilization{gpu_uuid="GPU-1234"} 85.0
+        nv_energy_consumption{gpu_uuid="GPU-1234"} 1500.0
+        nv_gpu_memory_total_bytes{gpu_uuid="GPU-1234"} 8000000000.0
+        nv_gpu_memory_used_bytes{gpu_uuid="GPU-1234"} 4000000000.0"""
+
+        triton_collector._process_and_update_metrics(triton_metrics_data)
+    
+        expected_data = {
+            "gpu_power_usage": [35.0],
+            "gpu_power_limit": [250.0],
+            "gpu_utilization": [85.0],
+            "energy_consumption": [1500.0],
+            "total_gpu_memory": [8000000000.0],
+            "gpu_memory_used": [4000000000.0],
+        }
+    
+        mock_metrics.return_value.update_metrics.assert_called_once_with(expected_data)
+
+    @patch.object(TritonTelemetryDataCollector, 'metrics', new_callable=PropertyMock)
+    def test_process_and_update_metrics_multiple_gpus(
+        self,
+        mock_metrics: PropertyMock,
+        triton_collector: TritonTelemetryDataCollector,
+        mock_telemetry_metrics: MagicMock
+    ) -> None:
+        
+        mock_metrics.return_value = mock_telemetry_metrics
+
+        triton_metrics_data = """nv_gpu_power_usage{gpu_uuid="GPU-1234"} 35.0
+        nv_gpu_power_usage{gpu_uuid="GPU-5678"} 40.0
+        nv_gpu_power_limit{gpu_uuid="GPU-1234"} 250.0
+        nv_gpu_power_limit{gpu_uuid="GPU-1234"} 300.0
+        nv_gpu_utilization{gpu_uuid="GPU-1234"} 85.0
+        nv_gpu_utilization{gpu_uuid="GPU-5678"} 90.0
+        nv_energy_consumption{gpu_uuid="GPU-1234"} 1500.0
+        nv_energy_consumption{gpu_uuid="GPU-1234"} 1600.0
+        nv_gpu_memory_total_bytes{gpu_uuid="GPU-1234"} 8000000000.0
+        nv_gpu_memory_total_bytes{gpu_uuid="GPU-1234"} 9000000000.0
+        nv_gpu_memory_used_bytes{gpu_uuid="GPU-1234"} 4000000000.0
+        nv_gpu_memory_used_bytes{gpu_uuid="GPU-1234"} 4500000000.0"""
+        
+        triton_collector._process_and_update_metrics(triton_metrics_data)
+        
+        expected_data = {
+            "gpu_power_usage": [35.0, 40.0],
+            "gpu_power_limit": [250.0, 300.0],
+            "gpu_utilization": [85.0, 90.0],
+            "energy_consumption": [1500.0, 1600.0],
+            "total_gpu_memory": [8000000000.0, 9000000000.0],
+            "gpu_memory_used": [4000000000.0, 4500000000.0],
+        }
+
+        mock_metrics.return_value.update_metrics.assert_called_once_with(expected_data)
+
+    @patch.object(TritonTelemetryDataCollector, 'metrics', new_callable=PropertyMock)
+    def test_process_and_update_metrics_empty_data(
+        self,
+        mock_metrics: PropertyMock,
+        triton_collector: TritonTelemetryDataCollector,
+        mock_telemetry_metrics: MagicMock
+    ) -> None:
+       
+        mock_metrics.return_value = mock_telemetry_metrics
+
+        trtion_metrics_data = ""
+
+        triton_collector._process_and_update_metrics(trtion_metrics_data)
+        
+        mock_telemetry_metrics.update_metrics.assert_not_called()
+

--- a/genai-perf/tests/test_wrapper.py
+++ b/genai-perf/tests/test_wrapper.py
@@ -147,16 +147,16 @@ class TestWrapper:
         assert cmd_string.count(" -i http") == 1
 
     @patch("genai_perf.wrapper.subprocess.run")
-    @patch("genai_perf.wrapper.TritonTelemetryDataCollector")
+    @patch("genai_perf.wrapper.TelemetryDataCollector")
     def test_stdout_verbose(self, mock_telemetry_collector, mock_subprocess_run):
         args = MagicMock()
         args.model = "test_model"
         args.verbose = True
         telemetry_data_collector = mock_telemetry_collector.return_value
         Profiler.run(
-            telemetry_data_collector=telemetry_data_collector,
             args=args,
             extra_args=None,
+            telemetry_data_collector=telemetry_data_collector,
         )
 
         # Check that standard output was not redirected.
@@ -167,16 +167,16 @@ class TestWrapper:
             ), "With the verbose flag, stdout should not be redirected."
 
     @patch("genai_perf.wrapper.subprocess.run")
-    @patch("genai_perf.wrapper.TritonTelemetryDataCollector")
+    @patch("genai_perf.wrapper.TelemetryDataCollector")
     def test_stdout_not_verbose(self, mock_telemetry_collector, mock_subprocess_run):
         args = MagicMock()
         args.model = "test_model"
         args.verbose = False
         telemetry_data_collector = mock_telemetry_collector.return_value
         Profiler.run(
-            telemetry_data_collector=telemetry_data_collector,
             args=args,
             extra_args=None,
+            telemetry_data_collector=telemetry_data_collector,
         )
 
         # Check that standard output was redirected.

--- a/genai-perf/tests/test_wrapper.py
+++ b/genai-perf/tests/test_wrapper.py
@@ -30,9 +30,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 from genai_perf import parser
 from genai_perf.constants import DEFAULT_GRPC_URL
-from genai_perf.telemetry_data.triton_telemetry_data_collector import (
-    TritonTelemetryDataCollector,
-)
 from genai_perf.wrapper import Profiler
 
 

--- a/genai-perf/tests/test_wrapper.py
+++ b/genai-perf/tests/test_wrapper.py
@@ -30,6 +30,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from genai_perf import parser
 from genai_perf.constants import DEFAULT_GRPC_URL
+from genai_perf.telemetry_data.triton_telemetry_data_collector import (
+    TritonTelemetryDataCollector,
+)
 from genai_perf.wrapper import Profiler
 
 
@@ -147,11 +150,17 @@ class TestWrapper:
         assert cmd_string.count(" -i http") == 1
 
     @patch("genai_perf.wrapper.subprocess.run")
-    def test_stdout_verbose(self, mock_subprocess_run):
+    @patch("genai_perf.wrapper.TritonTelemetryDataCollector")
+    def test_stdout_verbose(self, mock_telemetry_collector, mock_subprocess_run):
         args = MagicMock()
         args.model = "test_model"
         args.verbose = True
-        Profiler.run(args=args, extra_args=None)
+        telemetry_data_collector = mock_telemetry_collector.return_value
+        Profiler.run(
+            telemetry_data_collector=telemetry_data_collector,
+            args=args,
+            extra_args=None,
+        )
 
         # Check that standard output was not redirected.
         for call_args in mock_subprocess_run.call_args_list:
@@ -161,11 +170,17 @@ class TestWrapper:
             ), "With the verbose flag, stdout should not be redirected."
 
     @patch("genai_perf.wrapper.subprocess.run")
-    def test_stdout_not_verbose(self, mock_subprocess_run):
+    @patch("genai_perf.wrapper.TritonTelemetryDataCollector")
+    def test_stdout_not_verbose(self, mock_telemetry_collector, mock_subprocess_run):
         args = MagicMock()
         args.model = "test_model"
         args.verbose = False
-        Profiler.run(args=args, extra_args=None)
+        telemetry_data_collector = mock_telemetry_collector.return_value
+        Profiler.run(
+            telemetry_data_collector=telemetry_data_collector,
+            args=args,
+            extra_args=None,
+        )
 
         # Check that standard output was redirected.
         for call_args in mock_subprocess_run.call_args_list:


### PR DESCRIPTION
This PR is a part of adding telemetry metrics to GenAI-perf.

Changes implemented in this PR:
  1. Added a new Telemetry metrics class that has the GPU metrics mentioned below.
      - gpu_power_usage
      - gpu_power_limit
      - energy_consumption
      - gpu_utilization
      - total_gpu_memory
      - gpu_memory_used
  2. A new folder to hold all telemetry data collection files
  3. A Base Telemetry Data Collector class that implements a thread to gather metrics from endpoint.
  4. A specific Triton Telemetry Data Collector class that has a specific implementation for Triton metrics.
  5. Modified wrapper.py to start TelemtryDataCollector thread once perf_analyzer subprocess starts running.
  
 This is how the metrics are stored.
 
![image](https://github.com/user-attachments/assets/a0b4667e-4dd3-42f1-a8af-85ef85d30b04)

For every metric, the values are stored as a list of lists. 
The outer list represents the sequence of metric measurements over time.
Each inner list contains the metric values for each GPU at a particular time point. 


