### PR TITLE
Remove duplicate error handling

### DIFF
--- a/genai-perf/genai_perf/main.py
+++ b/genai-perf/genai_perf/main.py
@@ -185,23 +185,20 @@ def create_plots(args: Namespace) -> None:
 # Separate function that can raise exceptions used for testing
 # to assert correct errors and messages.
 def run():
-    try:
-        # TMA-1900: refactor CLI handler
-        logging.init_logging()
-        args, extra_args = parser.parse_args()
-        config_options = create_config_options(args)
-        if args.subcommand == "compare":
-            args.func(args)
-        else:
-            create_artifacts_dirs(args)
-            tokenizer = get_tokenizer(args.tokenizer)
-            generate_inputs(config_options)
-            telemetry_data_collector = create_telemetry_data_collector(args)
-            args.func(args, extra_args, telemetry_data_collector)
-            data_parser = calculate_metrics(args, tokenizer)
-            report_output(data_parser, telemetry_data_collector, args)
-    except Exception as e:
-        raise GenAIPerfException(e)
+    # TMA-1900: refactor CLI handler
+    logging.init_logging()
+    args, extra_args = parser.parse_args()
+    config_options = create_config_options(args)
+    if args.subcommand == "compare":
+        args.func(args)
+    else:
+        create_artifacts_dirs(args)
+        tokenizer = get_tokenizer(args.tokenizer)
+        generate_inputs(config_options)
+        telemetry_data_collector = create_telemetry_data_collector(args)
+        args.func(args, extra_args, telemetry_data_collector)
+        data_parser = calculate_metrics(args, tokenizer)
+        report_output(data_parser, telemetry_data_collector, args)
 
 
 def main():


### PR DESCRIPTION
Error signals are caught and handled by the entry function `main`, so there's no need to catch and raise another error in the `run` function.

Before:
```
root@nv-ubuntu:/workspace/perf_analyzer# genai-perf profile -m gpt2 --service-kind openai --endpoint-type completions
2024-09-20 23:55 [INFO] genai_perf.parser:83 - Profiling these models: gpt2
2024-09-20 23:55 [INFO] genai_perf.wrapper:160 - Running Perf Analyzer : 'perf_analyzer -m gpt2 --async --input-data artifacts/gpt2-openai-completions-concurrency1/inputs.json -i http --conc
urrency-range 1 --endpoint v1/completions --service-kind openai --measurement-interval 10000 --stability-percentage 999 --profile-export-file artifacts/gpt2-openai-completions-concurrency1/p
rofile_export.json'
Failed to retrieve results from inference request.
Thread [0] had error: OpenAI response returns HTTP code 400


Traceback (most recent call last):
  File "/workspace/perf_analyzer/genai-perf/genai_perf/main.py", line 200, in run
    args.func(args, extra_args, telemetry_data_collector)
  File "/workspace/perf_analyzer/genai-perf/genai_perf/parser.py", line 875, in profile_handler
    Profiler.run(
  File "/workspace/perf_analyzer/genai-perf/genai_perf/wrapper.py", line 164, in run
    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL)
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['perf_analyzer', '-m', 'gpt2', '--async', '--input-data', 'artifacts/gpt2-openai-completions-concurrency1/inputs.json', '-i', 'http', '--concurrency-
range', '1', '--endpoint', 'v1/completions', '--service-kind', 'openai', '--measurement-interval', '10000', '--stability-percentage', '999', '--profile-export-file', 'artifacts/gpt2-openai-c
ompletions-concurrency1/profile_export.json']' returned non-zero exit status 99.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/workspace/perf_analyzer/genai-perf/genai_perf/main.py", line 211, in main
    run()
  File "/workspace/perf_analyzer/genai-perf/genai_perf/main.py", line 204, in run
    raise GenAIPerfException(e)
genai_perf.exceptions.GenAIPerfException: Command '['perf_analyzer', '-m', 'gpt2', '--async', '--input-data', 'artifacts/gpt2-openai-completions-concurrency1/inputs.json', '-i', 'http', '--c
oncurrency-range', '1', '--endpoint', 'v1/completions', '--service-kind', 'openai', '--measurement-interval', '10000', '--stability-percentage', '999', '--profile-export-file', 'artifacts/gp
t2-openai-completions-concurrency1/profile_export.json']' returned non-zero exit status 99.
2024-09-20 23:55 [ERROR] genai_perf.main:215 - Command '['perf_analyzer', '-m', 'gpt2', '--async', '--input-data', 'artifacts/gpt2-openai-completions-concurrency1/inputs.json', '-i', 'http',
 '--concurrency-range', '1', '--endpoint', 'v1/completions', '--service-kind', 'openai', '--measurement-interval', '10000', '--stability-percentage', '999', '--profile-export-file', 'artifac
ts/gpt2-openai-completions-concurrency1/profile_export.json']' returned non-zero exit status 99.
```

After:
```
root@nv-ubuntu:/workspace/perf_analyzer# genai-perf profile -m gpt2 --service-kind openai --endpoint-type completions
2024-09-20 23:54 [INFO] genai_perf.parser:83 - Profiling these models: gpt2
2024-09-20 23:54 [INFO] genai_perf.wrapper:160 - Running Perf Analyzer : 'perf_analyzer -m gpt2 --async --input-data artifacts/gpt2-openai-completions-concurrency1/inputs.json -i http --conc
urrency-range 1 --endpoint v1/completions --service-kind openai --measurement-interval 10000 --stability-percentage 999 --profile-export-file artifacts/gpt2-openai-completions-concurrency1/p
rofile_export.json'
Failed to retrieve results from inference request.
Thread [0] had error: OpenAI response returns HTTP code 400


Traceback (most recent call last):
  File "/workspace/perf_analyzer/genai-perf/genai_perf/main.py", line 208, in main
    run()
  File "/workspace/perf_analyzer/genai-perf/genai_perf/main.py", line 199, in run
    args.func(args, extra_args, telemetry_data_collector)
  File "/workspace/perf_analyzer/genai-perf/genai_perf/parser.py", line 875, in profile_handler
    Profiler.run(
  File "/workspace/perf_analyzer/genai-perf/genai_perf/wrapper.py", line 164, in run
    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL)
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['perf_analyzer', '-m', 'gpt2', '--async', '--input-data', 'artifacts/gpt2-openai-completions-concurrency1/inputs.json', '-i', 'http', '--concurrency-
range', '1', '--endpoint', 'v1/completions', '--service-kind', 'openai', '--measurement-interval', '10000', '--stability-percentage', '999', '--profile-export-file', 'artifacts/gpt2-openai-c
ompletions-concurrency1/profile_export.json']' returned non-zero exit status 99.
2024-09-20 23:54 [ERROR] genai_perf.main:212 - Command '['perf_analyzer', '-m', 'gpt2', '--async', '--input-data', 'artifacts/gpt2-openai-completions-concurrency1/inputs.json', '-i', 'http',
 '--concurrency-range', '1', '--endpoint', 'v1/completions', '--service-kind', 'openai', '--measurement-interval', '10000', '--stability-percentage', '999', '--profile-export-file', 'artifac
ts/gpt2-openai-completions-concurrency1/profile_export.json']' returned non-zero exit status 99.
```
