### PR TITLE
Move telemetry metrics url reachability check to parser.py for efficient error handling

### DIFF
--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -870,7 +870,7 @@ def compare_handler(args: argparse.Namespace):
     plot_manager.generate_plots()
 
 
-def profile_handler(args, extra_args):
+def profile_handler(args, extra_args) -> None:
     from genai_perf.telemetry_data.triton_telemetry_data_collector import (
         TritonTelemetryDataCollector,
     )
@@ -882,6 +882,13 @@ def profile_handler(args, extra_args):
         telemetry_data_collector = TritonTelemetryDataCollector(
             server_metrics_url=server_metrics_url
         )
+
+    if telemetry_data_collector and not telemetry_data_collector.is_url_reachable():
+        logger.warning(
+            f"The metrics URL ({telemetry_data_collector.metrics_url}) is unreachable. "
+            "GenAI-Perf cannot collect telemetry data."
+        )
+        telemetry_data_collector = None
 
     Profiler.run(
         args=args,

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -155,13 +155,7 @@ class Profiler:
     ) -> None:
         try:
             if telemetry_data_collector is not None:
-                if telemetry_data_collector.is_url_reachable():
-                    telemetry_data_collector.start()
-                else:
-                    logger.warning(
-                        f"The metrics URL ({telemetry_data_collector.metrics_url}) is unreachable. "
-                        "GenAI-Perf cannot collect telemetry data."
-                    )
+                telemetry_data_collector.start()
             cmd = Profiler.build_cmd(args, extra_args)
             logger.info(f"Running Perf Analyzer : '{' '.join(cmd)}'")
             if args and args.verbose:

--- a/genai-perf/tests/test_profile_handler.py
+++ b/genai-perf/tests/test_profile_handler.py
@@ -26,9 +26,10 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from genai_perf.constants import DEFAULT_TRITON_METRICS_URL
 from genai_perf.parser import profile_handler
 from genai_perf.telemetry_data.triton_telemetry_data_collector import (
@@ -53,19 +54,45 @@ class TestProfileHandler:
         ],
     )
     @patch("genai_perf.wrapper.Profiler.run")
+    @patch("requests.get")
     def test_profile_handler_creates_telemetry_collector(
-        self, mock_profiler_run, server_metrics_url, expected_url
+        self, mock_requests_get, mock_profiler_run, server_metrics_url, expected_url
     ):
+        mock_requests_get.return_value = MagicMock(status_code=requests.codes.ok)
         mock_args = MockArgs(
             service_kind="triton", server_metrics_url=server_metrics_url
         )
         profile_handler(mock_args, extra_args={})
         mock_profiler_run.assert_called_once()
 
-        args, kwargs = mock_profiler_run.call_args
+        _, kwargs = mock_profiler_run.call_args
 
         assert "telemetry_data_collector" in kwargs
 
         telemetry_data_collector = kwargs["telemetry_data_collector"]
         assert isinstance(telemetry_data_collector, TritonTelemetryDataCollector)
         assert telemetry_data_collector.metrics_url == expected_url
+
+    @pytest.mark.parametrize(
+        "server_metrics_url",
+        [
+            test_triton_metrics_url,
+            None,
+        ],
+    )
+    @patch("genai_perf.wrapper.Profiler.run")
+    @patch("requests.get")
+    def test_profile_handler_does_not_create_telemetry_collector(
+        self, mock_requests_get, mock_profiler_run, server_metrics_url
+    ):
+        mock_requests_get.return_value = MagicMock(status_code=requests.codes.not_found)
+
+        mock_args = MockArgs(
+            service_kind="triton", server_metrics_url=server_metrics_url
+        )
+        profile_handler(mock_args, extra_args={})
+        mock_profiler_run.assert_called_once()
+
+        _, kwargs = mock_profiler_run.call_args
+        telemetry_data_collector = kwargs["telemetry_data_collector"]
+        assert telemetry_data_collector is None


### PR DESCRIPTION
This is a small PR where I moved the metrics url reachability check to parser.py.
This will enable setting telemetry_data_collector to None and thus avoid calling TelmetryStatistics and exporters.
I will use this to add a check before calling TelemetryStatistics or OutputReporter for telemetry metrics.

The test_profiler_handler unit test is updated to handle the modification.