### PR TITLE
Graceful handling of exception thrown by genai-perf if metrics url is unreachable 

### DIFF
--- a/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
@@ -47,11 +47,11 @@ class TelemetryDataCollector(ABC):
         self._thread: Optional[Thread] = None
 
     def is_url_reachable(self) -> bool:
-        TIMEOUT_SECONDS = 5
+        timeout_seconds = 5
         if self._server_metrics_url:
             try:
                 response = requests.get(
-                    self._server_metrics_url, timeout=TIMEOUT_SECONDS
+                    self._server_metrics_url, timeout=timeout_seconds
                 )
                 return response.status_code == requests.codes.ok
             except requests.RequestException:
@@ -59,20 +59,17 @@ class TelemetryDataCollector(ABC):
         return True
 
     def start(self) -> None:
-        """Start the telemetry data collection thread."""
         if self._thread is None or not self._thread.is_alive():
             self._stop_event.clear()
             self._thread = Thread(target=self._collect_metrics)
             self._thread.start()
 
     def stop(self) -> None:
-        """Stop the telemetry data collection thread."""
         if self._thread is not None and self._thread.is_alive():
             self._stop_event.set()
             self._thread.join()
 
     def _fetch_metrics(self) -> str:
-        """Fetch metrics from the metrics endpoint"""
         response = requests.get(self._server_metrics_url)
         response.raise_for_status()
         return response.text
@@ -83,7 +80,7 @@ class TelemetryDataCollector(ABC):
         pass
 
     def _collect_metrics(self) -> None:
-        """Continuously collect telemetry metrics at for every second"""
+        """Continuously collect telemetry metrics for every second"""
         while not self._stop_event.is_set():
             metrics_data = self._fetch_metrics()
             self._process_and_update_metrics(metrics_data)
@@ -91,10 +88,8 @@ class TelemetryDataCollector(ABC):
 
     @property
     def metrics(self) -> TelemetryMetrics:
-        """Return the collected metrics."""
         return self._metrics
 
     @property
     def metrics_url(self) -> str:
-        """Return server metrics url"""
         return self._server_metrics_url

--- a/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
@@ -46,11 +46,13 @@ class TelemetryDataCollector(ABC):
         self._stop_event = Event()
         self._thread: Optional[Thread] = None
 
-    def check_url_reachability(self) -> bool:
-        """Check if the server metrics URL is reachable"""
+    def is_url_reachable(self) -> bool:
+        TIMEOUT_SECONDS = 5
         if self._server_metrics_url:
             try:
-                response = requests.get(self._server_metrics_url, timeout=5)
+                response = requests.get(
+                    self._server_metrics_url, timeout=TIMEOUT_SECONDS
+                )
                 return response.status_code == requests.codes.ok
             except requests.RequestException:
                 return False

--- a/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
@@ -46,6 +46,16 @@ class TelemetryDataCollector(ABC):
         self._stop_event = Event()
         self._thread: Optional[Thread] = None
 
+    def check_url_reachability(self) -> bool:
+        """Check if the server metrics URL is reachable"""
+        if self._server_metrics_url:
+            try:
+                response = requests.get(self._server_metrics_url, timeout=5)
+                return response.status_code == requests.codes.ok
+            except requests.RequestException:
+                return False
+        return True
+
     def start(self) -> None:
         """Start the telemetry data collection thread."""
         if self._thread is None or not self._thread.is_alive():
@@ -81,3 +91,8 @@ class TelemetryDataCollector(ABC):
     def metrics(self) -> TelemetryMetrics:
         """Return the collected metrics."""
         return self._metrics
+
+    @property
+    def metrics_url(self) -> str:
+        """Return server metrics url"""
+        return self._server_metrics_url

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -153,7 +153,12 @@ class Profiler:
     ) -> None:
         try:
             if telemetry_data_collector is not None:
-                telemetry_data_collector.start()
+                if telemetry_data_collector.check_url_reachability():
+                    telemetry_data_collector.start()
+                else:
+                    logger.warning(
+                        f"The metrics url ({telemetry_data_collector.metrics_url}) is unreachable, cannot collect telemetry data"
+                    )
             cmd = Profiler.build_cmd(args, extra_args)
             logger.info(f"Running Perf Analyzer : '{' '.join(cmd)}'")
             if args and args.verbose:

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -153,11 +153,12 @@ class Profiler:
     ) -> None:
         try:
             if telemetry_data_collector is not None:
-                if telemetry_data_collector.check_url_reachability():
+                if telemetry_data_collector.is_url_reachable():
                     telemetry_data_collector.start()
                 else:
                     logger.warning(
-                        f"The metrics url ({telemetry_data_collector.metrics_url}) is unreachable, cannot collect telemetry data"
+                        f"The metrics URL ({telemetry_data_collector.metrics_url}) is unreachable."
+                        "GenAI-Perf cannot collect telemetry data."
                     )
             cmd = Profiler.build_cmd(args, extra_args)
             logger.info(f"Running Perf Analyzer : '{' '.join(cmd)}'")

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -157,7 +157,7 @@ class Profiler:
                     telemetry_data_collector.start()
                 else:
                     logger.warning(
-                        f"The metrics URL ({telemetry_data_collector.metrics_url}) is unreachable."
+                        f"The metrics URL ({telemetry_data_collector.metrics_url}) is unreachable. "
                         "GenAI-Perf cannot collect telemetry data."
                     )
             cmd = Profiler.build_cmd(args, extra_args)

--- a/genai-perf/tests/test_telemetry_data_collector.py
+++ b/genai-perf/tests/test_telemetry_data_collector.py
@@ -130,11 +130,9 @@ class TestTelemetryDataCollector:
         with patch.object(
             collector, "_process_and_update_metrics", new_callable=MagicMock
         ) as mock_process_and_update_metrics:
-            # Mock _stop_event.is_set
+
             collector._stop_event = MagicMock()
-            collector._stop_event.is_set = MagicMock(
-                side_effect=[False, True]
-            )  # Ensure loop exits immediately
+            collector._stop_event.is_set = MagicMock(side_effect=[False, True])
 
             collector._collect_metrics()
 
@@ -157,30 +155,23 @@ class TestTelemetryDataCollector:
     def test_url_reachability_check_failure(
         self, mock_get: MagicMock, collector: MockTelemetryDataCollector
     ) -> None:
-        # Simulate a 404 Not Found error
         mock_get.return_value.status_code = requests.codes.not_found
         assert collector.is_url_reachable() is False
 
-        # Simulate a 500 Internal Server Error
         mock_get.return_value.status_code = requests.codes.server_error
         assert collector.is_url_reachable() is False
 
-        # Simulate a 403 Forbidden error
         mock_get.return_value.status_code = requests.codes.forbidden
         assert collector.is_url_reachable() is False
 
-        # Simulate a timeout exception
         mock_get.side_effect = requests.exceptions.Timeout
         assert collector.is_url_reachable() is False
 
-        # Simulate a connection error
         mock_get.side_effect = requests.exceptions.ConnectionError
         assert collector.is_url_reachable() is False
 
-        # Simulate too many redirects
         mock_get.side_effect = requests.exceptions.TooManyRedirects
         assert collector.is_url_reachable() is False
 
-        # Simulate a generic request exception
         mock_get.side_effect = requests.exceptions.RequestException
         assert collector.is_url_reachable() is False

--- a/genai-perf/tests/test_telemetry_data_collector.py
+++ b/genai-perf/tests/test_telemetry_data_collector.py
@@ -150,37 +150,37 @@ class TestTelemetryDataCollector:
         mock_get: MagicMock,
         collector: MockTelemetryDataCollector,
     ) -> None:
-        mock_get.return_value.status_code = requests.codes.ok  # 200
-        assert collector.check_url_reachability() is True
+        mock_get.return_value.status_code = requests.codes.ok
+        assert collector.is_url_reachable() is True
 
     @patch("requests.get")
     def test_url_reachability_check_failure(
         self, mock_get: MagicMock, collector: MockTelemetryDataCollector
     ) -> None:
         # Simulate a 404 Not Found error
-        mock_get.return_value.status_code = requests.codes.not_found  # 404
-        assert collector.check_url_reachability() is False
+        mock_get.return_value.status_code = requests.codes.not_found
+        assert collector.is_url_reachable() is False
 
         # Simulate a 500 Internal Server Error
-        mock_get.return_value.status_code = requests.codes.server_error  # 500
-        assert collector.check_url_reachability() is False
+        mock_get.return_value.status_code = requests.codes.server_error
+        assert collector.is_url_reachable() is False
 
         # Simulate a 403 Forbidden error
-        mock_get.return_value.status_code = requests.codes.forbidden  # 403
-        assert collector.check_url_reachability() is False
+        mock_get.return_value.status_code = requests.codes.forbidden
+        assert collector.is_url_reachable() is False
 
         # Simulate a timeout exception
         mock_get.side_effect = requests.exceptions.Timeout
-        assert collector.check_url_reachability() is False
+        assert collector.is_url_reachable() is False
 
         # Simulate a connection error
         mock_get.side_effect = requests.exceptions.ConnectionError
-        assert collector.check_url_reachability() is False
+        assert collector.is_url_reachable() is False
 
         # Simulate too many redirects
         mock_get.side_effect = requests.exceptions.TooManyRedirects
-        assert collector.check_url_reachability() is False
+        assert collector.is_url_reachable() is False
 
         # Simulate a generic request exception
         mock_get.side_effect = requests.exceptions.RequestException
-        assert collector.check_url_reachability() is False
+        assert collector.is_url_reachable() is False

--- a/genai-perf/tests/test_telemetry_data_collector.py
+++ b/genai-perf/tests/test_telemetry_data_collector.py
@@ -42,7 +42,7 @@ class TestTelemetryDataCollector:
 
     TEST_SERVER_URL = "http://testserver:8080/metrics"
 
-    triton_metrics_response = """\
+    TRITON_METRICS_RESPONSE = """\
             nv_gpu_power_usage{gpu="0",uuid="GPU-1234"} 123.45
             nv_gpu_power_usage{gpu="1",uuid="GPU-5678"} 234.56
             nv_gpu_utilization{gpu="0",uuid="GPU-1234"} 76.3
@@ -98,14 +98,14 @@ class TestTelemetryDataCollector:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.text = self.triton_metrics_response
+        mock_response.text = self.TRITON_METRICS_RESPONSE
         mock_requests_get.return_value = mock_response
 
         result = collector._fetch_metrics()
 
         mock_requests_get.assert_called_once_with(self.TEST_SERVER_URL)
 
-        assert result == self.triton_metrics_response
+        assert result == self.TRITON_METRICS_RESPONSE
 
     @patch("requests.get")
     def test_fetch_metrics_failure(
@@ -125,7 +125,7 @@ class TestTelemetryDataCollector:
         collector: MockTelemetryDataCollector,
     ) -> None:
 
-        mock_fetch_metrics.return_value = self.triton_metrics_response
+        mock_fetch_metrics.return_value = self.TRITON_METRICS_RESPONSE
 
         with patch.object(
             collector, "_process_and_update_metrics", new_callable=MagicMock
@@ -138,7 +138,7 @@ class TestTelemetryDataCollector:
 
             mock_fetch_metrics.assert_called_once()
             mock_process_and_update_metrics.assert_called_once_with(
-                self.triton_metrics_response
+                self.TRITON_METRICS_RESPONSE
             )
             mock_sleep.assert_called_once()
 


### PR DESCRIPTION
This is a small PR to gracefully handle the exception thrown by GenAI-Perf and it is logged as a warning that the url is not reachable.


![image](https://github.com/user-attachments/assets/464a37cc-3a1a-4124-b8bd-097aadaddb43)
