### PR TITLE
Add CLI argument for server-metrics-url

### DIFF
--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -31,6 +31,7 @@ import sys
 from enum import Enum, auto
 from pathlib import Path
 from typing import Tuple
+from urllib.parse import urlparse
 
 import genai_perf.logging as logging
 import genai_perf.utils as utils
@@ -247,6 +248,49 @@ def _check_load_manager_args(args: argparse.Namespace) -> argparse.Namespace:
     # If no concurrency or request rate is set, default to 1
     if not args.concurrency and not args.request_rate:
         args.concurrency = 1
+    return args
+
+
+def _is_valid_url(url: str, parser: argparse.ArgumentParser) -> None:
+    """
+    Validates a URL to ensure it meets the following criteria:
+    - The scheme must be 'http' or 'https'.
+    - The netloc (domain) must be present.
+    - The path must contain '/metrics'.
+
+    Raises:
+        `parser.error()` if the URL is invalid.
+
+    The URL structure is expected to follow:
+    <scheme>://<netloc>/<path>;<params>?<query>#<fragment>
+    """
+    parsed_url = urlparse(url)
+
+    if (
+        parsed_url.scheme not in ["http", "https"]
+        or not parsed_url.netloc
+        or "/metrics" not in parsed_url.path
+        or parsed_url.port is None
+    ):
+        parser.error(
+            "The URL passed for --server-metrics-url is invalid. "
+            "It must use 'http' or 'https', have a valid domain, "
+            "and contain '/metrics' in the path. The expected structure is: "
+            "<scheme>://<netloc>/<path>;<params>?<query>#<fragment>"
+        )
+
+
+def _check_server_metrics_url(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> argparse.Namespace:
+    """
+    Checks if the server metrics URL passed is valid
+    """
+
+    # Check if the URL is valid and contains the expected path
+    if args.service_kind == "triton" and args.server_metrics_url:
+        _is_valid_url(args.server_metrics_url, parser)
+
     return args
 
 
@@ -594,6 +638,14 @@ def _add_endpoint_args(parser):
     )
 
     endpoint_group.add_argument(
+        "--server-metrics-url",
+        type=str,
+        default=None,
+        required=False,
+        help="The full URL to access the server metrics endpoint. This argument is required if the metrics are available on a different machine than localhost (where GenAI-Perf is running).",
+    )
+
+    endpoint_group.add_argument(
         "--streaming",
         action="store_true",
         required=False,
@@ -773,9 +825,9 @@ def profile_handler(args, extra_args):
 
     telemetry_data_collector = None
     if args.service_kind == "triton":
-        # TPA-275: pass server url as a CLI option in non-default case
+        server_metrics_url = args.server_metrics_url or DEFAULT_TRITON_METRICS_URL
         telemetry_data_collector = TritonTelemetryDataCollector(
-            server_metrics_url=DEFAULT_TRITON_METRICS_URL
+            server_metrics_url=server_metrics_url
         )
 
     Profiler.run(
@@ -831,6 +883,7 @@ def refine_args(
         args = _check_conditional_args(parser, args)
         args = _check_image_input_args(parser, args)
         args = _check_load_manager_args(args)
+        args = _check_server_metrics_url(parser, args)
         args = _set_artifact_paths(args)
     elif args.subcommand == Subcommand.COMPARE.to_lowercase():
         args = _check_compare_args(parser, args)

--- a/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
@@ -46,6 +46,16 @@ class TelemetryDataCollector(ABC):
         self._stop_event = Event()
         self._thread: Optional[Thread] = None
 
+    def check_url_reachability(self) -> bool:
+        """Check if the server metrics URL is reachable"""
+        if self._server_metrics_url:
+            try:
+                response = requests.get(self._server_metrics_url, timeout=5)
+                return response.status_code == requests.codes.ok
+            except requests.RequestException:
+                return False
+        return True
+
     def start(self) -> None:
         """Start the telemetry data collection thread."""
         if self._thread is None or not self._thread.is_alive():
@@ -81,3 +91,8 @@ class TelemetryDataCollector(ABC):
     def metrics(self) -> TelemetryMetrics:
         """Return the collected metrics."""
         return self._metrics
+
+    @property
+    def metrics_url(self) -> str:
+        """Return server metrics url"""
+        return self._server_metrics_url

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -101,6 +101,7 @@ class Profiler:
             "image_height_mean",
             "image_height_stddev",
             "image_format",
+            "server_metrics_url",
         ]
 
         utils.remove_file(args.profile_export_file)
@@ -152,7 +153,13 @@ class Profiler:
     ) -> None:
         try:
             if telemetry_data_collector is not None:
-                telemetry_data_collector.start()
+                if telemetry_data_collector.check_url_reachability():
+                    telemetry_data_collector.start()
+                else:
+                    logger.warning(
+                        f"The server-metrics-url ({telemetry_data_collector.metrics_url}) is unreachable, cannot collect telemetry data"
+                    )
+
             cmd = Profiler.build_cmd(args, extra_args)
             logger.info(f"Running Perf Analyzer : '{' '.join(cmd)}'")
             if args and args.verbose:
@@ -162,3 +169,4 @@ class Profiler:
         finally:
             if telemetry_data_collector is not None:
                 telemetry_data_collector.stop()
+                print(telemetry_data_collector.metrics)

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -846,3 +846,75 @@ class TestCLIArguments:
         namespace.extra_inputs = extra_inputs_list
         actual_dict = parser.get_extra_inputs_as_dict(namespace)
         assert actual_dict == expected_dict
+
+    TEST_TRITON_METRICS_URL = "http://custom-metrics-url:8002/metrics"
+    INVALID_URL = "invalid_url"
+    INVALID_URL_ERROR_MESSAGE = (
+        "The URL passed for --server-metrics-url is invalid. "
+        "It must use 'http' or 'https', have a valid domain, "
+        "and contain '/metrics' in the path. The expected structure is: "
+        "<scheme>://<netloc>/<path>;<params>?<query>#<fragment>"
+    )
+
+    @pytest.mark.parametrize(
+        "args_list, expected_url, expected_error",
+        [
+            # Test with a custom URL
+            (
+                [
+                    "genai-perf",
+                    "profile",
+                    "--model",
+                    "test_model",
+                    "--service-kind",
+                    "triton",
+                    "--server-metrics-url",
+                    TEST_TRITON_METRICS_URL,
+                ],
+                TEST_TRITON_METRICS_URL,
+                None,
+            ),
+            # Test with default URL
+            (
+                [
+                    "genai-perf",
+                    "profile",
+                    "--model",
+                    "test_model",
+                    "--service-kind",
+                    "triton",
+                ],
+                None,
+                None,
+            ),
+            # Test with invalid URL
+            (
+                [
+                    "genai-perf",
+                    "profile",
+                    "--model",
+                    "test_model",
+                    "--service-kind",
+                    "triton",
+                    "--server-metrics-url",
+                    INVALID_URL,
+                ],
+                None,
+                INVALID_URL_ERROR_MESSAGE,
+            ),
+        ],
+    )
+    def test_server_metrics_url_for_triton(
+        self, args_list, expected_url, expected_error, monkeypatch, capsys
+    ):
+        monkeypatch.setattr("sys.argv", args_list)
+
+        if expected_error:
+            with pytest.raises(SystemExit) as excinfo:
+                parser.parse_args()
+            captured = capsys.readouterr()
+            assert expected_error in captured.err
+            assert excinfo.value.code != 0
+        else:
+            args, _ = parser.parse_args()
+            assert args.server_metrics_url == expected_url

--- a/genai-perf/tests/test_json_exporter.py
+++ b/genai-perf/tests/test_json_exporter.py
@@ -325,6 +325,7 @@ class TestJsonExporter:
           "endpoint": null,
           "endpoint_type": null,
           "service_kind": "triton",
+          "server_metrics_url": null,
           "streaming": true,
           "u": null,
           "input_dataset": null,

--- a/genai-perf/tests/test_profile_handler.py
+++ b/genai-perf/tests/test_profile_handler.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+#
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from unittest.mock import patch
+
+import pytest
+from genai_perf.constants import DEFAULT_TRITON_METRICS_URL
+from genai_perf.parser import profile_handler
+from genai_perf.telemetry_data.triton_telemetry_data_collector import (
+    TritonTelemetryDataCollector,
+)
+
+TRITON_TEST_METRICS_URL = "http://tritonmetrics.com:8080/metrics"
+
+
+# Parameterized fixture
+@pytest.fixture(
+    params=[
+        {"service_kind": "triton", "server_metrics_url": TRITON_TEST_METRICS_URL},
+        {"service_kind": "triton", "server_metrics_url": None},  # Default URL case
+    ]
+)
+def mock_args(request):
+    params = request.param
+
+    class MockArgs:
+        def __init__(self, service_kind, server_metrics_url):
+            self.service_kind = service_kind
+            self.server_metrics_url = server_metrics_url
+
+    return MockArgs(params["service_kind"], params["server_metrics_url"])
+
+
+@patch("genai_perf.wrapper.Profiler.run")
+def test_profile_handler_creates_telemetry_collector_triton(
+    mock_profiler_run, mock_args
+):
+    profile_handler(mock_args, extra_args={})
+    mock_profiler_run.assert_called_once()
+
+    args, kwargs = mock_profiler_run.call_args
+    telemetry_collector = kwargs.get("telemetry_data_collector")
+
+    expected_url = (
+        TRITON_TEST_METRICS_URL
+        if mock_args.server_metrics_url == TRITON_TEST_METRICS_URL
+        else DEFAULT_TRITON_METRICS_URL
+    )
+
+    assert isinstance(telemetry_collector, TritonTelemetryDataCollector)
+    assert telemetry_collector.metrics_url == expected_url


### PR DESCRIPTION
This is a new PR for adding a CLI argument to get server-metrics-url to collect telemetry data when the server is running on a different machine than genai-perf.
1. Add a new endpoint arg --server-metrics-url
2. Add checks for server-metrics-url
3. Add a check if url is reachable.
4. Unit tests