### PR TITLE
Add ability to enable code execution for custom tokenizers

### DIFF
--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -522,16 +522,16 @@ The HuggingFace tokenizer to use to interpret token metrics from prompts and
 responses. The value can be the name of a tokenizer or the filepath of the
 tokenizer. (default: `hf-internal-testing/llama-tokenizer`)
 
+##### `--tokenizer-revision <str>`
+
+The specific tokenizer model version to use. It can be a branch
+name, tag name, or commit ID. (default: `main`)
+
 ##### `--tokenizer-trust-remote-code`
 
 Allow custom tokenizer to be downloaded and executed. This carries security
 risks and should only be used for repositories you trust. This is only
 necessary for custom tokenizers stored in HuggingFace Hub.  (default: `False`)
-
-##### `--tokenizer-revision <str>`
-
-The specific tokenizer model version to use. It can be a branch
-name, tag name, or commit ID. (default: `main`)
 
 ##### `-v`
 ##### `--verbose`

--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -522,6 +522,17 @@ The HuggingFace tokenizer to use to interpret token metrics from prompts and
 responses. The value can be the name of a tokenizer or the filepath of the
 tokenizer. (default: `hf-internal-testing/llama-tokenizer`)
 
+##### `--tokenizer-trust-remote-code`
+
+Allow custom tokenizer to be downloaded and executed. This carries security
+risks and should only be used for repositories you trust. This is only
+necessary for custom tokenizers stored in HuggingFace Hub.  (default: `False`)
+
+##### `--tokenizer-revision <str>`
+
+The specific tokenizer model version to use. It can be a branch
+name, tag name, or commit ID. (default: `main`)
+
 ##### `-v`
 ##### `--verbose`
 

--- a/genai-perf/genai_perf/main.py
+++ b/genai-perf/genai_perf/main.py
@@ -95,7 +95,9 @@ def create_config_options(args: Namespace) -> InputsConfig:
         random_seed=args.random_seed,
         num_prompts=args.num_prompts,
         add_stream=args.streaming,
-        tokenizer=get_tokenizer(args.tokenizer),
+        tokenizer=get_tokenizer(
+            args.tokenizer, args.tokenizer_trust_remote_code, args.tokenizer_revision
+        ),
         extra_inputs=extra_input_dict,
         batch_size=args.batch_size,
         output_dir=args.artifact_dir,
@@ -193,7 +195,13 @@ def run():
         args.func(args)
     else:
         create_artifacts_dirs(args)
-        tokenizer = get_tokenizer(args.tokenizer)
+        tokenizer = (
+            get_tokenizer(
+                args.tokenizer,
+                args.tokenizer_trust_remote_code,
+                args.tokenizer_revision,
+            ),
+        )
         generate_inputs(config_options)
         telemetry_data_collector = create_telemetry_data_collector(args)
         args.func(args, extra_args, telemetry_data_collector)

--- a/genai-perf/genai_perf/main.py
+++ b/genai-perf/genai_perf/main.py
@@ -195,12 +195,10 @@ def run():
         args.func(args)
     else:
         create_artifacts_dirs(args)
-        tokenizer = (
-            get_tokenizer(
-                args.tokenizer,
-                args.tokenizer_trust_remote_code,
-                args.tokenizer_revision,
-            ),
+        tokenizer = get_tokenizer(
+            args.tokenizer,
+            args.tokenizer_trust_remote_code,
+            args.tokenizer_revision,
         )
         generate_inputs(config_options)
         telemetry_data_collector = create_telemetry_data_collector(args)

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -289,6 +289,15 @@ def _is_valid_url(parser: argparse.ArgumentParser, url: str) -> None:
         )
 
 
+def _print_warnings(args: argparse.Namespace) -> None:
+    if args.tokenizer_trust_remote_code:
+        logger.warning(
+            "--tokenizer-trust-remote-code is enabled. "
+            "Custom tokenizer code can be executed. "
+            "This should only be used with repositories you trust."
+        )
+
+
 def _check_server_metrics_url(
     parser: argparse.ArgumentParser, args: argparse.Namespace
 ) -> argparse.Namespace:
@@ -947,6 +956,7 @@ def refine_args(
         args = _check_server_metrics_url(parser, args)
         args = _set_artifact_paths(args)
         args = _check_goodput_args(args)
+        _print_warnings(args)
     elif args.subcommand == Subcommand.COMPARE.to_lowercase():
         args = _check_compare_args(parser, args)
     else:

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -753,6 +753,14 @@ def _add_other_args(parser):
         "or the filepath of the tokenizer.",
     )
     other_group.add_argument(
+        "--tokenizer-revision",
+        type=str,
+        default=DEFAULT_TOKENIZER_REVISION,
+        required=False,
+        help="The specific model version to use. It can be a branch name, "
+        "tag name, or commit ID.",
+    )
+    other_group.add_argument(
         "--tokenizer-trust-remote-code",
         action="store_true",
         required=False,
@@ -760,14 +768,6 @@ def _add_other_args(parser):
         "This carries security risks and should only be used "
         "for repositories you trust. This is only necessary for custom "
         "tokenizers stored in HuggingFace Hub. ",
-    )
-    other_group.add_argument(
-        "--tokenizer-revision",
-        type=str,
-        default=DEFAULT_TOKENIZER_REVISION,
-        required=False,
-        help="The specific model version to use. It can be a branch name, "
-        "tag name, or commit ID.",
     )
 
     other_group.add_argument(

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -41,7 +41,7 @@ from genai_perf.inputs.synthetic_image_generator import ImageFormat
 from genai_perf.plots.plot_config_parser import PlotConfigParser
 from genai_perf.plots.plot_manager import PlotManager
 from genai_perf.telemetry_data import TelemetryDataCollector
-from genai_perf.tokenizer import DEFAULT_TOKENIZER
+from genai_perf.tokenizer import DEFAULT_TOKENIZER, DEFAULT_TOKENIZER_REVISION
 
 from . import __version__
 
@@ -732,9 +732,10 @@ def _add_output_args(parser):
         type=Path,
         default=Path("profile_export.json"),
         help="The path where the perf_analyzer profile export will be "
-        "generated. By default, the profile export will be to profile_export.json. "
-        "The genai-perf file will be exported to <profile_export_file>_genai_perf.csv. "
-        "For example, if the profile export file is profile_export.json, the genai-perf file will be "
+        "generated. By default, the profile export will be to "
+        "profile_export.json. The genai-perf file will be exported to "
+        "<profile_export_file>_genai_perf.csv. For example, if the profile "
+        "export file is profile_export.json, the genai-perf file will be "
         "exported to profile_export_genai_perf.csv.",
     )
 
@@ -747,8 +748,26 @@ def _add_other_args(parser):
         type=str,
         default=DEFAULT_TOKENIZER,
         required=False,
-        help="The HuggingFace tokenizer to use to interpret token metrics from prompts and responses. "
-        " The value can be the name of a tokenizer or the filepath of the tokenizer.",
+        help="The HuggingFace tokenizer to use to interpret token metrics "
+        "from prompts and responses. The value can be the name of a tokenizer "
+        "or the filepath of the tokenizer.",
+    )
+    other_group.add_argument(
+        "--tokenizer-trust-remote-code",
+        action="store_true",
+        required=False,
+        help="Allow custom tokenizer to be downloaded and executed. "
+        "This carries security risks and should only be used "
+        "for repositories you trust. This is only necessary for custom "
+        "tokenizers stored in HuggingFace Hub. ",
+    )
+    other_group.add_argument(
+        "--tokenizer-revision",
+        type=str,
+        default=DEFAULT_TOKENIZER_REVISION,
+        required=False,
+        help="The specific model version to use. It can be a branch name, "
+        "tag name, or commit ID.",
     )
 
     other_group.add_argument(

--- a/genai-perf/genai_perf/tokenizer.py
+++ b/genai-perf/genai_perf/tokenizer.py
@@ -36,7 +36,7 @@ class Tokenizer:
     A small wrapper class around Huggingface Tokenizer
     """
 
-    def __init__(self, name: str, trust_model_code: bool, revision: str) -> None:
+    def __init__(self, name: str, trust_remote_code: bool, revision: str) -> None:
         """
         Initialize by downloading the tokenizer from Huggingface.co
         """
@@ -46,7 +46,7 @@ class Tokenizer:
                 io.StringIO()
             ) as stdout, contextlib.redirect_stderr(io.StringIO()) as stderr:
                 tokenizer = AutoTokenizer.from_pretrained(
-                    name, trust_remote_code=False, revision="main"
+                    name, trust_remote_code=trust_remote_code, revision=revision
                 )
         except Exception as e:
             raise GenAIPerfException(e)
@@ -76,10 +76,10 @@ class Tokenizer:
 
 def get_tokenizer(
     tokenizer_model: str,
-    trust_model_code: bool = False,
+    trust_remote_code: bool = False,
     tokenizer_revision: str = DEFAULT_TOKENIZER_REVISION,
 ) -> Tokenizer:
     """
     Return tokenizer for the given model name
     """
-    return Tokenizer(tokenizer_model, trust_model_code, tokenizer_revision)
+    return Tokenizer(tokenizer_model, trust_remote_code, tokenizer_revision)

--- a/genai-perf/genai_perf/tokenizer.py
+++ b/genai-perf/genai_perf/tokenizer.py
@@ -45,7 +45,6 @@ class Tokenizer:
             with contextlib.redirect_stdout(
                 io.StringIO()
             ) as stdout, contextlib.redirect_stderr(io.StringIO()) as stderr:
-                ## TODO: Set trust_remote_code and revision
                 tokenizer = AutoTokenizer.from_pretrained(
                     name, trust_remote_code=False, revision="main"
                 )

--- a/genai-perf/genai_perf/tokenizer.py
+++ b/genai-perf/genai_perf/tokenizer.py
@@ -28,6 +28,7 @@ with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_st
     token_logger.set_verbosity_error()
 
 DEFAULT_TOKENIZER = "hf-internal-testing/llama-tokenizer"
+DEFAULT_TOKENIZER_REVISION = "main"
 
 
 class Tokenizer:
@@ -35,7 +36,7 @@ class Tokenizer:
     A small wrapper class around Huggingface Tokenizer
     """
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, trust_model_code: bool, revision: str) -> None:
         """
         Initialize by downloading the tokenizer from Huggingface.co
         """
@@ -44,7 +45,10 @@ class Tokenizer:
             with contextlib.redirect_stdout(
                 io.StringIO()
             ) as stdout, contextlib.redirect_stderr(io.StringIO()) as stderr:
-                tokenizer = AutoTokenizer.from_pretrained(name)
+                ## TODO: Set trust_remote_code and revision
+                tokenizer = AutoTokenizer.from_pretrained(
+                    name, trust_remote_code=False, revision="main"
+                )
         except Exception as e:
             raise GenAIPerfException(e)
 
@@ -71,8 +75,12 @@ class Tokenizer:
         return self._tokenizer.__repr__()
 
 
-def get_tokenizer(tokenizer_model: str) -> Tokenizer:
+def get_tokenizer(
+    tokenizer_model: str,
+    trust_model_code: bool = False,
+    tokenizer_revision: str = DEFAULT_TOKENIZER_REVISION,
+) -> Tokenizer:
     """
     Return tokenizer for the given model name
     """
-    return Tokenizer(tokenizer_model)
+    return Tokenizer(tokenizer_model, trust_model_code, tokenizer_revision)

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -104,6 +104,8 @@ class Profiler:
             "synthetic_input_tokens_mean",
             "synthetic_input_tokens_stddev",
             "tokenizer",
+            "tokenizer_trust_remote_code",
+            "tokenizer_revision",
         ]
 
         utils.remove_file(args.profile_export_file)

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -241,6 +241,8 @@ class TestCLIArguments:
                 {"image_height_stddev": 456},
             ),
             (["--image-format", "png"], {"image_format": ImageFormat.PNG}),
+            (["--tokenizer-trust-remote-code"], {"tokenizer_trust_remote_code": True}),
+            (["--tokenizer-revision", "not_main"], {"tokenizer_revision": "not_main"}),
             (["-v"], {"verbose": True}),
             (["--verbose"], {"verbose": True}),
             (["-u", "test_url"], {"u": "test_url"}),

--- a/genai-perf/tests/test_json_exporter.py
+++ b/genai-perf/tests/test_json_exporter.py
@@ -243,6 +243,8 @@ class TestJsonExporter:
           "profile_export_file": "artifacts/gpt2_vllm-triton-vllm-concurrency1/profile_export.json",
           "artifact_dir": "artifacts/gpt2_vllm-triton-vllm-concurrency1",
           "tokenizer": "hf-internal-testing/llama-tokenizer",
+          "tokenizer_revision": "main",
+          "tokenizer_trust_remote_code": false,
           "verbose": false,
           "goodput": null,
           "subcommand": "profile",

--- a/genai-perf/tests/test_tokenizer.py
+++ b/genai-perf/tests/test_tokenizer.py
@@ -26,7 +26,11 @@
 
 import pytest
 from genai_perf.exceptions import GenAIPerfException
-from genai_perf.tokenizer import DEFAULT_TOKENIZER, get_tokenizer
+from genai_perf.tokenizer import (
+    DEFAULT_TOKENIZER,
+    DEFAULT_TOKENIZER_REVISION,
+    get_tokenizer,
+)
 
 
 class TestTokenizer:
@@ -37,6 +41,16 @@ class TestTokenizer:
     def test_non_default_tokenizer(self):
         tokenizer_model = "gpt2"
         get_tokenizer(tokenizer_model)
+
+    def test_default_tokenizer_all_args(self):
+        tokenizer_model = DEFAULT_TOKENIZER
+        get_tokenizer(tokenizer_model, False, DEFAULT_TOKENIZER_REVISION)
+
+    def test_non_default_tokenizer_all_args(self):
+        tokenizer_model = "gpt2"
+        get_tokenizer(
+            tokenizer_model, False, "11c5a3d5811f50298f278a704980280950aedb10"
+        )
 
     def test_bad_tokenizer(self):
         with pytest.raises(GenAIPerfException):

--- a/templates/genai-perf-templates/README_template
+++ b/templates/genai-perf-templates/README_template
@@ -522,16 +522,16 @@ The HuggingFace tokenizer to use to interpret token metrics from prompts and
 responses. The value can be the name of a tokenizer or the filepath of the
 tokenizer. (default: `hf-internal-testing/llama-tokenizer`)
 
+##### `--tokenizer-revision <str>`
+
+The specific tokenizer model version to use. It can be a branch
+name, tag name, or commit ID. (default: `main`)
+
 ##### `--tokenizer-trust-remote-code`
 
 Allow custom tokenizer to be downloaded and executed. This carries security
 risks and should only be used for repositories you trust. This is only
 necessary for custom tokenizers stored in HuggingFace Hub.  (default: `False`)
-
-##### `--tokenizer-revision <str>`
-
-The specific tokenizer model version to use. It can be a branch
-name, tag name, or commit ID. (default: `main`)
 
 ##### `-v`
 ##### `--verbose`

--- a/templates/genai-perf-templates/README_template
+++ b/templates/genai-perf-templates/README_template
@@ -522,6 +522,17 @@ The HuggingFace tokenizer to use to interpret token metrics from prompts and
 responses. The value can be the name of a tokenizer or the filepath of the
 tokenizer. (default: `hf-internal-testing/llama-tokenizer`)
 
+##### `--tokenizer-trust-remote-code`
+
+Allow custom tokenizer to be downloaded and executed. This carries security
+risks and should only be used for repositories you trust. This is only
+necessary for custom tokenizers stored in HuggingFace Hub.  (default: `False`)
+
+##### `--tokenizer-revision <str>`
+
+The specific tokenizer model version to use. It can be a branch
+name, tag name, or commit ID. (default: `main`)
+
 ##### `-v`
 ##### `--verbose`
 


### PR DESCRIPTION
Add the ability to execute code for custom tokenizers. This is necessary for custom tokenizers hosted on HuggingFace Hub as well as local tokenizers that require it to be enabled.

As part of these changes, I also added a flag to use a specific model tag. This is often necessary for production code to ensure you are using an approved version of a model. It is paramount for those users who would enable trusting remote code, as they may want a specific model version for enhanced security.