### PR TITLE
Document filepath option for tokenizer

### DIFF
--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -541,7 +541,8 @@ export file is `profile_export.json`, the genai-perf file will be exported to
 ##### `--tokenizer <str>`
 
 The HuggingFace tokenizer to use to interpret token metrics from prompts and
-responses. (default: `hf-internal-testing/llama-tokenizer`)
+responses. The value can be the name of a tokenizer or the filepath of the
+tokenizer. (default: `hf-internal-testing/llama-tokenizer`)
 
 ##### `-v`
 ##### `--verbose`

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -696,7 +696,8 @@ def _add_other_args(parser):
         type=str,
         default=DEFAULT_TOKENIZER,
         required=False,
-        help="The HuggingFace tokenizer to use to interpret token metrics from prompts and responses.",
+        help="The HuggingFace tokenizer to use to interpret token metrics from prompts and responses. "
+        " The value can be the name of a tokenizer or the filepath of the tokenizer.",
     )
 
     other_group.add_argument(

--- a/templates/genai-perf-templates/README_template
+++ b/templates/genai-perf-templates/README_template
@@ -541,7 +541,8 @@ export file is `profile_export.json`, the genai-perf file will be exported to
 ##### `--tokenizer <str>`
 
 The HuggingFace tokenizer to use to interpret token metrics from prompts and
-responses. (default: `hf-internal-testing/llama-tokenizer`)
+responses. The value can be the name of a tokenizer or the filepath of the
+tokenizer. (default: `hf-internal-testing/llama-tokenizer`)
 
 ##### `-v`
 ##### `--verbose`


### PR DESCRIPTION
Document that the filepath to a tokenizer can be used in addition to a tokenizer name for GenAI-Perf's `--tokenizer` argument.