### PR TITLE
Fix console title for vlm models

### DIFF
--- a/genai-perf/genai_perf/export_data/console_exporter.py
+++ b/genai-perf/genai_perf/export_data/console_exporter.py
@@ -50,6 +50,8 @@ class ConsoleExporter:
             title += "Rankings Metrics"
         elif self._args.endpoint_type == "image_retrieval":
             title += "Image Retrieval Metrics"
+        elif self._args.endpoint_type == "vision":
+            title += "VLM Metrics"
         else:
             title += "LLM Metrics"
         return title


### PR DESCRIPTION
Example output: 
<img width="938" alt="image" src="https://github.com/user-attachments/assets/d9977a5a-5100-42c3-8017-657014442f17">
