### PR TITLE
Print models being profiled in GenAI-Perf

### DIFF
--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -85,10 +85,9 @@ def _check_model_args(
     parser: argparse.ArgumentParser, args: argparse.Namespace
 ) -> argparse.Namespace:
     """
-    Check if model name is provided.
+    Check arguments associated with the model and apply any necessary formatting.
     """
-    if not args.model:
-        parser.error("The -m/--model option is required and cannot be empty.")
+    logger.info(f"Profiling these models: {', '.join(args.model)}")
     args = _convert_str_to_enum_entry(
         args, "model_selection_strategy", ModelSelectionStrategy
     )
@@ -532,7 +531,7 @@ def _add_endpoint_args(parser):
         "-m",
         "--model",
         nargs="+",
-        default=[],
+        required=True,
         help=f"The name of the model(s) to benchmark.",
     )
     endpoint_group.add_argument(

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -250,9 +250,6 @@ class TestCLIArguments:
         for key, value in expected_attributes.items():
             assert getattr(args, key) == value
 
-        # Check that nothing was printed as a byproduct of parsing the arguments
-        captured = capsys.readouterr()
-        assert captured.out == ""
 
     @pytest.mark.parametrize(
         "models, expected_model_list, formatted_name",
@@ -294,10 +291,6 @@ class TestCLIArguments:
         # Check that the formatted_model_name is correctly generated
         for key, value in formatted_name.items():
             assert getattr(args, key) == value
-
-        # Check that nothing was printed as a byproduct of parsing the arguments
-        captured = capsys.readouterr()
-        assert captured.out == ""
 
     def test_file_flags_parsed(self, monkeypatch, mocker):
         _ = mocker.patch("os.path.isfile", return_value=True)
@@ -362,8 +355,6 @@ class TestCLIArguments:
         args, _ = parser.parse_args()
 
         assert args.artifact_dir == Path(expected_path)
-        captured = capsys.readouterr()
-        assert captured.out == ""
 
     @pytest.mark.parametrize(
         "arg, expected_path, expected_output",
@@ -412,8 +403,6 @@ class TestCLIArguments:
         )
         args, _ = parser.parse_args()
         assert args.concurrency == 1
-        captured = capsys.readouterr()
-        assert captured.out == ""
 
     def test_load_level_mutually_exclusive(self, monkeypatch, capsys):
         monkeypatch.setattr(
@@ -433,7 +422,7 @@ class TestCLIArguments:
 
     def test_model_not_provided(self, monkeypatch, capsys):
         monkeypatch.setattr("sys.argv", ["genai-perf", "profile"])
-        expected_output = "The -m/--model option is required and cannot be empty."
+        expected_output = "the following arguments are required: -m/--model"
 
         with pytest.raises(SystemExit) as excinfo:
             parser.parse_args()


### PR DESCRIPTION
For ease, print the models being profiled by GenAI-Perf. This can help those profiling multiple models know all names were correctly parsed.

As part of these changes:
- Removed the error checking for model not being provided. This can be done in ArgParse now that profile is its own subcommand.
- Removed the check that there is not output in the parser unit tests. With this print command, the parser now prints output. That check is also too strict. It was initially put in place when GenAI-Perf was created to avoid accidentally committing debugging print statements, but there may be some logs that are appropriate for the parser like this one.


**Before - multiple models**
<img width="1349" alt="image" src="https://github.com/user-attachments/assets/6d934abb-1ac5-40d9-bda5-fb8daf2b25ae">
_A user cannot tell that all three models are being parsed. If you know what to look for, you know "multi" indicates that multiple models are being parsed._

**After - multiple models**
<img width="1333" alt="image" src="https://github.com/user-attachments/assets/81a17c58-6b50-46f9-86d2-5d212e5b7c13">
_It is clear exactly which models are being parsed._


**Before - single model**
<img width="1353" alt="image" src="https://github.com/user-attachments/assets/268f9c97-5040-4b33-85e4-0a5ffabd3f5d">

**After  - single model**
<img width="1357" alt="image" src="https://github.com/user-attachments/assets/cf79b9c5-fbf2-4f67-83b3-be3dc85de482">
