### PR TITLE
Modify the data structure to store telemetry metrics

### DIFF
--- a/genai-perf/genai_perf/metrics/__init__.py
+++ b/genai-perf/genai_perf/metrics/__init__.py
@@ -29,3 +29,4 @@ from genai_perf.metrics.llm_metrics import LLMMetrics
 from genai_perf.metrics.metrics import MetricMetadata, Metrics
 from genai_perf.metrics.statistics import Statistics
 from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
+from genai_perf.metrics.telemetry_statistics import TelemetryStatistics

--- a/genai-perf/genai_perf/metrics/statistics.py
+++ b/genai-perf/genai_perf/metrics/statistics.py
@@ -28,11 +28,12 @@
 
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
 from genai_perf.metrics.metrics import Metrics
+from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
 
 
 class Statistics:
@@ -53,7 +54,7 @@ class Statistics:
       >>> print(stats.avg_request_throughput)  # output: 3
     """
 
-    def __init__(self, metrics: Metrics):
+    def __init__(self, metrics: Union[Metrics, TelemetryMetrics]):
         # iterate through Metrics to calculate statistics and set attributes
         self._metrics = metrics
         self._stats_dict: Dict = defaultdict(dict)
@@ -61,13 +62,21 @@ class Statistics:
             if self._should_skip(data, attr):
                 continue
 
-            attr = metrics.get_base_name(attr)
-            self._add_units(attr)
-            self._calculate_mean(data, attr)
-            if not self._is_system_metric(metrics, attr):
-                self._calculate_percentiles(data, attr)
-                self._calculate_minmax(data, attr)
-                self._calculate_std(data, attr)
+            if hasattr(metrics, "get_base_name"):
+                attr = metrics.get_base_name(attr)
+                self._add_units(attr)
+                self._stats_dict[attr]["avg"] = self._calculate_mean(data)
+                if not self._is_system_metric(attr):
+                    percentile_results = self._calculate_percentiles(data)
+                    for (
+                        percentile_label,
+                        percentile_value,
+                    ) in percentile_results.items():
+                        self._stats_dict[attr][percentile_label] = percentile_value
+                    min, max = self._calculate_minmax(data)
+                    self._stats_dict[attr]["min"] = min
+                    self._stats_dict[attr]["max"] = max
+                    self._stats_dict[attr]["std"] = self._calculate_std(data)
 
     def _should_skip(self, data: List[Union[int, float]], attr: str) -> bool:
         """Checks if some metrics should be skipped."""
@@ -79,38 +88,23 @@ class Statistics:
             return True
         return False
 
-    def _calculate_mean(self, data: List[Union[int, float]], attr: str) -> None:
+    def _calculate_mean(self, data: List[Union[int, float]]) -> float:
         avg = np.mean(data)
-        setattr(self, "avg_" + attr, avg)
-        self._stats_dict[attr]["avg"] = float(avg)
+        return float(avg)
 
-    def _calculate_percentiles(self, data: List[Union[int, float]], attr: str) -> None:
-        p25, p50, p75 = np.percentile(data, [25, 50, 75])
-        p90, p95, p99 = np.percentile(data, [90, 95, 99])
-        setattr(self, "p25_" + attr, p25)
-        setattr(self, "p50_" + attr, p50)
-        setattr(self, "p75_" + attr, p75)
-        setattr(self, "p90_" + attr, p90)
-        setattr(self, "p95_" + attr, p95)
-        setattr(self, "p99_" + attr, p99)
-        self._stats_dict[attr]["p99"] = float(p99)
-        self._stats_dict[attr]["p95"] = float(p95)
-        self._stats_dict[attr]["p90"] = float(p90)
-        self._stats_dict[attr]["p75"] = float(p75)
-        self._stats_dict[attr]["p50"] = float(p50)
-        self._stats_dict[attr]["p25"] = float(p25)
+    def _calculate_percentiles(self, data: List[Union[int, float]]) -> Dict[str, float]:
+        percentiles = [25, 50, 75, 90, 95, 99]
+        percentile_labels = [f"p{p}" for p in percentiles]
+        percentile_values = [float(np.percentile(data, p)) for p in percentiles]
+        return dict(zip(percentile_labels, percentile_values))
 
-    def _calculate_minmax(self, data: List[Union[int, float]], attr: str) -> None:
+    def _calculate_minmax(self, data: List[Union[int, float]]) -> Tuple[float, float]:
         min, max = np.min(data), np.max(data)
-        setattr(self, "min_" + attr, min)
-        setattr(self, "max_" + attr, max)
-        self._stats_dict[attr]["max"] = float(max)
-        self._stats_dict[attr]["min"] = float(min)
+        return (float(min), float(max))
 
-    def _calculate_std(self, data: List[Union[int, float]], attr: str) -> None:
+    def _calculate_std(self, data: List[Union[int, float]]) -> float:
         std = np.std(data)
-        setattr(self, "std_" + attr, std)
-        self._stats_dict[attr]["std"] = float(std)
+        return float(std)
 
     def scale_data(self, factor: float = 1 / 1e6) -> None:
         for k1, v1 in self.stats_dict.items():
@@ -119,10 +113,9 @@ class Statistics:
                     if k2 != "unit":
                         self.stats_dict[k1][k2] = self._scale(v2, factor)
 
-    def _scale(self, metric: float, factor: float = 1 / 1e6) -> float:
+    def _scale(self, metric: float, factor: float) -> float:
         """
-        Scale metrics from nanoseconds by factor.
-        Default is nanoseconds to milliseconds.
+        Scale metrics by the factor
         """
         return metric * factor
 
@@ -153,7 +146,7 @@ class Statistics:
         return {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
 
     @property
-    def metrics(self) -> Metrics:
+    def metrics(self) -> Union[Metrics, TelemetryMetrics]:
         """Return the underlying metrics used to calculate the statistics."""
         return self._metrics
 
@@ -161,8 +154,10 @@ class Statistics:
     def stats_dict(self) -> Dict:
         return self._stats_dict
 
-    def _is_system_metric(self, metrics: Metrics, attr: str) -> bool:
-        return attr in [m.name for m in metrics.system_metrics]
+    def _is_system_metric(self, attr: str) -> bool:
+        if isinstance(self._metrics, Metrics):
+            return attr in [m.name for m in self._metrics.system_metrics]
+        return False
 
     def _is_time_metric(self, field: str) -> bool:
         # TPA-188: Remove the hardcoded time metrics list

--- a/genai-perf/genai_perf/metrics/telemetry_statistics.py
+++ b/genai-perf/genai_perf/metrics/telemetry_statistics.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from collections import defaultdict
+from typing import Any, DefaultDict, Dict, List
+
+from genai_perf.metrics.statistics import Statistics
+from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
+
+
+class TelemetryStatistics:
+    """A class that aggregates various statistics from telemetry metrics class."""
+
+    def __init__(self, metrics: TelemetryMetrics):
+        self._metrics = metrics
+        self._stats_dict: DefaultDict[str, Any] = defaultdict(lambda: defaultdict(dict))
+        self._statistics = Statistics(metrics)
+
+        self._add_units()
+        for attr, data in self._metrics.data.items():
+            if self._should_skip(data):
+                continue
+            for gpu_index, gpu_data in data.items():
+                self._stats_dict[attr][gpu_index]["avg"] = (
+                    self._statistics._calculate_mean(gpu_data)
+                )
+            if not self._is_constant_metric(attr):
+                percentile_results = self._statistics._calculate_percentiles(gpu_data)
+                for percentile_label, percentile_value in percentile_results.items():
+                    self._stats_dict[attr][gpu_index][
+                        percentile_label
+                    ] = percentile_value
+                min, max = self._statistics._calculate_minmax(gpu_data)
+                self._stats_dict[attr][gpu_index]["min"] = min
+                self._stats_dict[attr][gpu_index]["max"] = max
+                self._stats_dict[attr][gpu_index]["std"] = (
+                    self._statistics._calculate_std(gpu_data)
+                )
+
+    def _should_skip(self, data: Dict[str, List[float]]) -> bool:
+        if len(data) == 0:
+            return True
+        return False
+
+    def _add_units(self) -> None:
+        for metric in self._metrics.telemetry_metrics:
+            self._stats_dict[metric.name]["unit"] = metric.unit
+
+    def _is_constant_metric(self, attr: str) -> bool:
+        return attr in ["gpu_power_limit", "total_gpu_memory"]
+
+    @property
+    def stats_dict(self) -> Dict:
+        return self._stats_dict

--- a/genai-perf/genai_perf/telemetry_data/__init__.py
+++ b/genai-perf/genai_perf/telemetry_data/__init__.py
@@ -25,3 +25,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from genai_perf.telemetry_data.telemetry_data_collector import TelemetryDataCollector
+from genai_perf.telemetry_data.triton_telemetry_data_collector import (
+    TritonTelemetryDataCollector,
+)

--- a/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
@@ -33,7 +33,7 @@ from threading import Event, Thread
 from typing import Optional
 
 import requests
-from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
+from genai_perf.metrics import TelemetryMetrics, TelemetryStatistics
 
 
 class TelemetryDataCollector(ABC):
@@ -68,6 +68,10 @@ class TelemetryDataCollector(ABC):
         if self._thread is not None and self._thread.is_alive():
             self._stop_event.set()
             self._thread.join()
+
+    def get_statistics(self) -> TelemetryStatistics:
+        telemetry_stats = TelemetryStatistics(self._metrics)
+        return telemetry_stats
 
     def _fetch_metrics(self) -> str:
         response = requests.get(self._server_metrics_url)

--- a/genai-perf/tests/test_telemetry_metrics.py
+++ b/genai-perf/tests/test_telemetry_metrics.py
@@ -35,22 +35,22 @@ class TestTelemetryMetrics:
 
     def test_update_metrics(self) -> None:
         telemetry = TelemetryMetrics()
-        measurement_data: Dict[str, List[float]] = {
-            "gpu_power_usage": [11.1, 11.2],
-            "gpu_power_limit": [101.2, 101.2],
-            "energy_consumption": [1004.0, 1005.0],
-            "gpu_utilization": [85.0, 90.0],
-            "total_gpu_memory": [9000.0, 9000.0],
-            "gpu_memory_used": [4500.0, 4500.0],
+        measurement_data: Dict[str, Dict[str, List[float]]] = {
+            "gpu_power_usage": {"gpu0": [11.1], "gpu1": [11.2]},
+            "gpu_power_limit": {"gpu0": [101.2], "gpu1": [101.2]},
+            "energy_consumption": {"gpu0": [1004.0], "gpu1": [1005.0]},
+            "gpu_utilization": {"gpu0": [85.0], "gpu1": [90.0]},
+            "total_gpu_memory": {"gpu0": [9000.0], "gpu1": [9000.0]},
+            "gpu_memory_used": {"gpu0": [4500.0], "gpu1": [4500.0]},
         }
         telemetry.update_metrics(measurement_data)
 
-        assert telemetry.gpu_power_usage == [[11.1, 11.2]]
-        assert telemetry.gpu_power_limit == [[101.2, 101.2]]
-        assert telemetry.energy_consumption == [[1004.0, 1005.0]]
-        assert telemetry.gpu_utilization == [[85.0, 90.0]]
-        assert telemetry.total_gpu_memory == [[9000.0, 9000.0]]
-        assert telemetry.gpu_memory_used == [[4500.0, 4500.0]]
+        assert telemetry.gpu_power_usage == {"gpu0": [11.1], "gpu1": [11.2]}
+        assert telemetry.gpu_power_limit == {"gpu0": [101.2], "gpu1": [101.2]}
+        assert telemetry.energy_consumption == {"gpu0": [1004.0], "gpu1": [1005.0]}
+        assert telemetry.gpu_utilization == {"gpu0": [85.0], "gpu1": [90.0]}
+        assert telemetry.total_gpu_memory == {"gpu0": [9000.0], "gpu1": [9000.0]}
+        assert telemetry.gpu_memory_used == {"gpu0": [4500.0], "gpu1": [4500.0]}
 
     def test_telemetry_metrics_property(self) -> None:
         telemetry = TelemetryMetrics()


### PR DESCRIPTION
Earlier, the telemetry metrics are stored as a list of lists, where each inner list corresponds to metric value of different GPUs for current measurement.
This data structure inflexible and provided challenges in utilizing existing methods in statistics.py , which led to duplication.
This PR  uses a different data structure.
With this change, the metrics are now stored as
'gpu_power_usage': {
        'gpu0': [27.01]
    },
    'gpu_utilization': {
        'gpu0': [75.5]
    },
    'energy_consumption': {
        'gpu0': [123.56]
    }
 With this new data structure, it's easy to leverage the methods in statistics.py