### PR TITLE
Refactor non-chat LLM endpoint converters into template style design

### DIFF
--- a/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
@@ -58,15 +58,11 @@ class OpenAICompletionsConverter(BaseConverter):
             prompt = self._construct_text_payload(entry)
 
             payload = {
-                "payload": [
-                    {
-                        "model": model_name,
-                        "prompt": prompt,
-                    }
-                ]
+                "model": model_name,
+                "prompt": prompt,
             }
             self._add_request_params(payload, config)
-            request_body["data"].append(payload)
+            request_body["data"].append({"payload": [payload]})
 
         return request_body
 

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
@@ -25,114 +25,56 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import random
-from copy import deepcopy
-from typing import Dict, List
+from typing import Any, Dict
 
 from genai_perf.inputs.converters.base_converter import BaseConverter
 from genai_perf.inputs.input_constants import (
     DEFAULT_OUTPUT_TOKENS_MEAN,
     DEFAULT_TENSORRTLLM_MAX_TOKENS,
-    EMPTY_JSON_IN_TENSORRTLLM_PA_FORMAT,
 )
 from genai_perf.inputs.inputs_config import InputsConfig
 
 
 class TensorRTLLMConverter(BaseConverter):
-    def convert(
-        self,
-        generic_dataset: Dict,
-        config: InputsConfig,
-    ) -> Dict:
-        (
-            system_role_headers,
-            user_role_headers,
-            text_input_headers,
-        ) = self._determine_json_feature_roles(generic_dataset)
 
-        pa_json = self._populate_trtllm_output_json(
-            generic_dataset,
-            system_role_headers,
-            user_role_headers,
-            text_input_headers,
-            config,
-        )
+    _CONTENT_NAMES = [
+        "text_input",
+        # OPENORCA
+        "system_prompt",
+        "question",
+        # CNN DAILYMAIL
+        "article",
+    ]
 
-        return pa_json
-
-    def _populate_trtllm_output_json(
-        self,
-        generic_dataset: Dict,
-        system_role_headers: List[str],
-        user_role_headers: List[str],
-        text_input_headers: List[str],
-        config,
-    ) -> Dict:
-        pa_json = deepcopy(EMPTY_JSON_IN_TENSORRTLLM_PA_FORMAT)
-        default_max_tokens = (
-            "max_tokens" not in config.extra_inputs
-            or config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN
-        )
+    def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
+        """
+        Construct a request body using the endpoint specific request format.
+        """
+        request_body: Dict[str, Any] = {"data": []}
 
         for index, entry in enumerate(generic_dataset["rows"]):
-            iter_model_name = self._select_model_name(config, index)
-            pa_json["data"].append({"text_input": [""]})
+            model_name = self._select_model_name(config, index)
+            text_input = self._construct_text_payload(entry)
 
-            for header, content in entry.items():
-                new_text_input = self._create_new_text_input(
-                    header,
-                    system_role_headers,
-                    user_role_headers,
-                    text_input_headers,
-                    content,
-                )
+            payload = {
+                "model": model_name,
+                "text_input": text_input,
+                "max_tokens": [DEFAULT_TENSORRTLLM_MAX_TOKENS],  # default
+            }
+            self._add_request_params(payload, config)
+            request_body["data"].append(payload)
 
-                pa_json = self._add_new_text_input_to_json(
-                    pa_json, index, new_text_input
-                )
+        return request_body
 
-            pa_json = self._add_required_tags_to_trtllm_json(
-                pa_json, index, default_max_tokens
-            )
-            pa_json = self._add_optional_tags_to_trtllm_json(
-                pa_json,
-                index,
-                config,
-                iter_model_name,
-            )
-
-        return pa_json
-
-    def _add_required_tags_to_trtllm_json(
-        self,
-        pa_json: Dict,
-        index: int,
-        default_max_tokens: bool,
-    ) -> Dict:
-        row = pa_json["data"][index]
-        if default_max_tokens:
-            row["max_tokens"] = [DEFAULT_TENSORRTLLM_MAX_TOKENS]
-
-        return pa_json
-
-    def _add_optional_tags_to_trtllm_json(
-        self,
-        pa_json: Dict,
-        index: int,
-        config,
-        model_name: str = "",
-    ) -> Dict:
-        row = pa_json["data"][index]
-        row["model"] = model_name
+    def _add_request_params(self, payload: Dict, config: InputsConfig) -> None:
         if config.add_stream:
-            row["stream"] = [True]
+            payload["stream"] = [True]
         if config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN:
             number_of_tokens = int(
                 random.gauss(config.output_tokens_mean, config.output_tokens_stddev)
             )
             if config.output_tokens_deterministic:
-                row["min_length"] = [number_of_tokens]
-            row["max_tokens"] = [number_of_tokens]
+                payload["min_length"] = [number_of_tokens]
+            payload["max_tokens"] = [number_of_tokens]
         for key, value in config.extra_inputs.items():
-            row[key] = [value]
-
-        return pa_json
+            payload[key] = [value]

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
@@ -25,14 +25,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import random
-from copy import deepcopy
-from typing import Dict
+from typing import Any, Dict
 
 from genai_perf.inputs.converters.base_converter import BaseConverter
 from genai_perf.inputs.input_constants import (
     DEFAULT_OUTPUT_TOKENS_MEAN,
     DEFAULT_TENSORRTLLM_MAX_TOKENS,
-    EMPTY_JSON_IN_TENSORRTLLM_PA_FORMAT,
 )
 from genai_perf.inputs.inputs_config import InputsConfig
 
@@ -43,7 +41,7 @@ class TensorRTLLMEngineConverter(BaseConverter):
         generic_dataset: Dict,
         config: InputsConfig,
     ) -> Dict:
-        pa_json = deepcopy(EMPTY_JSON_IN_TENSORRTLLM_PA_FORMAT)
+        pa_json: Dict[str, Any] = {"data": []}
 
         for index, entry in enumerate(generic_dataset["rows"]):
             token_ids = config.tokenizer.encode(entry["text_input"])

--- a/genai-perf/genai_perf/inputs/converters/vllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/vllm_converter.py
@@ -26,7 +26,7 @@
 
 import json
 import random
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from genai_perf.inputs.converters.base_converter import BaseConverter
 from genai_perf.inputs.input_constants import DEFAULT_OUTPUT_TOKENS_MEAN

--- a/genai-perf/genai_perf/inputs/converters/vllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/vllm_converter.py
@@ -26,86 +26,47 @@
 
 import json
 import random
-from copy import deepcopy
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from genai_perf.inputs.converters.base_converter import BaseConverter
-from genai_perf.inputs.input_constants import (
-    DEFAULT_OUTPUT_TOKENS_MEAN,
-    EMPTY_JSON_IN_VLLM_PA_FORMAT,
-)
+from genai_perf.inputs.input_constants import DEFAULT_OUTPUT_TOKENS_MEAN
 from genai_perf.inputs.inputs_config import InputsConfig
 
 
 class VLLMConverter(BaseConverter):
-    def convert(
-        self,
-        generic_dataset: Dict,
-        config: InputsConfig,
-    ) -> Dict:
-        (
-            system_role_headers,
-            user_role_headers,
-            text_input_headers,
-        ) = self._determine_json_feature_roles(generic_dataset)
 
-        pa_json = self._populate_vllm_output_json(
-            generic_dataset,
-            system_role_headers,
-            user_role_headers,
-            text_input_headers,
-            config,
-        )
+    _CONTENT_NAMES = [
+        "text_input",
+        # OPENORCA
+        "system_prompt",
+        "question",
+        # CNN DAILYMAIL
+        "article",
+    ]
 
-        return pa_json
-
-    def _populate_vllm_output_json(
-        self,
-        generic_dataset: Dict,
-        system_role_headers: List[str],
-        user_role_headers: List[str],
-        text_input_headers: List[str],
-        config: InputsConfig,
-    ) -> Dict:
-        pa_json = deepcopy(EMPTY_JSON_IN_VLLM_PA_FORMAT)
+    def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
+        """
+        Construct a request body using the endpoint specific request format.
+        """
+        request_body: Dict[str, Any] = {"data": []}
 
         for index, entry in enumerate(generic_dataset["rows"]):
-            iter_model_name = self._select_model_name(config, index)
-            pa_json["data"].append({"text_input": [""]})
+            model_name = self._select_model_name(config, index)
+            text_input = self._construct_text_payload(entry)
 
-            for header, content in entry.items():
-                new_text_input = self._create_new_text_input(
-                    header,
-                    system_role_headers,
-                    user_role_headers,
-                    text_input_headers,
-                    content,
-                )
+            payload = {
+                "model": model_name,
+                "text_input": text_input,
+                "exclude_input_in_output": [True],  # default
+            }
+            self._add_request_params(payload, config)
+            request_body["data"].append(payload)
 
-                pa_json = self._add_new_text_input_to_json(
-                    pa_json, index, new_text_input
-                )
+        return request_body
 
-            pa_json = self._add_optional_tags_to_vllm_json(
-                pa_json,
-                index,
-                config,
-                iter_model_name,
-            )
-
-        return pa_json
-
-    def _add_optional_tags_to_vllm_json(
-        self,
-        pa_json: Dict,
-        index: int,
-        config: InputsConfig,
-        model_name: str = "",
-    ) -> Dict:
-        row = pa_json["data"][index]
-        row["model"] = model_name
+    def _add_request_params(self, payload: Dict, config: InputsConfig) -> None:
         if config.add_stream:
-            row["stream"] = [True]
+            payload["stream"] = [True]
         if config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN:
             number_of_tokens = str(
                 int(
@@ -124,10 +85,6 @@ class VLLMConverter(BaseConverter):
             if config.output_tokens_deterministic:
                 sampling_parameters["min_tokens"] = number_of_tokens
             sampling_parameters_str = json.dumps(sampling_parameters)
-            row["sampling_parameters"] = [sampling_parameters_str]
+            payload["sampling_parameters"] = [sampling_parameters_str]
         for key, value in config.extra_inputs.items():
-            row[key] = [value]
-        if "exclude_input_in_output" not in row:
-            row["exclude_input_in_output"] = [True]
-
-        return pa_json
+            payload[key] = [value]

--- a/genai-perf/genai_perf/inputs/input_constants.py
+++ b/genai-perf/genai_perf/inputs/input_constants.py
@@ -92,10 +92,3 @@ DEFAULT_IMAGE_WIDTH_MEAN = 100
 DEFAULT_IMAGE_WIDTH_STDDEV = 0
 DEFAULT_IMAGE_HEIGHT_MEAN = 100
 DEFAULT_IMAGE_HEIGHT_STDDEV = 0
-
-###########################
-# Default JSON Parameters
-###########################
-EMPTY_JSON_IN_VLLM_PA_FORMAT: Dict = {"data": []}
-EMPTY_JSON_IN_TENSORRTLLM_PA_FORMAT: Dict = {"data": []}
-EMPTY_JSON_IN_OPENAI_PA_FORMAT: Dict = {"data": []}

--- a/genai-perf/tests/test_openai_completions_converter.py
+++ b/genai-perf/tests/test_openai_completions_converter.py
@@ -1,0 +1,129 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from genai_perf.inputs.converters import OpenAICompletionsConverter
+from genai_perf.inputs.input_constants import ModelSelectionStrategy, OutputFormat
+from genai_perf.inputs.inputs_config import InputsConfig
+
+
+class TestOpenAICompletionsConverter:
+
+    def test_convert_default(self):
+        generic_dataset = {
+            "rows": [
+                {"text_input": "text input one"},
+                {"text_input": "text input two"},
+            ]
+        }
+
+        config = InputsConfig(
+            extra_inputs={},  # no extra inputs
+            model_name=["test_model"],
+            model_selection_strategy=ModelSelectionStrategy.ROUND_ROBIN,
+            output_format=OutputFormat.OPENAI_COMPLETIONS,
+        )
+
+        completions_converter = OpenAICompletionsConverter()
+        result = completions_converter.convert(generic_dataset, config)
+
+        expected_result = {
+            "data": [
+                {
+                    "payload": [
+                        {
+                            "prompt": "text input one",
+                            "model": "test_model",
+                        }
+                    ]
+                },
+                {
+                    "payload": [
+                        {
+                            "prompt": "text input two",
+                            "model": "test_model",
+                        }
+                    ]
+                },
+            ]
+        }
+
+        assert result == expected_result
+
+    def test_convert_with_request_parameters(self):
+        generic_dataset = {
+            "rows": [
+                {"text_input": "text input one"},
+                {"text_input": "text input two"},
+            ]
+        }
+
+        extra_inputs = {
+            "ignore_eos": True,
+            "max_tokens": 1234,
+            "additional_key": "additional_value",
+        }
+
+        config = InputsConfig(
+            extra_inputs=extra_inputs,
+            model_name=["test_model"],
+            model_selection_strategy=ModelSelectionStrategy.ROUND_ROBIN,
+            output_format=OutputFormat.OPENAI_COMPLETIONS,
+            add_stream=True,  # set streaming
+        )
+
+        completions_converter = OpenAICompletionsConverter()
+        result = completions_converter.convert(generic_dataset, config)
+
+        expected_result = {
+            "data": [
+                {
+                    "payload": [
+                        {
+                            "prompt": "text input one",
+                            "model": "test_model",
+                            "stream": True,
+                            "ignore_eos": True,
+                            "max_tokens": 1234,
+                            "additional_key": "additional_value",
+                        }
+                    ]
+                },
+                {
+                    "payload": [
+                        {
+                            "prompt": "text input two",
+                            "model": "test_model",
+                            "stream": True,
+                            "ignore_eos": True,
+                            "max_tokens": 1234,
+                            "additional_key": "additional_value",
+                        }
+                    ]
+                },
+            ]
+        }
+
+        assert result == expected_result

--- a/genai-perf/tests/test_triton_tensorrtllm_converter.py
+++ b/genai-perf/tests/test_triton_tensorrtllm_converter.py
@@ -1,0 +1,120 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from genai_perf.inputs.converters import TensorRTLLMConverter
+from genai_perf.inputs.input_constants import (
+    DEFAULT_TENSORRTLLM_MAX_TOKENS,
+    ModelSelectionStrategy,
+    OutputFormat,
+    PromptSource,
+)
+from genai_perf.inputs.inputs_config import InputsConfig
+
+
+class TestTensorRTLLMConverter:
+
+    def test_convert_default(self):
+        generic_dataset = {
+            "rows": [
+                {"text_input": "text input one"},
+                {"text_input": "text input two"},
+            ]
+        }
+
+        config = InputsConfig(
+            extra_inputs={},  # no extra inputs
+            model_name=["test_model"],
+            model_selection_strategy=ModelSelectionStrategy.ROUND_ROBIN,
+            output_format=OutputFormat.TENSORRTLLM,
+        )
+
+        trtllm_converter = TensorRTLLMConverter()
+        result = trtllm_converter.convert(generic_dataset, config)
+
+        expected_result = {
+            "data": [
+                {
+                    "model": "test_model",
+                    "text_input": "text input one",
+                    "max_tokens": [DEFAULT_TENSORRTLLM_MAX_TOKENS],
+                },
+                {
+                    "model": "test_model",
+                    "text_input": "text input two",
+                    "max_tokens": [DEFAULT_TENSORRTLLM_MAX_TOKENS],
+                },
+            ]
+        }
+
+        assert result == expected_result
+
+    def test_convert_with_request_parameters(self):
+        generic_dataset = {
+            "rows": [
+                {"text_input": "text input one"},
+                {"text_input": "text input two"},
+            ]
+        }
+
+        extra_inputs = {
+            "ignore_eos": True,
+            "max_tokens": 1234,
+            "additional_key": "additional_value",
+        }
+
+        config = InputsConfig(
+            extra_inputs=extra_inputs,
+            model_name=["test_model"],
+            model_selection_strategy=ModelSelectionStrategy.ROUND_ROBIN,
+            output_format=OutputFormat.TENSORRTLLM,
+            add_stream=True,  # set streaming
+        )
+
+        trtllm_converter = TensorRTLLMConverter()
+        result = trtllm_converter.convert(generic_dataset, config)
+
+        expected_result = {
+            "data": [
+                {
+                    "model": "test_model",
+                    "text_input": "text input one",
+                    "ignore_eos": [True],
+                    "max_tokens": [1234],
+                    "stream": [True],
+                    "additional_key": ["additional_value"],
+                },
+                {
+                    "model": "test_model",
+                    "text_input": "text input two",
+                    "ignore_eos": [True],
+                    "max_tokens": [1234],
+                    "stream": [True],
+                    "additional_key": ["additional_value"],
+                },
+            ]
+        }
+
+        assert result == expected_result

--- a/genai-perf/tests/test_triton_tensorrtllm_converter.py
+++ b/genai-perf/tests/test_triton_tensorrtllm_converter.py
@@ -29,7 +29,6 @@ from genai_perf.inputs.input_constants import (
     DEFAULT_TENSORRTLLM_MAX_TOKENS,
     ModelSelectionStrategy,
     OutputFormat,
-    PromptSource,
 )
 from genai_perf.inputs.inputs_config import InputsConfig
 

--- a/genai-perf/tests/test_triton_vllm_converter.py
+++ b/genai-perf/tests/test_triton_vllm_converter.py
@@ -1,0 +1,161 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from genai_perf.inputs.converters import VLLMConverter
+from genai_perf.inputs.input_constants import ModelSelectionStrategy, OutputFormat
+from genai_perf.inputs.inputs_config import InputsConfig
+
+
+class TestVLLMConverter:
+
+    def test_convert_default(self):
+        generic_dataset = {
+            "rows": [
+                {"text_input": "text input one"},
+                {"text_input": "text input two"},
+            ]
+        }
+
+        config = InputsConfig(
+            extra_inputs={},  # no extra inputs
+            model_name=["test_model"],
+            model_selection_strategy=ModelSelectionStrategy.ROUND_ROBIN,
+            output_format=OutputFormat.VLLM,
+        )
+
+        vllm_converter = VLLMConverter()
+        result = vllm_converter.convert(generic_dataset, config)
+
+        expected_result = {
+            "data": [
+                {
+                    "model": "test_model",
+                    "text_input": "text input one",
+                    "exclude_input_in_output": [True],
+                },
+                {
+                    "model": "test_model",
+                    "text_input": "text input two",
+                    "exclude_input_in_output": [True],
+                },
+            ]
+        }
+
+        assert result == expected_result
+
+    def test_convert_with_request_parameters(self):
+        generic_dataset = {
+            "rows": [
+                {"text_input": "text input one"},
+                {"text_input": "text input two"},
+            ]
+        }
+
+        extra_inputs = {
+            "ignore_eos": True,
+            "max_tokens": 1234,
+            "exclude_input_in_output": False,
+            "additional_key": "additional_value",
+        }
+
+        config = InputsConfig(
+            extra_inputs=extra_inputs,
+            model_name=["test_model"],
+            model_selection_strategy=ModelSelectionStrategy.ROUND_ROBIN,
+            output_format=OutputFormat.VLLM,
+            add_stream=True,  # set streaming
+        )
+
+        vllm_converter = VLLMConverter()
+        result = vllm_converter.convert(generic_dataset, config)
+
+        expected_result = {
+            "data": [
+                {
+                    "model": "test_model",
+                    "text_input": "text input one",
+                    "exclude_input_in_output": [False],
+                    "ignore_eos": [True],
+                    "max_tokens": [1234],
+                    "stream": [True],
+                    "additional_key": ["additional_value"],
+                },
+                {
+                    "model": "test_model",
+                    "text_input": "text input two",
+                    "exclude_input_in_output": [False],
+                    "ignore_eos": [True],
+                    "max_tokens": [1234],
+                    "stream": [True],
+                    "additional_key": ["additional_value"],
+                },
+            ]
+        }
+
+        assert result == expected_result
+
+    def test_convert_with_sampling_parameters(self):
+        generic_dataset = {
+            "rows": [
+                {"text_input": "text input one"},
+                {"text_input": "text input two"},
+            ]
+        }
+
+        config = InputsConfig(
+            extra_inputs={},
+            model_name=["test_model"],
+            model_selection_strategy=ModelSelectionStrategy.ROUND_ROBIN,
+            output_format=OutputFormat.VLLM,
+            output_tokens_mean=1234,  # set max output sequence length
+            output_tokens_deterministic=True,  # set min output sequence length
+        )
+
+        vllm_converter = VLLMConverter()
+        result = vllm_converter.convert(generic_dataset, config)
+
+        expected_result = {
+            "data": [
+                {
+                    "model": "test_model",
+                    "text_input": "text input one",
+                    "exclude_input_in_output": [True],
+                    "sampling_parameters": [
+                        '{"max_tokens": "1234", "min_tokens": "1234"}'
+                    ],
+                },
+                {
+                    "model": "test_model",
+                    "text_input": "text input two",
+                    "exclude_input_in_output": [True],
+                    "sampling_parameters": [
+                        '{"max_tokens": "1234", "min_tokens": "1234"}'
+                    ],
+                },
+            ]
+        }
+
+        assert result == expected_result


### PR DESCRIPTION
This PR
- refactors non-chat based LLM endpoint converters into simpler template-style implementation
- removes chat API specific logics (e.g. system/user roles) from non-chat APIs

This PR does _NOT_
- change any behavior of the overall codebase