### PR TITLE
Use generic retriever functions for embeddings endpoint

### DIFF
--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -74,7 +74,7 @@ The easiest way to install GenAI-Perf is through
 Install the latest release using the following command:
 
 ```bash
-export RELEASE="24.08"
+export RELEASE="24.09"
 
 docker run -it --net=host --gpus=all  nvcr.io/nvidia/tritonserver:${RELEASE}-py3-sdk
 
@@ -138,7 +138,7 @@ docker run -ti \
     --shm-size=1g --ulimit memlock=-1 \
     -v /tmp:/tmp \
     -v ${HOME}/.cache/huggingface:/root/.cache/huggingface \
-    nvcr.io/nvidia/tritonserver:24.08-trtllm-python-py3
+    nvcr.io/nvidia/tritonserver:24.09-trtllm-python-py3
 
 # Install the Triton CLI
 pip install git+https://github.com/triton-inference-server/triton_cli.git@0.0.11

--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -105,9 +105,7 @@ You can also build Perf Analyzer [from source](../docs/install.md#build-from-sou
 ### Install GenAI-Perf from source
 
 ```bash
-git clone https://github.com/triton-inference-server/perf_analyzer.git && cd perf_analyzer
-
-pip install -e genai-perf
+pip install git+https://github.com/triton-inference-server/perf_analyzer.git#subdirectory=genai-perf
 ```
 
 </details>

--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -520,6 +520,17 @@ The HuggingFace tokenizer to use to interpret token metrics from prompts and
 responses. The value can be the name of a tokenizer or the filepath of the
 tokenizer. (default: `hf-internal-testing/llama-tokenizer`)
 
+##### `--tokenizer-revision <str>`
+
+The specific tokenizer model version to use. It can be a branch
+name, tag name, or commit ID. (default: `main`)
+
+##### `--tokenizer-trust-remote-code`
+
+Allow custom tokenizer to be downloaded and executed. This carries security
+risks and should only be used for repositories you trust. This is only
+necessary for custom tokenizers stored in HuggingFace Hub.  (default: `False`)
+
 ##### `-v`
 ##### `--verbose`
 

--- a/genai-perf/docs/embeddings.md
+++ b/genai-perf/docs/embeddings.md
@@ -36,18 +36,18 @@ GenAI-Perf allows you to profile embedding models running on an
 To create a sample embeddings input file, use the following command:
 
 ```bash
-echo '{"text": "What was the first car ever driven?"}
-{"text": "Who served as the 5th President of the United States of America?"}
-{"text": "Is the Sydney Opera House located in Australia?"}
-{"text": "In what state did they film Shrek 2?"}' > embeddings.jsonl
+echo '{"text_input": "What was the first car ever driven?"}
+{"text_input": "Who served as the 5th President of the United States of America?"}
+{"text_input": "Is the Sydney Opera House located in Australia?"}
+{"text_input": "In what state did they film Shrek 2?"}' > embeddings.jsonl
 ```
 
 This will generate a file named embeddings.jsonl with the following content:
 ```jsonl
-{"text": "What was the first car ever driven?"}
-{"text": "Who served as the 5th President of the United States of America?"}
-{"text": "Is the Sydney Opera House located in Australia?"}
-{"text": "In what state did they film Shrek 2?"}
+{"text_input": "What was the first car ever driven?"}
+{"text_input": "Who served as the 5th President of the United States of America?"}
+{"text_input": "Is the Sydney Opera House located in Australia?"}
+{"text_input": "In what state did they film Shrek 2?"}
 ```
 
 ## Start an OpenAI Embeddings-Compatible Server

--- a/genai-perf/docs/goodput.md
+++ b/genai-perf/docs/goodput.md
@@ -94,18 +94,18 @@ Example output:
 To create a sample embeddings input file, use the following command:
 
 ```bash
-echo '{"text": "What was the first car ever driven?"}
-{"text": "Who served as the 5th President of the United States of America?"}
-{"text": "Is the Sydney Opera House located in Australia?"}
-{"text": "In what state did they film Shrek 2?"}' > embeddings.jsonl
+echo '{"text_input": "What was the first car ever driven?"}
+{"text_input": "Who served as the 5th President of the United States of America?"}
+{"text_input": "Is the Sydney Opera House located in Australia?"}
+{"text_input": "In what state did they film Shrek 2?"}' > embeddings.jsonl
 ```
 
 This will generate a file named embeddings.jsonl with the following content:
 ```jsonl
-{"text": "What was the first car ever driven?"}
-{"text": "Who served as the 5th President of the United States of America?"}
-{"text": "Is the Sydney Opera House located in Australia?"}
-{"text": "In what state did they film Shrek 2?"}
+{"text_input": "What was the first car ever driven?"}
+{"text_input": "Who served as the 5th President of the United States of America?"}
+{"text_input": "Is the Sydney Opera House located in Australia?"}
+{"text_input": "In what state did they film Shrek 2?"}
 ```
 
 #### Start an OpenAI Embeddings-Compatible Server

--- a/genai-perf/docs/lora.md
+++ b/genai-perf/docs/lora.md
@@ -90,7 +90,7 @@ docker run -it --net=host --rm --gpus=all \
 Run GenAI-Perf from the Triton Inference Server SDK container:
 
 ```bash
-export RELEASE="24.08"
+export RELEASE="24.09"
 
 docker run -it --net=host --gpus=all nvcr.io/nvidia/tritonserver:${RELEASE}-py3-sdk
 
@@ -149,7 +149,7 @@ docker run \
 Run GenAI-Perf from the Triton Inference Server SDK container:
 
 ```bash
-export RELEASE="24.08"
+export RELEASE="24.09"
 
 docker run -it --net=host --gpus=all nvcr.io/nvidia/tritonserver:${RELEASE}-py3-sdk
 
@@ -207,7 +207,7 @@ docker run \
 Run GenAI-Perf from the Triton Inference Server SDK container:
 
 ```bash
-export RELEASE="24.08"
+export RELEASE="24.09"
 
 docker run -it --net=host --gpus=all nvcr.io/nvidia/tritonserver:${RELEASE}-py3-sdk
 

--- a/genai-perf/docs/tutorial.md
+++ b/genai-perf/docs/tutorial.md
@@ -38,7 +38,7 @@ that are widely used across the industry.
 
 - [Profile GPT2 running on Triton + TensorRT-LLM Backend](#tensorrt-llm)
 - [Profile GPT2 running on Triton + vLLM Backend](#triton-vllm)
-- [Profile GPT2 running on OpenAI Chat Completions API-Compatible Server](#openai-chat)
+- [Profile Zephyr-7B-Beta running on OpenAI Chat Completions API-Compatible Server](#openai-chat)
 - [Profile GPT2 running on OpenAI Completions API-Compatible Server](#openai-completions)
 
 </br>

--- a/genai-perf/genai_perf/inputs/converters/base_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/base_converter.py
@@ -64,7 +64,7 @@ class BaseConverter:
             return self._construct_text_payload(input_data)
         else:
             input_data = cast(List, input_data)
-            return self._construct_texts_payload(input_data)
+            return self._construct_batched_text_payload(input_data)
 
     def _construct_text_payload(self, input_data: Dict) -> str:
         """
@@ -75,7 +75,7 @@ class BaseConverter:
         contents = [v for k, v in input_data.items() if k in self._CONTENT_NAMES]
         return " ".join(contents)
 
-    def _construct_texts_payload(self, input_data: List) -> List:
+    def _construct_batched_text_payload(self, input_data: List) -> List:
         """
         Construct batched text payload content for non-chat based LLM converters.
         """

--- a/genai-perf/genai_perf/inputs/converters/openai_embeddings_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_embeddings_converter.py
@@ -32,15 +32,22 @@ from genai_perf.inputs.inputs_config import InputsConfig
 
 class OpenAIEmbeddingsConverter(BaseConverter):
 
+    _CONTENT_NAMES = [
+        "text_input",
+    ]
+
     def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
         request_body: Dict[str, Any] = {"data": []}
 
         for index, entry in enumerate(generic_dataset["rows"]):
+            text_input = self._construct_text_payload_batch_agnostic(
+                config.batch_size, entry
+            )
             model_name = self._select_model_name(config, index)
 
             payload = {
-                "input": entry["input"],
                 "model": model_name,
+                "input": text_input,
             }
             self._add_request_params(payload, config)
             request_body["data"].append({"payload": [payload]})

--- a/genai-perf/genai_perf/inputs/file_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/file_input_retriever.py
@@ -157,9 +157,16 @@ class FileInputRetriever:
         with open(self.config.input_filename, mode="r", newline=None) as file:
             for line in file:
                 if line.strip():
+                    data = load_json_str(line)
                     # None if not provided
-                    prompt = load_json_str(line).get("text_input")
-                    image = load_json_str(line).get("image")
+                    prompt = data.get("text_input")
+                    prompt_alt = data.get("text")
+                    if prompt and prompt_alt:
+                        raise ValueError(
+                            "Each data entry must have only one of 'text_input' or 'text' key name."
+                        )
+                    prompt = prompt if prompt else prompt_alt
+                    image = data.get("image")
                     prompts.append(prompt.strip() if prompt else prompt)
                     images.append(image.strip() if image else image)
         return prompts, images

--- a/genai-perf/genai_perf/inputs/file_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/file_input_retriever.py
@@ -44,37 +44,12 @@ class FileInputRetriever:
 
     # TODO: match return type to retriever interface
     def retrieve_data(self) -> Dict[str, Any]:
-        if self.config.output_format == OutputFormat.OPENAI_EMBEDDINGS:
-            return self._read_embeddings_input_file()
-        elif self.config.output_format == OutputFormat.RANKINGS:
+        if self.config.output_format == OutputFormat.RANKINGS:
             queries_filename = self.config.input_filename / "queries.jsonl"
             passages_filename = self.config.input_filename / "passages.jsonl"
             return self._read_rankings_input_files(queries_filename, passages_filename)
-        elif self.config.output_format == OutputFormat.IMAGE_RETRIEVAL:
-            return self._get_input_dataset_from_file()
         else:
             return self._get_input_dataset_from_file()
-
-    def _read_embeddings_input_file(self) -> Dict[str, Any]:
-        with open(self.config.input_filename, "r") as file:
-            file_content = [load_json_str(line) for line in file]
-
-        texts = [item["text"] for item in file_content]
-
-        if self.config.batch_size > len(texts):
-            raise ValueError(
-                "Batch size cannot be larger than the number of available texts"
-            )
-
-        dataset_json: Dict[str, Any] = {}
-        dataset_json["features"] = [{"name": "input"}]
-        dataset_json["rows"] = []
-
-        for _ in range(self.config.num_prompts):
-            sampled_texts = random.sample(texts, self.config.batch_size)
-            dataset_json["rows"].append({"row": {"input": sampled_texts}})
-
-        return dataset_json
 
     def _read_rankings_input_files(
         self,

--- a/genai-perf/genai_perf/inputs/input_retriever_factory.py
+++ b/genai-perf/genai_perf/inputs/input_retriever_factory.py
@@ -78,12 +78,6 @@ class InputRetrieverFactory:
             )
         else:
             if self.config.input_type == PromptSource.DATASET:
-                # (TMA-1990) support VLM input from public dataset
-                if self.config.output_format == OutputFormat.OPENAI_VISION:
-                    raise GenAIPerfException(
-                        f"{OutputFormat.OPENAI_VISION.to_lowercase()} currently "
-                        "does not support dataset as input."
-                    )
                 dataset = self._get_input_dataset_from_url()
                 generic_dataset_json = self._convert_input_url_dataset_to_generic_json(
                     dataset

--- a/genai-perf/genai_perf/inputs/inputs.py
+++ b/genai-perf/genai_perf/inputs/inputs.py
@@ -87,6 +87,13 @@ class Inputs:
                     f"{self.config.output_format.to_lowercase()} only supports "
                     "a file as input source."
                 )
+        elif self.config.output_format == OutputFormat.OPENAI_VISION:
+            # (TMA-1990) support VLM input from public dataset
+            if self.config.input_type == PromptSource.DATASET:
+                raise GenAIPerfException(
+                    f"{OutputFormat.OPENAI_VISION.to_lowercase()} currently "
+                    "does not support dataset as input."
+                )
 
     def _check_for_dataset_name_if_input_type_is_url(self) -> None:
         if (

--- a/genai-perf/genai_perf/main.py
+++ b/genai-perf/genai_perf/main.py
@@ -95,7 +95,9 @@ def create_config_options(args: Namespace) -> InputsConfig:
         random_seed=args.random_seed,
         num_prompts=args.num_prompts,
         add_stream=args.streaming,
-        tokenizer=get_tokenizer(args.tokenizer),
+        tokenizer=get_tokenizer(
+            args.tokenizer, args.tokenizer_trust_remote_code, args.tokenizer_revision
+        ),
         extra_inputs=extra_input_dict,
         batch_size=args.batch_size,
         output_dir=args.artifact_dir,
@@ -193,7 +195,11 @@ def run():
         args.func(args)
     else:
         create_artifacts_dirs(args)
-        tokenizer = get_tokenizer(args.tokenizer)
+        tokenizer = get_tokenizer(
+            args.tokenizer,
+            args.tokenizer_trust_remote_code,
+            args.tokenizer_revision,
+        )
         generate_inputs(config_options)
         telemetry_data_collector = create_telemetry_data_collector(args)
         args.func(args, extra_args, telemetry_data_collector)

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -40,7 +40,7 @@ from genai_perf.inputs.synthetic_image_generator import ImageFormat
 from genai_perf.plots.plot_config_parser import PlotConfigParser
 from genai_perf.plots.plot_manager import PlotManager
 from genai_perf.telemetry_data import TelemetryDataCollector
-from genai_perf.tokenizer import DEFAULT_TOKENIZER
+from genai_perf.tokenizer import DEFAULT_TOKENIZER, DEFAULT_TOKENIZER_REVISION
 
 from . import __version__
 
@@ -285,6 +285,15 @@ def _is_valid_url(parser: argparse.ArgumentParser, url: str) -> None:
             "It must use 'http' or 'https', have a valid domain and port, "
             "and contain '/metrics' in the path. The expected structure is: "
             "<scheme>://<netloc>/<path>;<params>?<query>#<fragment>"
+        )
+
+
+def _print_warnings(args: argparse.Namespace) -> None:
+    if args.tokenizer_trust_remote_code:
+        logger.warning(
+            "--tokenizer-trust-remote-code is enabled. "
+            "Custom tokenizer code can be executed. "
+            "This should only be used with repositories you trust."
         )
 
 
@@ -741,9 +750,10 @@ def _add_output_args(parser):
         type=Path,
         default=Path("profile_export.json"),
         help="The path where the perf_analyzer profile export will be "
-        "generated. By default, the profile export will be to profile_export.json. "
-        "The genai-perf file will be exported to <profile_export_file>_genai_perf.csv. "
-        "For example, if the profile export file is profile_export.json, the genai-perf file will be "
+        "generated. By default, the profile export will be to "
+        "profile_export.json. The genai-perf file will be exported to "
+        "<profile_export_file>_genai_perf.csv. For example, if the profile "
+        "export file is profile_export.json, the genai-perf file will be "
         "exported to profile_export_genai_perf.csv.",
     )
 
@@ -756,8 +766,26 @@ def _add_other_args(parser):
         type=str,
         default=DEFAULT_TOKENIZER,
         required=False,
-        help="The HuggingFace tokenizer to use to interpret token metrics from prompts and responses. "
-        " The value can be the name of a tokenizer or the filepath of the tokenizer.",
+        help="The HuggingFace tokenizer to use to interpret token metrics "
+        "from prompts and responses. The value can be the name of a tokenizer "
+        "or the filepath of the tokenizer.",
+    )
+    other_group.add_argument(
+        "--tokenizer-revision",
+        type=str,
+        default=DEFAULT_TOKENIZER_REVISION,
+        required=False,
+        help="The specific model version to use. It can be a branch name, "
+        "tag name, or commit ID.",
+    )
+    other_group.add_argument(
+        "--tokenizer-trust-remote-code",
+        action="store_true",
+        required=False,
+        help="Allow custom tokenizer to be downloaded and executed. "
+        "This carries security risks and should only be used "
+        "for repositories you trust. This is only necessary for custom "
+        "tokenizers stored in HuggingFace Hub. ",
     )
 
     other_group.add_argument(
@@ -937,6 +965,7 @@ def refine_args(
         args = _check_server_metrics_url(parser, args)
         args = _set_artifact_paths(args)
         args = _check_goodput_args(args)
+        _print_warnings(args)
     elif args.subcommand == Subcommand.COMPARE.to_lowercase():
         args = _check_compare_args(parser, args)
     else:

--- a/genai-perf/genai_perf/tokenizer.py
+++ b/genai-perf/genai_perf/tokenizer.py
@@ -28,6 +28,7 @@ with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_st
     token_logger.set_verbosity_error()
 
 DEFAULT_TOKENIZER = "hf-internal-testing/llama-tokenizer"
+DEFAULT_TOKENIZER_REVISION = "main"
 
 
 class Tokenizer:
@@ -35,7 +36,7 @@ class Tokenizer:
     A small wrapper class around Huggingface Tokenizer
     """
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, trust_remote_code: bool, revision: str) -> None:
         """
         Initialize by downloading the tokenizer from Huggingface.co
         """
@@ -44,7 +45,9 @@ class Tokenizer:
             with contextlib.redirect_stdout(
                 io.StringIO()
             ) as stdout, contextlib.redirect_stderr(io.StringIO()) as stderr:
-                tokenizer = AutoTokenizer.from_pretrained(name)
+                tokenizer = AutoTokenizer.from_pretrained(
+                    name, trust_remote_code=trust_remote_code, revision=revision
+                )
         except Exception as e:
             raise GenAIPerfException(e)
 
@@ -71,8 +74,12 @@ class Tokenizer:
         return self._tokenizer.__repr__()
 
 
-def get_tokenizer(tokenizer_model: str) -> Tokenizer:
+def get_tokenizer(
+    tokenizer_model: str,
+    trust_remote_code: bool = False,
+    tokenizer_revision: str = DEFAULT_TOKENIZER_REVISION,
+) -> Tokenizer:
     """
     Return tokenizer for the given model name
     """
-    return Tokenizer(tokenizer_model)
+    return Tokenizer(tokenizer_model, trust_remote_code, tokenizer_revision)

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -104,6 +104,8 @@ class Profiler:
             "synthetic_input_tokens_mean",
             "synthetic_input_tokens_stddev",
             "tokenizer",
+            "tokenizer_trust_remote_code",
+            "tokenizer_revision",
         ]
 
         utils.remove_file(args.profile_export_file)

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -241,6 +241,8 @@ class TestCLIArguments:
                 {"image_height_stddev": 456},
             ),
             (["--image-format", "png"], {"image_format": ImageFormat.PNG}),
+            (["--tokenizer-trust-remote-code"], {"tokenizer_trust_remote_code": True}),
+            (["--tokenizer-revision", "not_main"], {"tokenizer_revision": "not_main"}),
             (["-v"], {"verbose": True}),
             (["--verbose"], {"verbose": True}),
             (["-u", "test_url"], {"u": "test_url"}),

--- a/genai-perf/tests/test_embeddings_converter.py
+++ b/genai-perf/tests/test_embeddings_converter.py
@@ -33,10 +33,11 @@ class TestEmbeddingsConverter:
 
     def test_convert_default(self):
         generic_dataset = {
+            "features": ["text_input"],
             "rows": [
-                {"input": ["text 1", "text 2"]},
-                {"input": ["text 3", "text 4"]},
-            ]
+                {"text_input": "text_1"},
+                {"text_input": "text_2"},
+            ],
         }
 
         config = InputsConfig(
@@ -54,7 +55,7 @@ class TestEmbeddingsConverter:
                 {
                     "payload": [
                         {
-                            "input": ["text 1", "text 2"],
+                            "input": "text_1",
                             "model": "test_model",
                         }
                     ]
@@ -62,7 +63,50 @@ class TestEmbeddingsConverter:
                 {
                     "payload": [
                         {
-                            "input": ["text 3", "text 4"],
+                            "input": "text_2",
+                            "model": "test_model",
+                        }
+                    ]
+                },
+            ]
+        }
+
+        assert result == expected_result
+
+    def test_convert_batched(self):
+        generic_dataset = {
+            "features": ["text_input"],
+            "rows": [
+                [{"text_input": "text_1"}, {"text_input": "text_2"}],
+                [{"text_input": "text_3"}, {"text_input": "text_4"}],
+            ],
+        }
+
+        config = InputsConfig(
+            extra_inputs={},  # no extra inputs
+            model_name=["test_model"],
+            model_selection_strategy=ModelSelectionStrategy.ROUND_ROBIN,
+            output_format=OutputFormat.OPENAI_EMBEDDINGS,
+            batch_size=2,
+        )
+
+        embedding_converter = OpenAIEmbeddingsConverter()
+        result = embedding_converter.convert(generic_dataset, config)
+
+        expected_result = {
+            "data": [
+                {
+                    "payload": [
+                        {
+                            "input": ["text_1", "text_2"],
+                            "model": "test_model",
+                        }
+                    ]
+                },
+                {
+                    "payload": [
+                        {
+                            "input": ["text_3", "text_4"],
                             "model": "test_model",
                         }
                     ]
@@ -74,10 +118,11 @@ class TestEmbeddingsConverter:
 
     def test_convert_with_request_parameters(self):
         generic_dataset = {
+            "features": ["text_input"],
             "rows": [
-                {"input": ["text 1", "text 2"]},
-                {"input": ["text 3", "text 4"]},
-            ]
+                {"text_input": "text_1"},
+                {"text_input": "text_2"},
+            ],
         }
 
         extra_inputs = {
@@ -101,7 +146,7 @@ class TestEmbeddingsConverter:
                 {
                     "payload": [
                         {
-                            "input": ["text 1", "text 2"],
+                            "input": "text_1",
                             "model": "test_model",
                             "encoding_format": "base64",
                             "truncate": "END",
@@ -112,7 +157,7 @@ class TestEmbeddingsConverter:
                 {
                     "payload": [
                         {
-                            "input": ["text 3", "text 4"],
+                            "input": "text_2",
                             "model": "test_model",
                             "encoding_format": "base64",
                             "truncate": "END",

--- a/genai-perf/tests/test_file_input_retriever.py
+++ b/genai-perf/tests/test_file_input_retriever.py
@@ -155,7 +155,7 @@ class TestFileInputRetriever:
         new_callable=mock_open,
         read_data='{"text": "single prompt"}\n',
     )
-    def test_get_input_file_with_deprecated_text(self, mock_file, mock_exists):
+    def test_get_input_file_with_deprecated_text_field(self, mock_file, mock_exists):
         expected_prompts = ["single prompt"]
         file_retriever = FileInputRetriever(
             InputsConfig(

--- a/genai-perf/tests/test_file_input_retriever.py
+++ b/genai-perf/tests/test_file_input_retriever.py
@@ -37,46 +37,6 @@ from PIL import Image
 
 class TestFileInputRetriever:
 
-    @patch("pathlib.Path.exists", return_value=True)
-    @patch(
-        "builtins.open",
-        new_callable=mock_open,
-        read_data="\n".join(
-            [
-                '{"text": "What production company co-owned by Kevin Loader and Rodger Michell produced My Cousin Rachel?"}',
-                '{"text": "Who served as the 1st Vice President of Colombia under El Libertador?"}',
-                '{"text": "Are the Barton Mine and Hermiston-McCauley Mine located in The United States of America?"}',
-                '{"text": "what state did they film daddy\'s home 2"}',
-            ]
-        ),
-    )
-    def test_read_embeddings_input_file(self, mock_file, mock_exists):
-        batch_size = 3
-        config = InputsConfig(
-            input_filename=Path("embeddings.jsonl"),
-            batch_size=batch_size,
-            num_prompts=100,
-        )
-        file_retriever = FileInputRetriever(config)
-        dataset = file_retriever._read_embeddings_input_file()
-
-        assert dataset is not None
-        assert len(dataset["rows"]) == 100
-        for row in dataset["rows"]:
-            assert "row" in row
-            payload = row["row"]
-            assert "input" in payload
-            assert isinstance(payload["input"], list)
-            assert len(payload["input"]) == batch_size
-
-        # Try error case where batch size is larger than the number of available texts
-        with pytest.raises(
-            ValueError,
-            match="Batch size cannot be larger than the number of available texts",
-        ):
-            config.batch_size = 5
-            file_retriever._read_embeddings_input_file()
-
     def open_side_effects(self, filepath, *args, **kwargs):
         queries_content = "\n".join(
             [

--- a/genai-perf/tests/test_file_input_retriever.py
+++ b/genai-perf/tests/test_file_input_retriever.py
@@ -153,6 +153,28 @@ class TestFileInputRetriever:
     @patch(
         "builtins.open",
         new_callable=mock_open,
+        read_data='{"text": "single prompt"}\n',
+    )
+    def test_get_input_file_with_deprecated_text(self, mock_file, mock_exists):
+        expected_prompts = ["single prompt"]
+        file_retriever = FileInputRetriever(
+            InputsConfig(
+                model_name=["test_model_A"],
+                model_selection_strategy=ModelSelectionStrategy.ROUND_ROBIN,
+                input_filename=Path("prompt.txt"),
+            )
+        )
+        dataset = file_retriever._get_input_dataset_from_file()
+
+        assert dataset is not None
+        assert len(dataset["rows"]) == len(expected_prompts)
+        for i, prompt in enumerate(expected_prompts):
+            assert dataset["rows"][i]["row"]["text_input"] == prompt
+
+    @patch("pathlib.Path.exists", return_value=True)
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
         read_data='{"text_input": "prompt1"}\n{"text_input": "prompt2"}\n{"text_input": "prompt3"}\n',
     )
     def test_get_input_file_with_multiple_prompts(self, mock_file, mock_exists):

--- a/genai-perf/tests/test_json_exporter.py
+++ b/genai-perf/tests/test_json_exporter.py
@@ -243,6 +243,8 @@ class TestJsonExporter:
           "profile_export_file": "artifacts/gpt2_vllm-triton-vllm-concurrency1/profile_export.json",
           "artifact_dir": "artifacts/gpt2_vllm-triton-vllm-concurrency1",
           "tokenizer": "hf-internal-testing/llama-tokenizer",
+          "tokenizer_revision": "main",
+          "tokenizer_trust_remote_code": false,
           "verbose": false,
           "goodput": null,
           "subcommand": "profile",

--- a/genai-perf/tests/test_tokenizer.py
+++ b/genai-perf/tests/test_tokenizer.py
@@ -26,7 +26,11 @@
 
 import pytest
 from genai_perf.exceptions import GenAIPerfException
-from genai_perf.tokenizer import DEFAULT_TOKENIZER, get_tokenizer
+from genai_perf.tokenizer import (
+    DEFAULT_TOKENIZER,
+    DEFAULT_TOKENIZER_REVISION,
+    get_tokenizer,
+)
 
 
 class TestTokenizer:
@@ -37,6 +41,16 @@ class TestTokenizer:
     def test_non_default_tokenizer(self):
         tokenizer_model = "gpt2"
         get_tokenizer(tokenizer_model)
+
+    def test_default_tokenizer_all_args(self):
+        tokenizer_model = DEFAULT_TOKENIZER
+        get_tokenizer(tokenizer_model, False, DEFAULT_TOKENIZER_REVISION)
+
+    def test_non_default_tokenizer_all_args(self):
+        tokenizer_model = "gpt2"
+        get_tokenizer(
+            tokenizer_model, False, "11c5a3d5811f50298f278a704980280950aedb10"
+        )
 
     def test_bad_tokenizer(self):
         with pytest.raises(GenAIPerfException):

--- a/templates/genai-perf-templates/README_template
+++ b/templates/genai-perf-templates/README_template
@@ -522,6 +522,17 @@ The HuggingFace tokenizer to use to interpret token metrics from prompts and
 responses. The value can be the name of a tokenizer or the filepath of the
 tokenizer. (default: `hf-internal-testing/llama-tokenizer`)
 
+##### `--tokenizer-revision <str>`
+
+The specific tokenizer model version to use. It can be a branch
+name, tag name, or commit ID. (default: `main`)
+
+##### `--tokenizer-trust-remote-code`
+
+Allow custom tokenizer to be downloaded and executed. This carries security
+risks and should only be used for repositories you trust. This is only
+necessary for custom tokenizers stored in HuggingFace Hub.  (default: `False`)
+
 ##### `-v`
 ##### `--verbose`
 

--- a/templates/genai-perf-templates/embeddings_template
+++ b/templates/genai-perf-templates/embeddings_template
@@ -36,18 +36,18 @@ GenAI-Perf allows you to profile embedding models running on an
 To create a sample embeddings input file, use the following command:
 
 ```bash
-echo '{"text": "What was the first car ever driven?"}
-{"text": "Who served as the 5th President of the United States of America?"}
-{"text": "Is the Sydney Opera House located in Australia?"}
-{"text": "In what state did they film Shrek 2?"}' > embeddings.jsonl
+echo '{"text_input": "What was the first car ever driven?"}
+{"text_input": "Who served as the 5th President of the United States of America?"}
+{"text_input": "Is the Sydney Opera House located in Australia?"}
+{"text_input": "In what state did they film Shrek 2?"}' > embeddings.jsonl
 ```
 
 This will generate a file named embeddings.jsonl with the following content:
 ```jsonl
-{"text": "What was the first car ever driven?"}
-{"text": "Who served as the 5th President of the United States of America?"}
-{"text": "Is the Sydney Opera House located in Australia?"}
-{"text": "In what state did they film Shrek 2?"}
+{"text_input": "What was the first car ever driven?"}
+{"text_input": "Who served as the 5th President of the United States of America?"}
+{"text_input": "Is the Sydney Opera House located in Australia?"}
+{"text_input": "In what state did they film Shrek 2?"}
 ```
 
 ## Start an OpenAI Embeddings-Compatible Server

--- a/templates/genai-perf-templates/tutorial_template
+++ b/templates/genai-perf-templates/tutorial_template
@@ -38,7 +38,7 @@ that are widely used across the industry.
 
 - [Profile GPT2 running on Triton + TensorRT-LLM Backend](#tensorrt-llm)
 - [Profile GPT2 running on Triton + vLLM Backend](#triton-vllm)
-- [Profile GPT2 running on OpenAI Chat Completions API-Compatible Server](#openai-chat)
+- [Profile Zephyr-7B-Beta running on OpenAI Chat Completions API-Compatible Server](#openai-chat)
 - [Profile GPT2 running on OpenAI Completions API-Compatible Server](#openai-completions)
 
 </br>

--- a/templates/template_vars.yaml
+++ b/templates/template_vars.yaml
@@ -1,7 +1,7 @@
 General:
   release: 24.09
   triton_cli_version: 0.0.12
-  genai_perf_version: 0.0.6
+  genai_perf_version: 0.0.7dev
 
 README:
   filename: README.md

--- a/templates/template_vars.yaml
+++ b/templates/template_vars.yaml
@@ -1,6 +1,6 @@
 General:
   release: 24.09
-  triton_cli_version: 0.0.12
+  triton_cli_version: 0.0.11
   genai_perf_version: 0.0.7dev
 
 README:

--- a/templates/template_vars.yaml
+++ b/templates/template_vars.yaml
@@ -1,7 +1,7 @@
 General:
-  release: 24.08
-  triton_cli_version: 0.0.11
-  genai_perf_version: 0.0.6dev
+  release: 24.09
+  triton_cli_version: 0.0.12
+  genai_perf_version: 0.0.6
 
 README:
   filename: README.md


### PR DESCRIPTION
This PR removes the need for a custom embeddings file retriever by using the generalized retrievers. The ultimate goal is to not have any endpoint-specific retrievers. GenAI-Perf should eventually have retrievers solely based on the data source, not the output format.

Based on feedback, this PR also allows users to specify text in an input file with both "text" and "text_input" for now, to avoid breaking embeddings/rankings (text) and the other endpoints (text_input).