### PR TITLE
Support 1-d array data in profile exporter

### DIFF
--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -582,25 +582,6 @@ def _add_endpoint_args(parser):
     )
 
     endpoint_group.add_argument(
-        "-m",
-        "--model",
-        nargs="+",
-        default=[],
-        help=f"The name of the model(s) to benchmark.",
-    )
-    endpoint_group.add_argument(
-        "--model-selection-strategy",
-        type=str,
-        choices=utils.get_enum_names(ModelSelectionStrategy),
-        default="round_robin",
-        required=False,
-        help=f"When multiple model are specified, this is how a specific model "
-        "should be assigned to a prompt.  round_robin means that ith prompt in the "
-        "list gets assigned to i mod len(models).  random means that assignment is "
-        "uniformly random",
-    )
-
-    endpoint_group.add_argument(
         "--service-kind",
         type=str,
         choices=["triton", "openai", "tensorrtllm_engine"],

--- a/src/client_backend/triton_c_api/triton_c_api_backend.cc
+++ b/src/client_backend/triton_c_api/triton_c_api_backend.cc
@@ -406,7 +406,7 @@ TritonCApiInferRequestedOutput::Create(
     const size_t class_count, const std::string& datatype)
 {
   TritonCApiInferRequestedOutput* local_infer_output =
-      new TritonCApiInferRequestedOutput(name);
+      new TritonCApiInferRequestedOutput(name, datatype);
 
   tc::InferRequestedOutput* triton_infer_output;
   RETURN_IF_TRITON_ERROR(tc::InferRequestedOutput::Create(
@@ -427,8 +427,8 @@ TritonCApiInferRequestedOutput::SetSharedMemory(
 }
 
 TritonCApiInferRequestedOutput::TritonCApiInferRequestedOutput(
-    const std::string& name)
-    : InferRequestedOutput(BackendKind::TRITON_C_API, name)
+    const std::string& name, const std::string& datatype)
+    : InferRequestedOutput(BackendKind::TRITON_C_API, name, datatype)
 {
 }
 

--- a/src/client_backend/triton_c_api/triton_c_api_backend.h
+++ b/src/client_backend/triton_c_api/triton_c_api_backend.h
@@ -215,7 +215,8 @@ class TritonCApiInferRequestedOutput : public InferRequestedOutput {
       const std::string& name, size_t byte_size, size_t offset = 0) override;
 
  private:
-  explicit TritonCApiInferRequestedOutput(const std::string& name);
+  explicit TritonCApiInferRequestedOutput(
+      const std::string& name, const std::string& datatype);
 
   std::unique_ptr<tc::InferRequestedOutput> output_;
 };

--- a/src/client_backend/triton_c_api/triton_loader.cc
+++ b/src/client_backend/triton_c_api/triton_loader.cc
@@ -338,16 +338,25 @@ TritonLoader::StartTriton()
   // Create the allocator that will be used to allocate buffers for
   // the result tensors.
   RETURN_IF_TRITONSERVER_ERROR(
-      GetSingleton()
-          ->response_allocator_new_fn_(
-              &allocator_,
-              reinterpret_cast<
-                  TRITONSERVER_Error* (*)(TRITONSERVER_ResponseAllocator * allocator, const char* tensor_name, size_t byte_size, TRITONSERVER_MemoryType memory_type, int64_t memory_type_id, void* userp, void** buffer, void** buffer_userp, TRITONSERVER_MemoryType* actual_memory_type, int64_t* actual_memory_type_id)>(
-                  ResponseAlloc),
-              reinterpret_cast<
-                  TRITONSERVER_Error* (*)(TRITONSERVER_ResponseAllocator * allocator, void* buffer, void* buffer_userp, size_t byte_size, TRITONSERVER_MemoryType memory_type, int64_t memory_type_id)>(
-                  ResponseRelease),
-              nullptr /* start_fn */),
+      GetSingleton()->response_allocator_new_fn_(
+          &allocator_,
+          reinterpret_cast<
+              TRITONSERVER_Error* (*)(TRITONSERVER_ResponseAllocator* allocator,
+                                      const char* tensor_name, size_t byte_size,
+                                      TRITONSERVER_MemoryType memory_type,
+                                      int64_t memory_type_id, void* userp,
+                                      void** buffer, void** buffer_userp,
+                                      TRITONSERVER_MemoryType*
+                                          actual_memory_type,
+                                      int64_t* actual_memory_type_id)>(
+              ResponseAlloc),
+          reinterpret_cast<
+              TRITONSERVER_Error* (*)(TRITONSERVER_ResponseAllocator* allocator,
+                                      void* buffer, void* buffer_userp,
+                                      size_t byte_size,
+                                      TRITONSERVER_MemoryType memory_type,
+                                      int64_t memory_type_id)>(ResponseRelease),
+          nullptr /* start_fn */),
       "creating response allocator");
 
   return Error::Success;

--- a/src/mock_profile_data_exporter.h
+++ b/src/mock_profile_data_exporter.h
@@ -59,10 +59,15 @@ class NaggyMockProfileDataExporter : public ProfileDataExporter {
                   entry, experiment, raw_experiment);
             });
 
-    ON_CALL(*this, AddDataToJSON(testing::_, testing::_, testing::_, testing::_))
-        .WillByDefault([this](rapidjson::Value& json, const uint8_t* buf, const size_t byte_size, const std::string& data_type) -> void {
-          this->ProfileDataExporter::AddDataToJSON(json, buf, byte_size, data_type);
-        });
+    ON_CALL(
+        *this, AddDataToJSON(testing::_, testing::_, testing::_, testing::_))
+        .WillByDefault(
+            [this](
+                rapidjson::Value& json, const uint8_t* buf,
+                const size_t byte_size, const std::string& data_type) -> void {
+              this->ProfileDataExporter::AddDataToJSON(
+                  json, buf, byte_size, data_type);
+            });
 
     ON_CALL(*this, AddServiceKind(testing::_))
         .WillByDefault([this](cb::BackendKind& service_kind) -> void {
@@ -87,7 +92,9 @@ class NaggyMockProfileDataExporter : public ProfileDataExporter {
   MOCK_METHOD(
       void, AddExperiment,
       (rapidjson::Value&, rapidjson::Value&, const Experiment&), (override));
-  MOCK_METHOD(void, AddDataToJSON, (rapidjson::Value&, const uint8_t*, const size_t, const std::string&));
+  MOCK_METHOD(
+      void, AddDataToJSON,
+      (rapidjson::Value&, const uint8_t*, const size_t, const std::string&));
   MOCK_METHOD(void, OutputToFile, (std::string&), (override));
   MOCK_METHOD(void, AddServiceKind, (cb::BackendKind&));
   MOCK_METHOD(void, AddEndpoint, (std::string&));

--- a/src/mock_profile_data_exporter.h
+++ b/src/mock_profile_data_exporter.h
@@ -59,6 +59,11 @@ class NaggyMockProfileDataExporter : public ProfileDataExporter {
                   entry, experiment, raw_experiment);
             });
 
+    ON_CALL(*this, AddDataToJSON(testing::_, testing::_, testing::_, testing::_))
+        .WillByDefault([this](rapidjson::Value& json, const uint8_t* buf, const size_t byte_size, const std::string& data_type) -> void {
+          this->ProfileDataExporter::AddDataToJSON(json, buf, byte_size, data_type);
+        });
+
     ON_CALL(*this, AddServiceKind(testing::_))
         .WillByDefault([this](cb::BackendKind& service_kind) -> void {
           this->ProfileDataExporter::AddServiceKind(service_kind);
@@ -82,6 +87,7 @@ class NaggyMockProfileDataExporter : public ProfileDataExporter {
   MOCK_METHOD(
       void, AddExperiment,
       (rapidjson::Value&, rapidjson::Value&, const Experiment&), (override));
+  MOCK_METHOD(void, AddDataToJSON, (rapidjson::Value&, const uint8_t*, const size_t, const std::string&));
   MOCK_METHOD(void, OutputToFile, (std::string&), (override));
   MOCK_METHOD(void, AddServiceKind, (cb::BackendKind&));
   MOCK_METHOD(void, AddEndpoint, (std::string&));

--- a/src/perf_utils.cc
+++ b/src/perf_utils.cc
@@ -443,7 +443,8 @@ GetDataTypeSize(const std::string& data_type)
   } else if (data_type == "JSON") {
     return sizeof(char);
   } else {
-    std::cerr << "WARNING: unsupported data type: '" + data_type + "'" << std::endl;
+    std::cerr << "WARNING: unsupported data type: '" + data_type + "'"
+              << std::endl;
   }
 }
 

--- a/src/perf_utils.cc
+++ b/src/perf_utils.cc
@@ -413,4 +413,38 @@ ParseTensorFormat(const std::string& content_type_str)
   }
 }
 
+size_t
+GetDataTypeSize(const std::string& data_type)
+{
+  if (data_type == "BOOL") {
+    return sizeof(bool);
+  } else if (data_type == "UINT8") {
+    return sizeof(uint8_t);
+  } else if (data_type == "UINT16") {
+    return sizeof(uint16_t);
+  } else if (data_type == "UINT32") {
+    return sizeof(uint32_t);
+  } else if (data_type == "UINT64") {
+    return sizeof(uint64_t);
+  } else if (data_type == "INT8") {
+    return sizeof(int8_t);
+  } else if (data_type == "INT16") {
+    return sizeof(int16_t);
+  } else if (data_type == "INT32") {
+    return sizeof(int32_t);
+  } else if (data_type == "INT64") {
+    return sizeof(int64_t);
+  } else if (data_type == "FP32") {
+    return sizeof(float);
+  } else if (data_type == "FP64") {
+    return sizeof(double);
+  } else if (data_type == "BYTES") {
+    return sizeof(char);
+  } else if (data_type == "JSON") {
+    return sizeof(char);
+  } else {
+    std::cerr << "WARNING: unsupported data type: '" + data_type + "'" << std::endl;
+  }
+}
+
 }}  // namespace triton::perfanalyzer

--- a/src/perf_utils.cc
+++ b/src/perf_utils.cc
@@ -413,7 +413,7 @@ ParseTensorFormat(const std::string& content_type_str)
   }
 }
 
-size_t
+std::optional<size_t>
 GetDataTypeSize(const std::string& data_type)
 {
   if (data_type == "BOOL") {
@@ -445,6 +445,7 @@ GetDataTypeSize(const std::string& data_type)
   } else {
     std::cerr << "WARNING: unsupported data type: '" + data_type + "'"
               << std::endl;
+    return {};
   }
 }
 

--- a/src/perf_utils.h
+++ b/src/perf_utils.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -36,6 +36,7 @@
 #include <iomanip>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <random>
 
 #include "client_backend/client_backend.h"
@@ -138,6 +139,6 @@ std::function<std::chrono::nanoseconds(std::mt19937&)> ScheduleDistribution(
 cb::TensorFormat ParseTensorFormat(const std::string& tensor_format_str);
 
 // Returns the size of a given data type in bytes.
-size_t GetDataTypeSize(const std::string& data_type);
+std::optional<size_t> GetDataTypeSize(const std::string& data_type);
 
 }}  // namespace triton::perfanalyzer

--- a/src/perf_utils.h
+++ b/src/perf_utils.h
@@ -137,4 +137,7 @@ std::function<std::chrono::nanoseconds(std::mt19937&)> ScheduleDistribution(
 // Parse the HTTP tensor format
 cb::TensorFormat ParseTensorFormat(const std::string& tensor_format_str);
 
+// Returns the size of a given data type in bytes.
+size_t GetDataTypeSize(const std::string& data_type);
+
 }}  // namespace triton::perfanalyzer

--- a/src/profile_data_exporter.cc
+++ b/src/profile_data_exporter.cc
@@ -205,11 +205,16 @@ ProfileDataExporter::AddDataToJSON(
 {
   // TPA-268: support N-dimensional tensor
   size_t data_size;
+  // TODO TPA-283: Add support for N-dimensional string tensors
   if (data_type == "BYTES" || data_type == "JSON") {
     // return string as is instead of array of chars
     data_size = 1;
   } else {
-    data_size = byte_size / GetDataTypeSize(data_type);
+    const std::optional<size_t> data_type_size{GetDataTypeSize(data_type)};
+    if (!data_type_size) {
+      return;
+    }
+    data_size = byte_size / data_type_size.value();
     if (data_size > 1) {
       json.SetArray();
     }

--- a/src/profile_data_exporter.cc
+++ b/src/profile_data_exporter.cc
@@ -162,44 +162,46 @@ ProfileDataExporter::AddResponseTimestamps(
 
 void
 ProfileDataExporter::SetValueToJSON(
-  rapidjson::Value& val, const size_t index, const uint8_t* buf, const size_t byte_size, const std::string& data_type)
+    rapidjson::Value& json, const size_t index, const uint8_t* buf,
+    const size_t byte_size, const std::string& data_type)
 {
   if (data_type == "BOOL") {
-    val.SetBool(reinterpret_cast<const bool*>(buf)[index]);
+    json.SetBool(reinterpret_cast<const bool*>(buf)[index]);
   } else if (data_type == "UINT8") {
-    val.SetUint(reinterpret_cast<const uint8_t*>(buf)[index]);
+    json.SetUint(reinterpret_cast<const uint8_t*>(buf)[index]);
   } else if (data_type == "UINT16") {
-    val.SetUint(reinterpret_cast<const uint16_t*>(buf)[index]);
+    json.SetUint(reinterpret_cast<const uint16_t*>(buf)[index]);
   } else if (data_type == "UINT32") {
-    val.SetUint(reinterpret_cast<const uint32_t*>(buf)[index]);
+    json.SetUint(reinterpret_cast<const uint32_t*>(buf)[index]);
   } else if (data_type == "UINT64") {
-    val.SetUint64(reinterpret_cast<const uint64_t*>(buf)[index]);
+    json.SetUint64(reinterpret_cast<const uint64_t*>(buf)[index]);
   } else if (data_type == "INT8") {
-    val.SetInt(reinterpret_cast<const int8_t*>(buf)[index]);
+    json.SetInt(reinterpret_cast<const int8_t*>(buf)[index]);
   } else if (data_type == "INT16") {
-    val.SetInt(reinterpret_cast<const int16_t*>(buf)[index]);
+    json.SetInt(reinterpret_cast<const int16_t*>(buf)[index]);
   } else if (data_type == "INT32") {
-    val.SetInt(reinterpret_cast<const int32_t*>(buf)[index]);
+    json.SetInt(reinterpret_cast<const int32_t*>(buf)[index]);
   } else if (data_type == "INT64") {
-    val.SetInt64(reinterpret_cast<const int64_t*>(buf)[index]);
+    json.SetInt64(reinterpret_cast<const int64_t*>(buf)[index]);
   } else if (data_type == "FP32") {
-    val.SetFloat(reinterpret_cast<const float*>(buf)[index]);
+    json.SetFloat(reinterpret_cast<const float*>(buf)[index]);
   } else if (data_type == "FP64") {
-    val.SetDouble(reinterpret_cast<const double*>(buf)[index]);
+    json.SetDouble(reinterpret_cast<const double*>(buf)[index]);
   } else if (data_type == "BYTES" || data_type == "JSON") {
-    val.SetString(
+    json.SetString(
         reinterpret_cast<const char*>(buf), byte_size,
         document_.GetAllocator());
   } else {
     std::cerr << "WARNING: data type '" + data_type +
                      "' is not supported with JSON."
               << std::endl;
-  } 
+  }
 }
 
 void
 ProfileDataExporter::AddDataToJSON(
-  rapidjson::Value& json, const uint8_t* buf, const size_t byte_size, const std::string& data_type)
+    rapidjson::Value& json, const uint8_t* buf, const size_t byte_size,
+    const std::string& data_type)
 {
   // TPA-268: support N-dimensional tensor
   size_t data_size;
@@ -208,7 +210,7 @@ ProfileDataExporter::AddDataToJSON(
     data_size = 1;
   } else {
     data_size = byte_size / GetDataTypeSize(data_type);
-    if (data_size > 1){
+    if (data_size > 1) {
       json.SetArray();
     }
   }
@@ -225,7 +227,7 @@ ProfileDataExporter::AddDataToJSON(
     }
   } else {
     json.SetString("", 0, document_.GetAllocator());
-  } 
+  }
 }
 
 void

--- a/src/profile_data_exporter.h
+++ b/src/profile_data_exporter.h
@@ -75,8 +75,12 @@ class ProfileDataExporter {
   void AddRequests(
       rapidjson::Value& entry, rapidjson::Value& requests,
       const Experiment& raw_experiment);
-  void SetValueToJSON(rapidjson::Value& json, const size_t index, const uint8_t* buf, const size_t byte_size, const std::string& data_type);
-  void AddDataToJSON(rapidjson::Value& json, const uint8_t* buf, const size_t byte_size, const std::string& data_type);
+  void SetValueToJSON(
+      rapidjson::Value& json, const size_t index, const uint8_t* buf,
+      const size_t byte_size, const std::string& data_type);
+  void AddDataToJSON(
+      rapidjson::Value& json, const uint8_t* buf, const size_t byte_size,
+      const std::string& data_type);
   void AddRequestInputs(
       rapidjson::Value& inputs_json,
       const std::vector<RequestRecord::RequestInput>& inputs);

--- a/src/profile_data_exporter.h
+++ b/src/profile_data_exporter.h
@@ -75,6 +75,7 @@ class ProfileDataExporter {
   void AddRequests(
       rapidjson::Value& entry, rapidjson::Value& requests,
       const Experiment& raw_experiment);
+  void AddDataToJSON(rapidjson::Value& inputs_json, const size_t index, const uint8_t* buf, const size_t byte_size, const std::string& data_type);
   void AddRequestInputs(
       rapidjson::Value& inputs_json,
       const std::vector<RequestRecord::RequestInput>& inputs);

--- a/src/profile_data_exporter.h
+++ b/src/profile_data_exporter.h
@@ -75,7 +75,8 @@ class ProfileDataExporter {
   void AddRequests(
       rapidjson::Value& entry, rapidjson::Value& requests,
       const Experiment& raw_experiment);
-  void AddDataToJSON(rapidjson::Value& inputs_json, const size_t index, const uint8_t* buf, const size_t byte_size, const std::string& data_type);
+  void SetValueToJSON(rapidjson::Value& json, const size_t index, const uint8_t* buf, const size_t byte_size, const std::string& data_type);
+  void AddDataToJSON(rapidjson::Value& json, const uint8_t* buf, const size_t byte_size, const std::string& data_type);
   void AddRequestInputs(
       rapidjson::Value& inputs_json,
       const std::vector<RequestRecord::RequestInput>& inputs);

--- a/src/request_record.h
+++ b/src/request_record.h
@@ -35,7 +35,7 @@ namespace triton { namespace perfanalyzer {
 
 /// A record containing the data of a single request input or response output
 struct RecordData {
-  RecordData(const uint8_t* buf, size_t size, std::string data_type = "")
+  RecordData(const uint8_t* buf, size_t size, std::string data_type)
   {
     uint8_t* array = new uint8_t[size];
     std::memcpy(array, buf, size);

--- a/src/test_profile_data_collector.cc
+++ b/src/test_profile_data_collector.cc
@@ -70,14 +70,14 @@ TEST_CASE("profile_data_collector: AddData")
   uint8_t fake_data_in[] = {0x01, 0x02, 0x03, 0x04};
   uint8_t fake_data_out[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
   RequestRecord::RequestInput request1_request_input{
-      {"key1", RecordData(fake_data_in, 1)},
-      {"key2", RecordData(fake_data_in, 2)}};
+      {"key1", RecordData(fake_data_in, 1, "fake_datatype")},
+      {"key2", RecordData(fake_data_in, 2, "fake_datatype")}};
   RequestRecord::ResponseOutput request1_response1_output{
-      {"key1", RecordData(fake_data_out, 1)},
-      {"key2", RecordData(fake_data_out, 2)}};
+      {"key1", RecordData(fake_data_out, 1, "fake_datatype")},
+      {"key2", RecordData(fake_data_out, 2, "fake_datatype")}};
   RequestRecord::ResponseOutput request1_response2_output{
-      {"key3", RecordData(fake_data_out, 3)},
-      {"key4", RecordData(fake_data_out, 4)}};
+      {"key3", RecordData(fake_data_out, 3, "fake_datatype")},
+      {"key4", RecordData(fake_data_out, 4, "fake_datatype")}};
 
   RequestRecord request_record1{
       request1_timestamp,
@@ -95,14 +95,14 @@ TEST_CASE("profile_data_collector: AddData")
   auto request2_response1_timestamp{clock_epoch + nanoseconds(5)};
   auto request2_response2_timestamp{clock_epoch + nanoseconds(6)};
   RequestRecord::RequestInput request2_request_input{
-      {"key3", RecordData(fake_data_in, 3)},
-      {"key4", RecordData(fake_data_in, 4)}};
+      {"key3", RecordData(fake_data_in, 3, "fake_datatype")},
+      {"key4", RecordData(fake_data_in, 4, "fake_datatype")}};
   RequestRecord::ResponseOutput request2_response1_output{
-      {"key5", RecordData(fake_data_out, 5)},
-      {"key6", RecordData(fake_data_out, 6)}};
+      {"key5", RecordData(fake_data_out, 5, "fake_datatype")},
+      {"key6", RecordData(fake_data_out, 6, "fake_datatype")}};
   RequestRecord::ResponseOutput request2_response2_output{
-      {"key7", RecordData(fake_data_out, 7)},
-      {"key8", RecordData(fake_data_out, 8)}};
+      {"key7", RecordData(fake_data_out, 7, "fake_datatype")},
+      {"key8", RecordData(fake_data_out, 8, "fake_datatype")}};
 
   RequestRecord request_record2{
       request2_timestamp,

--- a/src/test_profile_data_exporter.cc
+++ b/src/test_profile_data_exporter.cc
@@ -195,12 +195,133 @@ TEST_CASE("profile_data_exporter: ConvertToJson")
 TEST_CASE("profile_data_exporter: AddDataToJSON")
 {
   MockProfileDataExporter exporter{};
-  rapidjson::Value value;
+  rapidjson::Value json;
+  const uint8_t* buf;
   
-  SUBCASE("Test Bool")
+  SUBCASE("Test bytes")
   {
-    const 
+    const std::string data{"abc123"};
+    buf = reinterpret_cast<const uint8_t*>(data.data());
+    exporter.AddDataToJSON(json, buf, data.size(), "BYTES");
+    CHECK(json == "abc123");    
+  }
+   
+  SUBCASE("Test json")
+  {
+    const std::string data{"{\"abc\":\"def\"}"};
+    buf = reinterpret_cast<const uint8_t*>(data.data());
+    exporter.AddDataToJSON(json, buf, data.size(), "JSON");
+    CHECK(json == "{\"abc\":\"def\"}");    
+  }
+  
+  SUBCASE("Test bool")
+  {
+    const bool data[3] = {true, false, true};
+    buf = reinterpret_cast<const uint8_t*>(data);
+    exporter.AddDataToJSON(json, buf, sizeof(data), "BOOL");
+    CHECK(json[0] == true);
+    CHECK(json[1] == false);
+    CHECK(json[2] == true);
+  }
 
+  SUBCASE("Test uint8")
+  {
+    const uint8_t data[3] = {1, 2, 3};
+    buf = reinterpret_cast<const uint8_t*>(data);
+    exporter.AddDataToJSON(json, buf, sizeof(data), "UINT8");
+    CHECK(json[0] == 1);
+    CHECK(json[1] == 2);
+    CHECK(json[2] == 3);
+  }
+
+  SUBCASE("Test uint16")
+  {
+    const uint16_t data[3] = {4, 5, 6};
+    buf = reinterpret_cast<const uint8_t*>(data);
+    exporter.AddDataToJSON(json, buf, sizeof(data), "UINT16");
+    CHECK(json[0] == 4);
+    CHECK(json[1] == 5);
+    CHECK(json[2] == 6);
+  }
+
+  SUBCASE("Test uint32")
+  {
+    const uint32_t data[3] = {7, 8, 9};
+    buf = reinterpret_cast<const uint8_t*>(data);
+    exporter.AddDataToJSON(json, buf, sizeof(data), "UINT32");
+    CHECK(json[0] == 7);
+    CHECK(json[1] == 8);
+    CHECK(json[2] == 9);
+  }
+
+  SUBCASE("Test uint64")
+  {
+    const uint64_t data[3] = {10, 11, 12};
+    buf = reinterpret_cast<const uint8_t*>(data);
+    exporter.AddDataToJSON(json, buf, sizeof(data), "UINT64");
+    CHECK(json[0] == 10);
+    CHECK(json[1] == 11);
+    CHECK(json[2] == 12);
+  }
+
+  SUBCASE("Test int8")
+  {
+    const int8_t data[3] = {1, -2, 3};
+    buf = reinterpret_cast<const uint8_t*>(data);
+    exporter.AddDataToJSON(json, buf, sizeof(data), "INT8");
+    CHECK(json[0] == 1);
+    CHECK(json[1] == -2);
+    CHECK(json[2] == 3);
+  }
+
+  SUBCASE("Test int16")
+  {
+    const int16_t data[3] = {4, -5, 6};
+    buf = reinterpret_cast<const uint8_t*>(data);
+    exporter.AddDataToJSON(json, buf, sizeof(data), "INT16");
+    CHECK(json[0] == 4);
+    CHECK(json[1] == -5);
+    CHECK(json[2] == 6);
+  }
+
+  SUBCASE("Test int32")
+  {
+    const int32_t data[3] = {7, -8, 9};
+    buf = reinterpret_cast<const uint8_t*>(data);
+    exporter.AddDataToJSON(json, buf, sizeof(data), "INT32");
+    CHECK(json[0] == 7);
+    CHECK(json[1] == -8);
+    CHECK(json[2] == 9);
+  }
+
+  SUBCASE("Test int64")
+  {
+    const int64_t data[3] = {10, -11, 12};
+    buf = reinterpret_cast<const uint8_t*>(data);
+    exporter.AddDataToJSON(json, buf, sizeof(data), "INT64");
+    CHECK(json[0] == 10);
+    CHECK(json[1] == -11);
+    CHECK(json[2] == 12);
+  }
+
+  SUBCASE("Test fp32")
+  {
+    const float data[3] = {1.0, -2.0, 3.0};
+    buf = reinterpret_cast<const uint8_t*>(data);
+    exporter.AddDataToJSON(json, buf, sizeof(data), "FP32");
+    CHECK(json[0] == 1.0);
+    CHECK(json[1] == -2.0);
+    CHECK(json[2] == 3.0);
+  }
+
+  SUBCASE("Test fp64")
+  {
+    const double data[3] = {4.0, -5.0, 6.0};
+    buf = reinterpret_cast<const uint8_t*>(data);
+    exporter.AddDataToJSON(json, buf, sizeof(data), "FP64");
+    CHECK(json[0] == 4.0);
+    CHECK(json[1] == -5.0);
+    CHECK(json[2] == 6.0);
   }
 }
 

--- a/src/test_profile_data_exporter.cc
+++ b/src/test_profile_data_exporter.cc
@@ -70,17 +70,17 @@ TEST_CASE("profile_data_exporter: ConvertToJson")
   RequestRecord::ResponseOutput response_output1{
       {"out_key1",
        {reinterpret_cast<const uint8_t*>(out_bufs[0].data()),
-        out_bufs[0].size()}},
+        out_bufs[0].size(), "BYTES"}},
       {"out_key2",
        {reinterpret_cast<const uint8_t*>(out_bufs[1].data()),
-        out_bufs[1].size()}}};
+        out_bufs[1].size(), "BYTES"}}};
   RequestRecord::ResponseOutput response_output2{
       {"out_key3",
        {reinterpret_cast<const uint8_t*>(out_bufs[2].data()),
-        out_bufs[2].size()}},
+        out_bufs[2].size(), "BYTES"}},
       {"out_key4",
        {reinterpret_cast<const uint8_t*>(out_bufs[3].data()),
-        out_bufs[3].size()}}};
+        out_bufs[3].size(), "BYTES"}}};
 
   RequestRecord request_record{
       request_timestamp,
@@ -190,6 +190,18 @@ TEST_CASE("profile_data_exporter: ConvertToJson")
   CHECK(actual_windows[2] == expected_windows[2]);
 
   CHECK(actual_version == expected_version);
+}
+
+TEST_CASE("profile_data_exporter: AddDataToJSON")
+{
+  MockProfileDataExporter exporter{};
+  rapidjson::Value value;
+  
+  SUBCASE("Test Bool")
+  {
+    const 
+
+  }
 }
 
 TEST_CASE("profile_data_exporter: AddExperiment")

--- a/src/test_profile_data_exporter.cc
+++ b/src/test_profile_data_exporter.cc
@@ -197,23 +197,23 @@ TEST_CASE("profile_data_exporter: AddDataToJSON")
   MockProfileDataExporter exporter{};
   rapidjson::Value json;
   const uint8_t* buf;
-  
+
   SUBCASE("Test bytes")
   {
     const std::string data{"abc123"};
     buf = reinterpret_cast<const uint8_t*>(data.data());
     exporter.AddDataToJSON(json, buf, data.size(), "BYTES");
-    CHECK(json == "abc123");    
+    CHECK(json == "abc123");
   }
-   
+
   SUBCASE("Test json")
   {
     const std::string data{"{\"abc\":\"def\"}"};
     buf = reinterpret_cast<const uint8_t*>(data.data());
     exporter.AddDataToJSON(json, buf, data.size(), "JSON");
-    CHECK(json == "{\"abc\":\"def\"}");    
+    CHECK(json == "{\"abc\":\"def\"}");
   }
-  
+
   SUBCASE("Test bool")
   {
     const bool data[3] = {true, false, true};


### PR DESCRIPTION
1. Support 1-d array data in profile exporter so that when the input/output involves more than one data value (or array of values), then it captures all the data, rather than just the first element. This is an incremental step towards supporting full N-dimensional tensor in profile exporter. Currently, we don't need to support N-dimensional tensors because we are mostly interested in the text string or token ids (which is just a 1-d array). Additionally, N-dimensional tensor support requires more changes to PA since response outputs doesn't store shape information of the tensors returned from the model so we need to retrieve that information somewhere.
2. Support other data types such as uint, fp, and etc.


Example:

When given trtllm engine the following input:
```
{
    "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
    "input_length": [8],
    "request_output_len": [10],
    ...
}
```
what we got from PA _before_ the change is
```
{
    "request_inputs": {
        "token_ids": 1,  // missing remaining values
        "input_length": 8,
        "request_output_len": 10,
    },
    ...
}
```
_After_ the fix, we get the full array of token ids (same for any other fields in the profile export json file):
```
{
    "request_inputs": {
        "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
        "input_length": 8,
        "request_output_len": 10,
    },
    ...
}
```