### PR TITLE
Fix prefix check

### DIFF
--- a/genai-perf/genai_perf/utils.py
+++ b/genai-perf/genai_perf/utils.py
@@ -56,7 +56,7 @@ def encode_image(img: Image, format: str):
 
 
 def remove_sse_prefix(msg: str) -> str:
-    prefix = "data: "
+    prefix = "data:"
     if msg.startswith(prefix):
         return msg[len(prefix) :].strip()
     return msg.strip()


### PR DESCRIPTION
A small fix for parsing messages coming back in SSE events.
Previously, we looked for "data: " with a space. However, not all protocols hold to that standard. Instead we now look for "data:" without a space and call ".strip()" to handle the cases with white space. This should better generalize to more response formats.