### PR TITLE
Add functionality to perform warmup before benchmarking

### DIFF
--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -824,71 +824,90 @@ CLParser::ParseCommandLine(int argc, char** argv)
   argc_ = argc;
   argv_ = argv;
 
+  constexpr int long_option_idx_base{256};
+
   // {name, has_arg, *flag, val}
   static struct option long_options[] = {
-      {"streaming", no_argument, 0, 0},
-      {"max-threads", required_argument, 0, 1},
-      {"sequence-length", required_argument, 0, 2},
-      {"percentile", required_argument, 0, 3},
-      {"data-directory", required_argument, 0, 4},
-      {"shape", required_argument, 0, 5},
-      {"measurement-interval", required_argument, 0, 6},
-      {"concurrency-range", required_argument, 0, 7},
-      {"latency-threshold", required_argument, 0, 8},
-      {"stability-percentage", required_argument, 0, 9},
-      {"max-trials", required_argument, 0, 10},
-      {"input-data", required_argument, 0, 11},
-      {"string-length", required_argument, 0, 12},
-      {"string-data", required_argument, 0, 13},
-      {"async", no_argument, 0, 14},
-      {"sync", no_argument, 0, 15},
-      {"request-rate-range", required_argument, 0, 16},
-      {"num-of-sequences", required_argument, 0, 17},
-      {"binary-search", no_argument, 0, 18},
-      {"request-distribution", required_argument, 0, 19},
-      {"request-intervals", required_argument, 0, 20},
-      {"shared-memory", required_argument, 0, 21},
-      {"output-shared-memory-size", required_argument, 0, 22},
-      {"service-kind", required_argument, 0, 23},
-      {"model-signature-name", required_argument, 0, 24},
-      {"grpc-compression-algorithm", required_argument, 0, 25},
-      {"measurement-mode", required_argument, 0, 26},
-      {"measurement-request-count", required_argument, 0, 27},
-      {"triton-server-directory", required_argument, 0, 28},
-      {"model-repository", required_argument, 0, 29},
-      {"sequence-id-range", required_argument, 0, 30},
-      {"ssl-grpc-use-ssl", no_argument, 0, 31},
-      {"ssl-grpc-root-certifications-file", required_argument, 0, 32},
-      {"ssl-grpc-private-key-file", required_argument, 0, 33},
-      {"ssl-grpc-certificate-chain-file", required_argument, 0, 34},
-      {"ssl-https-verify-peer", required_argument, 0, 35},
-      {"ssl-https-verify-host", required_argument, 0, 36},
-      {"ssl-https-ca-certificates-file", required_argument, 0, 37},
-      {"ssl-https-client-certificate-file", required_argument, 0, 38},
-      {"ssl-https-client-certificate-type", required_argument, 0, 39},
-      {"ssl-https-private-key-file", required_argument, 0, 40},
-      {"ssl-https-private-key-type", required_argument, 0, 41},
-      {"verbose-csv", no_argument, 0, 42},
-      {"enable-mpi", no_argument, 0, 43},
-      {"trace-level", required_argument, 0, 44},
-      {"trace-rate", required_argument, 0, 45},
-      {"trace-count", required_argument, 0, 46},
-      {"log-frequency", required_argument, 0, 47},
-      {"collect-metrics", no_argument, 0, 48},
-      {"metrics-url", required_argument, 0, 49},
-      {"metrics-interval", required_argument, 0, 50},
-      {"sequence-length-variation", required_argument, 0, 51},
-      {"bls-composing-models", required_argument, 0, 52},
-      {"serial-sequences", no_argument, 0, 53},
-      {"input-tensor-format", required_argument, 0, 54},
-      {"output-tensor-format", required_argument, 0, 55},
-      {"version", no_argument, 0, 56},
-      {"profile-export-file", required_argument, 0, 57},
-      {"periodic-concurrency-range", required_argument, 0, 58},
-      {"request-period", required_argument, 0, 59},
-      {"request-parameter", required_argument, 0, 60},
-      {"endpoint", required_argument, 0, 61},
-      {"request-count", required_argument, 0, 62},
+      {"streaming", no_argument, 0, long_option_idx_base + 0},
+      {"max-threads", required_argument, 0, long_option_idx_base + 1},
+      {"sequence-length", required_argument, 0, long_option_idx_base + 2},
+      {"percentile", required_argument, 0, long_option_idx_base + 3},
+      {"data-directory", required_argument, 0, long_option_idx_base + 4},
+      {"shape", required_argument, 0, long_option_idx_base + 5},
+      {"measurement-interval", required_argument, 0, long_option_idx_base + 6},
+      {"concurrency-range", required_argument, 0, long_option_idx_base + 7},
+      {"latency-threshold", required_argument, 0, long_option_idx_base + 8},
+      {"stability-percentage", required_argument, 0, long_option_idx_base + 9},
+      {"max-trials", required_argument, 0, long_option_idx_base + 10},
+      {"input-data", required_argument, 0, long_option_idx_base + 11},
+      {"string-length", required_argument, 0, long_option_idx_base + 12},
+      {"string-data", required_argument, 0, long_option_idx_base + 13},
+      {"async", no_argument, 0, long_option_idx_base + 14},
+      {"sync", no_argument, 0, long_option_idx_base + 15},
+      {"request-rate-range", required_argument, 0, long_option_idx_base + 16},
+      {"num-of-sequences", required_argument, 0, long_option_idx_base + 17},
+      {"binary-search", no_argument, 0, long_option_idx_base + 18},
+      {"request-distribution", required_argument, 0, long_option_idx_base + 19},
+      {"request-intervals", required_argument, 0, long_option_idx_base + 20},
+      {"shared-memory", required_argument, 0, long_option_idx_base + 21},
+      {"output-shared-memory-size", required_argument, 0,
+       long_option_idx_base + 22},
+      {"service-kind", required_argument, 0, long_option_idx_base + 23},
+      {"model-signature-name", required_argument, 0, long_option_idx_base + 24},
+      {"grpc-compression-algorithm", required_argument, 0,
+       long_option_idx_base + 25},
+      {"measurement-mode", required_argument, 0, long_option_idx_base + 26},
+      {"measurement-request-count", required_argument, 0,
+       long_option_idx_base + 27},
+      {"triton-server-directory", required_argument, 0,
+       long_option_idx_base + 28},
+      {"model-repository", required_argument, 0, long_option_idx_base + 29},
+      {"sequence-id-range", required_argument, 0, long_option_idx_base + 30},
+      {"ssl-grpc-use-ssl", no_argument, 0, long_option_idx_base + 31},
+      {"ssl-grpc-root-certifications-file", required_argument, 0,
+       long_option_idx_base + 32},
+      {"ssl-grpc-private-key-file", required_argument, 0,
+       long_option_idx_base + 33},
+      {"ssl-grpc-certificate-chain-file", required_argument, 0,
+       long_option_idx_base + 34},
+      {"ssl-https-verify-peer", required_argument, 0,
+       long_option_idx_base + 35},
+      {"ssl-https-verify-host", required_argument, 0,
+       long_option_idx_base + 36},
+      {"ssl-https-ca-certificates-file", required_argument, 0,
+       long_option_idx_base + 37},
+      {"ssl-https-client-certificate-file", required_argument, 0,
+       long_option_idx_base + 38},
+      {"ssl-https-client-certificate-type", required_argument, 0,
+       long_option_idx_base + 39},
+      {"ssl-https-private-key-file", required_argument, 0,
+       long_option_idx_base + 40},
+      {"ssl-https-private-key-type", required_argument, 0,
+       long_option_idx_base + 41},
+      {"verbose-csv", no_argument, 0, long_option_idx_base + 42},
+      {"enable-mpi", no_argument, 0, long_option_idx_base + 43},
+      {"trace-level", required_argument, 0, long_option_idx_base + 44},
+      {"trace-rate", required_argument, 0, long_option_idx_base + 45},
+      {"trace-count", required_argument, 0, long_option_idx_base + 46},
+      {"log-frequency", required_argument, 0, long_option_idx_base + 47},
+      {"collect-metrics", no_argument, 0, long_option_idx_base + 48},
+      {"metrics-url", required_argument, 0, long_option_idx_base + 49},
+      {"metrics-interval", required_argument, 0, long_option_idx_base + 50},
+      {"sequence-length-variation", required_argument, 0,
+       long_option_idx_base + 51},
+      {"bls-composing-models", required_argument, 0, long_option_idx_base + 52},
+      {"serial-sequences", no_argument, 0, long_option_idx_base + 53},
+      {"input-tensor-format", required_argument, 0, long_option_idx_base + 54},
+      {"output-tensor-format", required_argument, 0, long_option_idx_base + 55},
+      {"version", no_argument, 0, long_option_idx_base + 56},
+      {"profile-export-file", required_argument, 0, long_option_idx_base + 57},
+      {"periodic-concurrency-range", required_argument, 0,
+       long_option_idx_base + 58},
+      {"request-period", required_argument, 0, long_option_idx_base + 59},
+      {"request-parameter", required_argument, 0, long_option_idx_base + 60},
+      {"endpoint", required_argument, 0, long_option_idx_base + 61},
+      {"request-count", required_argument, 0, long_option_idx_base + 62},
+      {"warmup-request-count", required_argument, 0, long_option_idx_base + 63},
       {0, 0, 0, 0}};
 
   // Parse commandline...
@@ -898,10 +917,10 @@ CLParser::ParseCommandLine(int argc, char** argv)
               NULL)) != -1) {
     try {
       switch (opt) {
-        case 0:
+        case long_option_idx_base + 0:
           params_->streaming = true;
           break;
-        case 1: {
+        case long_option_idx_base + 1: {
           std::string max_threads{optarg};
           if (std::stoi(max_threads) > 0) {
             params_->max_threads = std::stoull(max_threads);
@@ -911,7 +930,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 2: {
+        case long_option_idx_base + 2: {
           std::string sequence_length{optarg};
           if (std::stoi(sequence_length) > 0) {
             params_->sequence_length = std::stoull(sequence_length);
@@ -924,13 +943,13 @@ CLParser::ParseCommandLine(int argc, char** argv)
           params_->sequence_length_specified = true;
           break;
         }
-        case 3:
+        case long_option_idx_base + 3:
           params_->percentile = std::atoi(optarg);
           break;
-        case 4:
+        case long_option_idx_base + 4:
           params_->user_data.push_back(optarg);
           break;
-        case 5: {
+        case long_option_idx_base + 5: {
           std::string arg = optarg;
           auto colon_pos = arg.rfind(":");
           if (colon_pos == std::string::npos) {
@@ -963,7 +982,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           params_->input_shapes[name] = shape;
           break;
         }
-        case 6:
+        case long_option_idx_base + 6:
         case 'p': {
           std::string measurement_window_ms{optarg};
           if (std::stoi(measurement_window_ms) > 0) {
@@ -975,7 +994,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 7: {
+        case long_option_idx_base + 7: {
           params_->using_concurrency_range = true;
           std::string arg = optarg;
           std::vector<std::string> values{SplitString(arg)};
@@ -997,7 +1016,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 8:
+        case long_option_idx_base + 8:
         case 'l': {
           std::string latency_threshold_ms{optarg};
           if (std::stoi(latency_threshold_ms) == 0) {
@@ -1011,7 +1030,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 9:
+        case long_option_idx_base + 9:
         case 's': {
           std::string stability_threshold{optarg};
           if (std::stof(stability_threshold) >= 0.0) {
@@ -1023,7 +1042,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 10:
+        case long_option_idx_base + 10:
         case 'r': {
           std::string max_trials{optarg};
           if (std::stoi(max_trials) > 0) {
@@ -1033,7 +1052,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 11: {
+        case long_option_idx_base + 11: {
           std::string arg = optarg;
           // Check whether the argument is a directory
           if (IsDirectory(arg) || IsFile(arg)) {
@@ -1051,7 +1070,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 12: {
+        case long_option_idx_base + 12: {
           std::string string_length{optarg};
           if (std::stoi(string_length) > 0) {
             params_->string_length = std::stoull(string_length);
@@ -1060,20 +1079,20 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 13: {
+        case long_option_idx_base + 13: {
           params_->string_data = optarg;
           break;
         }
-        case 14:
+        case long_option_idx_base + 14:
         case 'a': {
           params_->async = true;
           break;
         }
-        case 15: {
+        case long_option_idx_base + 15: {
           params_->forced_sync = true;
           break;
         }
-        case 16: {
+        case long_option_idx_base + 16: {
           params_->using_request_rate_range = true;
           std::string arg = optarg;
           size_t pos = 0;
@@ -1099,7 +1118,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
 
           break;
         }
-        case 17: {
+        case long_option_idx_base + 17: {
           std::string num_of_sequences{optarg};
           if (std::stoi(num_of_sequences) > 0) {
             params_->num_of_sequences = std::stoul(num_of_sequences);
@@ -1108,11 +1127,11 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 18: {
+        case long_option_idx_base + 18: {
           params_->search_mode = SearchMode::BINARY;
           break;
         }
-        case 19: {
+        case long_option_idx_base + 19: {
           std::string arg = optarg;
           if (arg.compare("poisson") == 0) {
             params_->request_distribution = Distribution::POISSON;
@@ -1126,7 +1145,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 20: {
+        case long_option_idx_base + 20: {
           std::string request_intervals_file{optarg};
           if (IsFile(request_intervals_file)) {
             params_->request_intervals_file = request_intervals_file;
@@ -1138,7 +1157,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 21: {
+        case long_option_idx_base + 21: {
           std::string arg = optarg;
           if (arg.compare("system") == 0) {
             params_->shared_memory_type =
@@ -1162,7 +1181,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 22: {
+        case long_option_idx_base + 22: {
           std::string output_shm_size{optarg};
           if (std::stoi(output_shm_size) >= 0) {
             params_->output_shm_size = std::stoull(output_shm_size);
@@ -1173,7 +1192,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 23: {
+        case long_option_idx_base + 23: {
           std::string arg = optarg;
           if (arg.compare("triton") == 0) {
             params_->kind = cb::TRITON;
@@ -1194,10 +1213,10 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 24:
+        case long_option_idx_base + 24:
           params_->model_signature_name = optarg;
           break;
-        case 25: {
+        case long_option_idx_base + 25: {
           std::string arg = optarg;
           if (arg.compare("none") == 0) {
             params_->compression_algorithm = cb::COMPRESS_NONE;
@@ -1215,7 +1234,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           params_->using_grpc_compression = true;
           break;
         }
-        case 26: {
+        case long_option_idx_base + 26: {
           std::string arg = optarg;
           if (arg.compare("time_windows") == 0) {
             params_->measurement_mode = MeasurementMode::TIME_WINDOWS;
@@ -1231,7 +1250,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 27: {
+        case long_option_idx_base + 27: {
           std::string request_count{optarg};
           if (std::stoi(request_count) > 0) {
             params_->measurement_request_count = std::stoull(request_count);
@@ -1242,15 +1261,15 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 28: {
+        case long_option_idx_base + 28: {
           params_->triton_server_path = optarg;
           break;
         }
-        case 29: {
+        case long_option_idx_base + 29: {
           params_->model_repository_path = optarg;
           break;
         }
-        case 30: {
+        case long_option_idx_base + 30: {
           std::string arg = optarg;
           int64_t start_id;
           int64_t end_id;
@@ -1298,11 +1317,11 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 31: {
+        case long_option_idx_base + 31: {
           params_->ssl_options.ssl_grpc_use_ssl = true;
           break;
         }
-        case 32: {
+        case long_option_idx_base + 32: {
           if (IsFile(optarg)) {
             params_->ssl_options.ssl_grpc_root_certifications_file = optarg;
           } else {
@@ -1312,7 +1331,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 33: {
+        case long_option_idx_base + 33: {
           if (IsFile(optarg)) {
             params_->ssl_options.ssl_grpc_private_key_file = optarg;
           } else {
@@ -1322,7 +1341,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 34: {
+        case long_option_idx_base + 34: {
           if (IsFile(optarg)) {
             params_->ssl_options.ssl_grpc_certificate_chain_file = optarg;
           } else {
@@ -1332,7 +1351,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 35: {
+        case long_option_idx_base + 35: {
           if (std::atol(optarg) == 0 || std::atol(optarg) == 1) {
             params_->ssl_options.ssl_https_verify_peer = std::atol(optarg);
           } else {
@@ -1342,7 +1361,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 36: {
+        case long_option_idx_base + 36: {
           if (std::atol(optarg) == 0 || std::atol(optarg) == 1 ||
               std::atol(optarg) == 2) {
             params_->ssl_options.ssl_https_verify_host = std::atol(optarg);
@@ -1353,7 +1372,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 37: {
+        case long_option_idx_base + 37: {
           if (IsFile(optarg)) {
             params_->ssl_options.ssl_https_ca_certificates_file = optarg;
           } else {
@@ -1363,7 +1382,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 38: {
+        case long_option_idx_base + 38: {
           if (IsFile(optarg)) {
             params_->ssl_options.ssl_https_client_certificate_file = optarg;
           } else {
@@ -1373,7 +1392,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 39: {
+        case long_option_idx_base + 39: {
           if (std::string(optarg) == "PEM" || std::string(optarg) == "DER") {
             params_->ssl_options.ssl_https_client_certificate_type = optarg;
           } else {
@@ -1385,7 +1404,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 40: {
+        case long_option_idx_base + 40: {
           if (IsFile(optarg)) {
             params_->ssl_options.ssl_https_private_key_file = optarg;
           } else {
@@ -1395,7 +1414,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 41: {
+        case long_option_idx_base + 41: {
           if (std::string(optarg) == "PEM" || std::string(optarg) == "DER") {
             params_->ssl_options.ssl_https_private_key_type = optarg;
           } else {
@@ -1407,15 +1426,15 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 42: {
+        case long_option_idx_base + 42: {
           params_->verbose_csv = true;
           break;
         }
-        case 43: {
+        case long_option_idx_base + 43: {
           params_->enable_mpi = true;
           break;
         }
-        case 44: {
+        case long_option_idx_base + 44: {
           std::string trace_level{optarg};
           if (trace_level == "OFF" || trace_level == "TIMESTAMPS" ||
               trace_level == "TENSORS") {
@@ -1429,11 +1448,11 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 45: {
+        case long_option_idx_base + 45: {
           params_->trace_options["trace_rate"] = {optarg};
           break;
         }
-        case 46: {
+        case long_option_idx_base + 46: {
           std::string trace_count{optarg};
           if (std::stoi(trace_count) >= -1) {
             params_->trace_options["trace_count"] = {trace_count};
@@ -1444,7 +1463,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 47: {
+        case long_option_idx_base + 47: {
           std::string log_frequency{optarg};
           if (std::stoi(log_frequency) >= 0) {
             params_->trace_options["log_frequency"] = {log_frequency};
@@ -1453,16 +1472,16 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 48: {
+        case long_option_idx_base + 48: {
           params_->should_collect_metrics = true;
           break;
         }
-        case 49: {
+        case long_option_idx_base + 49: {
           params_->metrics_url = optarg;
           params_->metrics_url_specified = true;
           break;
         }
-        case 50: {
+        case long_option_idx_base + 50: {
           std::string metrics_interval_ms{optarg};
           if (std::stoi(metrics_interval_ms) > 0) {
             params_->metrics_interval_ms = std::stoull(metrics_interval_ms);
@@ -1474,11 +1493,11 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 51: {
+        case long_option_idx_base + 51: {
           params_->sequence_length_variation = std::stod(optarg);
           break;
         }
-        case 52: {
+        case long_option_idx_base + 52: {
           std::string arg = optarg;
 
           // Remove all spaces in the string
@@ -1507,11 +1526,11 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 53: {
+        case long_option_idx_base + 53: {
           params_->serial_sequences = true;
           break;
         }
-        case 54: {
+        case long_option_idx_base + 54: {
           cb::TensorFormat input_tensor_format{ParseTensorFormat(optarg)};
           if (input_tensor_format == cb::TensorFormat::UNKNOWN) {
             Usage(
@@ -1523,7 +1542,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           params_->input_tensor_format = input_tensor_format;
           break;
         }
-        case 55: {
+        case long_option_idx_base + 55: {
           cb::TensorFormat output_tensor_format{ParseTensorFormat(optarg)};
           if (output_tensor_format == cb::TensorFormat::UNKNOWN) {
             Usage(
@@ -1535,11 +1554,11 @@ CLParser::ParseCommandLine(int argc, char** argv)
           params_->output_tensor_format = output_tensor_format;
           break;
         }
-        case 56: {
+        case long_option_idx_base + 56: {
           PrintVersion();
           break;
         }
-        case 57: {
+        case long_option_idx_base + 57: {
           std::string profile_export_file{optarg};
           if (IsFile(profile_export_file) || IsDirectory(profile_export_file)) {
             Usage(
@@ -1549,7 +1568,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           params_->profile_export_file = profile_export_file;
           break;
         }
-        case 58: {
+        case long_option_idx_base + 58: {
           params_->is_using_periodic_concurrency_mode = true;
           std::string arg = optarg;
           std::vector<std::string> values{SplitString(arg)};
@@ -1590,7 +1609,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 59: {
+        case long_option_idx_base + 59: {
           std::string request_period{optarg};
           if (std::stoi(request_period) > 0) {
             params_->request_period = std::stoull(request_period);
@@ -1599,7 +1618,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           }
           break;
         }
-        case 60: {
+        case long_option_idx_base + 60: {
           std::string arg = optarg;
           std::vector<std::string> values{SplitString(arg)};
           if (values.size() != 3) {
@@ -1620,15 +1639,24 @@ CLParser::ParseCommandLine(int argc, char** argv)
           params_->request_parameters[name] = param;
           break;
         }
-        case 61: {
+        case long_option_idx_base + 61: {
           params_->endpoint = optarg;
           break;
         }
-        case 62: {
+        case long_option_idx_base + 62: {
           if (std::stoi(optarg) < 0) {
             Usage("Failed to parse --request-count. The value must be > 0.");
           }
           params_->request_count = std::stoi(optarg);
+          break;
+        }
+        case long_option_idx_base + 63: {
+          if (std::stoi(optarg) < 0) {
+            Usage(
+                "Failed to parse --warmup-request-count. The value must be >= "
+                "0.");
+          }
+          params_->warmup_request_count = std::stoi(optarg);
           break;
         }
         case 'v':
@@ -1688,13 +1716,14 @@ CLParser::ParseCommandLine(int argc, char** argv)
       }
     }
     catch (const std::invalid_argument& ia) {
-      if (opt >= 'A') {  // short options
+      if (opt < long_option_idx_base) {  // short options
         Usage(
             "Failed to parse -" + std::string{(char)opt} +
             ". Invalid value provided: " + std::string{optarg});
       } else {
         Usage(
-            "Failed to parse --" + std::string{long_options[opt].name} +
+            "Failed to parse --" +
+            std::string{long_options[opt - long_option_idx_base].name} +
             ". Invalid value provided: " + std::string{optarg});
       }
     }

--- a/src/command_line_parser.h
+++ b/src/command_line_parser.h
@@ -156,6 +156,7 @@ struct PerfAnalyzerParameters {
   bool is_using_periodic_concurrency_mode{false};
   Range<uint64_t> periodic_concurrency_range{1, 1, 1};
   uint64_t request_period{10};
+  size_t warmup_request_count{0};
 };
 
 using PAParamsPtr = std::shared_ptr<PerfAnalyzerParameters>;

--- a/src/concurrency_manager.cc
+++ b/src/concurrency_manager.cc
@@ -83,6 +83,16 @@ ConcurrencyManager::InitManagerFinalize()
 }
 
 cb::Error
+ConcurrencyManager::PerformWarmup(
+    size_t concurrent_request_count, size_t warmup_request_count)
+{
+  RETURN_IF_ERROR(
+      ChangeConcurrencyLevel(concurrent_request_count, warmup_request_count));
+  WaitForWarmupAndCleanup();
+  return cb::Error::Success;
+}
+
+cb::Error
 ConcurrencyManager::ChangeConcurrencyLevel(
     const size_t concurrent_request_count, const size_t request_count)
 {

--- a/src/concurrency_manager.cc
+++ b/src/concurrency_manager.cc
@@ -86,6 +86,9 @@ cb::Error
 ConcurrencyManager::PerformWarmup(
     size_t concurrent_request_count, size_t warmup_request_count)
 {
+  if (warmup_request_count == 0) {
+    return cb::Error::Success;
+  }
   RETURN_IF_ERROR(
       ChangeConcurrencyLevel(concurrent_request_count, warmup_request_count));
   WaitForWarmupAndCleanup();

--- a/src/concurrency_manager.h
+++ b/src/concurrency_manager.h
@@ -86,6 +86,13 @@ class ConcurrencyManager : public LoadManager {
       const std::unordered_map<std::string, cb::RequestParameter>&
           request_parameters);
 
+  /// Performs warmup for benchmarking by sending a fixed number of requests
+  /// according to the specified concurrency
+  /// \param concurent_request_count The number of concurrent requests.
+  /// \param warmup_request_count The number of warmup requests to send.
+  cb::Error PerformWarmup(
+      size_t concurrent_request_count, size_t warmup_request_count);
+
   /// Adjusts the number of concurrent requests to be the same as
   /// 'concurrent_request_count' (by creating or pausing threads)
   /// \param concurent_request_count The number of concurrent requests.
@@ -115,8 +122,6 @@ class ConcurrencyManager : public LoadManager {
   bool execute_;
 
   size_t max_concurrency_;
-
-  std::vector<std::shared_ptr<ThreadConfig>> threads_config_;
 
  private:
   void InitManagerFinalize() override;

--- a/src/custom_load_manager.cc
+++ b/src/custom_load_manager.cc
@@ -78,7 +78,10 @@ CustomLoadManager::CustomLoadManager(
 cb::Error
 CustomLoadManager::PerformWarmup(size_t warmup_request_count)
 {
-  InitCustomIntervals(warmup_request_count);
+  if (warmup_request_count == 0) {
+    return cb::Error::Success;
+  }
+  RETURN_IF_ERROR(InitCustomIntervals(warmup_request_count));
   WaitForWarmupAndCleanup();
   return cb::Error::Success;
 }

--- a/src/custom_load_manager.cc
+++ b/src/custom_load_manager.cc
@@ -76,6 +76,14 @@ CustomLoadManager::CustomLoadManager(
 }
 
 cb::Error
+CustomLoadManager::PerformWarmup(size_t warmup_request_count)
+{
+  InitCustomIntervals(warmup_request_count);
+  WaitForWarmupAndCleanup();
+  return cb::Error::Success;
+}
+
+cb::Error
 CustomLoadManager::InitCustomIntervals(const size_t request_count)
 {
   PauseWorkers();
@@ -173,6 +181,13 @@ CustomLoadManager::ReadTimeIntervalsFile(
     return cb::Error("file '" + path + "' is empty", pa::GENERIC_ERROR);
   }
   return cb::Error::Success;
+}
+
+void
+CustomLoadManager::WaitForWarmupAndCleanup()
+{
+  RequestRateManager::WaitForWarmupAndCleanup();
+  custom_intervals_.clear();
 }
 
 }}  // namespace triton::perfanalyzer

--- a/src/custom_load_manager.h
+++ b/src/custom_load_manager.h
@@ -86,6 +86,11 @@ class CustomLoadManager : public RequestRateManager {
       const std::unordered_map<std::string, cb::RequestParameter>&
           request_parameter);
 
+  /// Performs warmup for benchmarking by sending a fixed number of requests
+  /// according to the prespecified custom intervals
+  /// \param warmup_request_count The number of warmup requests to send.
+  cb::Error PerformWarmup(size_t warmup_request_count);
+
   /// Initializes the load manager with the provided file containing request
   /// intervals
   /// \param request_count The number of requests to generate. If 0, then
@@ -122,6 +127,9 @@ class CustomLoadManager : public RequestRateManager {
   /// \return cb::Error object indicating success or failure.
   virtual cb::Error ReadTimeIntervalsFile(
       const std::string& path, NanoIntervals* contents);
+
+  /// Waits for worker threads to complete then reset data members after warmup
+  void WaitForWarmupAndCleanup() override;
 
   std::string request_intervals_file_;
   NanoIntervals custom_intervals_;

--- a/src/load_manager.cc
+++ b/src/load_manager.cc
@@ -213,8 +213,6 @@ LoadManager::InitManagerInputs(
     const size_t string_length, const std::string& string_data,
     const bool zero_input, std::vector<std::string>& user_data)
 {
-  RETURN_IF_ERROR(factory_->CreateClientBackend(&backend_));
-
   // Read provided data
   if (!user_data.empty()) {
     if (IsDirectory(user_data[0])) {
@@ -270,6 +268,20 @@ LoadManager::StopWorkerThreads()
     cnt++;
   }
   threads_.clear();
+}
+
+void
+LoadManager::WaitForWarmupAndCleanup()
+{
+  for (std::thread& thread : threads_) {
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+  threads_.clear();
+  threads_config_.clear();
+  threads_stat_.clear();
+  workers_.clear();
 }
 
 std::shared_ptr<SequenceManager>

--- a/src/load_manager.h
+++ b/src/load_manager.h
@@ -134,6 +134,9 @@ class LoadManager {
   /// Stops all the worker threads generating the request load.
   void StopWorkerThreads();
 
+  /// Waits for worker threads to complete then reset data members after warmup
+  virtual void WaitForWarmupAndCleanup();
+
  protected:
   bool async_;
   bool streaming_;
@@ -147,7 +150,6 @@ class LoadManager {
   bool using_json_data_;
 
   std::shared_ptr<DataLoader> data_loader_;
-  std::unique_ptr<cb::ClientBackend> backend_;
   std::shared_ptr<IInferDataManager> infer_data_manager_;
 
   // Track the workers so they all go out of scope at the
@@ -158,6 +160,8 @@ class LoadManager {
   std::vector<std::thread> threads_;
   // Contains the statistics on the current working threads
   std::vector<std::shared_ptr<ThreadStat>> threads_stat_;
+  // Contains the configs for the current working threads
+  std::vector<std::shared_ptr<ThreadConfig>> threads_config_;
 
   // Use condition variable to pause/continue worker threads
   std::condition_variable wake_signal_;

--- a/src/perf_analyzer.cc
+++ b/src/perf_analyzer.cc
@@ -306,9 +306,15 @@ PerfAnalyzer::PrerunReport()
   std::cout << "  Service Kind: " << BackendKindToString(params_->kind)
             << std::endl;
 
+  if (params_->warmup_request_count > 0) {
+    std::cout << "  Sending " << params_->warmup_request_count
+              << " warmup request"
+              << (params_->warmup_request_count > 1 ? "s" : "") << std::endl;
+  }
+
   if (params_->request_count != 0) {
-    std::cout << "  Sending a total of " << params_->request_count
-              << " requests" << std::endl;
+    std::cout << "  Sending " << params_->request_count << " benchmark request"
+              << (params_->request_count > 1 ? "s" : "") << std::endl;
   } else {
     if (params_->measurement_mode == pa::MeasurementMode::COUNT_WINDOWS) {
       std::cout << "  Using \"count_windows\" mode for stabilization"
@@ -399,7 +405,7 @@ PerfAnalyzer::Profile()
     err = profiler_->Profile<size_t>(
         params_->concurrency_range.start, params_->concurrency_range.end,
         params_->concurrency_range.step, params_->search_mode,
-        params_->request_count, perf_statuses_);
+        params_->warmup_request_count, params_->request_count, perf_statuses_);
   } else if (params_->is_using_periodic_concurrency_mode) {
     err = profiler_->ProfilePeriodicConcurrencyMode();
   } else {
@@ -407,7 +413,8 @@ PerfAnalyzer::Profile()
         params_->request_rate_range[pa::SEARCH_RANGE::kSTART],
         params_->request_rate_range[pa::SEARCH_RANGE::kEND],
         params_->request_rate_range[pa::SEARCH_RANGE::kSTEP],
-        params_->search_mode, params_->request_count, perf_statuses_);
+        params_->search_mode, params_->warmup_request_count,
+        params_->request_count, perf_statuses_);
   }
 
   params_->mpi_driver->MPIBarrierWorld();

--- a/src/request_rate_manager.cc
+++ b/src/request_rate_manager.cc
@@ -89,6 +89,15 @@ RequestRateManager::InitManagerFinalize()
 }
 
 cb::Error
+RequestRateManager::PerformWarmup(
+    double request_rate, size_t warmup_request_count)
+{
+  ChangeRequestRate(request_rate, warmup_request_count);
+  WaitForWarmupAndCleanup();
+  return cb::Error::Success;
+}
+
+cb::Error
 RequestRateManager::ChangeRequestRate(
     const double request_rate, const size_t request_count)
 {

--- a/src/request_rate_manager.cc
+++ b/src/request_rate_manager.cc
@@ -92,7 +92,10 @@ cb::Error
 RequestRateManager::PerformWarmup(
     double request_rate, size_t warmup_request_count)
 {
-  ChangeRequestRate(request_rate, warmup_request_count);
+  if (warmup_request_count == 0) {
+    return cb::Error::Success;
+  }
+  RETURN_IF_ERROR(ChangeRequestRate(request_rate, warmup_request_count));
   WaitForWarmupAndCleanup();
   return cb::Error::Success;
 }

--- a/src/request_rate_manager.h
+++ b/src/request_rate_manager.h
@@ -98,6 +98,14 @@ class RequestRateManager : public LoadManager {
       const std::unordered_map<std::string, cb::RequestParameter>&
           request_parameters);
 
+  /// Performs warmup for benchmarking by sending a fixed number of requests
+  /// according to the specified request rate
+  /// \param target_request_rate The rate at which requests must be issued to
+  /// the server.
+  /// \param warmup_request_count The number of warmup requests to send.
+  cb::Error PerformWarmup(
+      double target_request_rate, size_t warmup_request_count);
+
   /// Adjusts the rate of issuing requests to be the same as 'request_rate'
   /// \param target_request_rate The rate at which requests must be issued to
   /// the server.
@@ -151,8 +159,6 @@ class RequestRateManager : public LoadManager {
       std::shared_ptr<ThreadStat>, std::shared_ptr<ThreadConfig>);
 
   size_t DetermineNumThreads();
-
-  std::vector<std::shared_ptr<ThreadConfig>> threads_config_;
 
   std::shared_ptr<std::chrono::nanoseconds> gen_duration_;
   Distribution request_distribution_;


### PR DESCRIPTION
Example:
```bash
perf_analyzer --warmup-request-count=3 --request-count=2 ...
```

* Allows user to specify fixed number of "warmup" requests that happen before benchmarking
* In concurrency mode, warmup requests get sent at specified concurrency
  * Only `N` total warmup requests get sent via `--warmup-request-count=N`, regardless of concurrency
* In request rate mode, warmup requests get sent at specified request rate
* In custom intervals mode, warmup requests get sent at specified custom intervals
* `--warmup-request-count` works independent of `--request-count` mode being used