### PR TITLE
Improve multithreading safety of TritonLoader

### DIFF
--- a/src/client_backend/triton_c_api/triton_loader.cc
+++ b/src/client_backend/triton_c_api/triton_loader.cc
@@ -321,6 +321,7 @@ TritonLoader::StartTriton()
         server_is_ready_fn_(server_.get(), &ready),
         "unable to get server readiness");
     if (live && ready) {
+      std::lock_guard<std::mutex> lock(server_is_ready_mtx_);
       server_is_ready_ = true;
       break;
     }

--- a/src/client_backend/triton_c_api/triton_loader.h
+++ b/src/client_backend/triton_c_api/triton_loader.h
@@ -540,6 +540,7 @@ class TritonLoader : public tc::InferenceServerClient {
   std::unique_ptr<SharedMemoryManager> shm_manager_{nullptr};
   TRITONSERVER_ResponseAllocator* allocator_{};
   std::mutex update_infer_stat_mutex_{};
+  std::mutex server_is_ready_mtx_{};
 };
 
 }}}}  // namespace triton::perfanalyzer::clientbackend::tritoncapi


### PR DESCRIPTION
Small PR that adds locking around the setting of a data member of a shared instance that could be set by multiple threads.