### PR TITLE
Pass Branch Names to Automatic CI

### DIFF
--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -17,4 +17,8 @@ jobs:
       - name: Trigger Pipeline
         run: |
           #!/bin/bash
-          curl --fail --request POST --form token=${{ secrets.PIPELINE_TOKEN }} -F ref=${GITHUB_HEAD_REF}  "${{ secrets.PIPELINE_URL }}"
+          curl --fail --request POST \
+            --form token=${{ secrets.PIPELINE_TOKEN }} \
+            --form variables[TRITON_CLIENT_REPO_TAG]=${GITHUB_HEAD_REF} \
+            --form variables[TRITON_CLIENT_REPO_TAG]=main \
+            -F ref=${GITHUB_HEAD_REF}  "${{ secrets.PIPELINE_URL }}"

--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -20,5 +20,5 @@ jobs:
           curl --fail --request POST \
             --form token=${{ secrets.PIPELINE_TOKEN }} \
             --form variables[TRITON_PERF_ANALYZER_REPO_TAG]=${GITHUB_HEAD_REF} \
-            --form variables[TRITON_CLIENT_REPO_TAG]=fpetrini-dumm \
+            --form variables[TRITON_CLIENT_REPO_TAG]=fpetrini-dummy \
             -F ref=${GITHUB_HEAD_REF}  "${{ secrets.PIPELINE_URL }}"

--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -19,6 +19,6 @@ jobs:
           #!/bin/bash
           curl --fail --request POST \
             --form token=${{ secrets.PIPELINE_TOKEN }} \
-            --form variables[TRITON_CLIENT_REPO_TAG]=${GITHUB_HEAD_REF} \
+            --form variables[TRITON_PERF_ANALYZER_REPO_TAG]=${GITHUB_HEAD_REF} \
             --form variables[TRITON_CLIENT_REPO_TAG]=main \
             -F ref=${GITHUB_HEAD_REF}  "${{ secrets.PIPELINE_URL }}"

--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -20,5 +20,5 @@ jobs:
           curl --fail --request POST \
             --form token=${{ secrets.PIPELINE_TOKEN }} \
             --form variables[TRITON_PERF_ANALYZER_REPO_TAG]=${GITHUB_HEAD_REF} \
-            --form variables[TRITON_CLIENT_REPO_TAG]=fpetrini-dummy \
+            --form variables[TRITON_CLIENT_REPO_TAG]=main \
             -F ref=${GITHUB_HEAD_REF}  "${{ secrets.PIPELINE_URL }}"

--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -20,5 +20,5 @@ jobs:
           curl --fail --request POST \
             --form token=${{ secrets.PIPELINE_TOKEN }} \
             --form variables[TRITON_PERF_ANALYZER_REPO_TAG]=${GITHUB_HEAD_REF} \
-            --form variables[TRITON_CLIENT_REPO_TAG]=main \
+            --form variables[TRITON_CLIENT_REPO_TAG]=fpetrini-dumm \
             -F ref=${GITHUB_HEAD_REF}  "${{ secrets.PIPELINE_URL }}"


### PR DESCRIPTION
_Context:_ Currently, automatic CI for PRs is run using both the `main` branch of the PA repo and the client repo. This is an issue because it means the changes in the PR are not actually being tested by CI, risking a false positive from CI and merging a PR that causes breakages.

**Goal:** Pass the appropriate branch names to CI. The PA repo will use the branch name associated with the CI that triggered the pipeline and the client repo branch will default to `main` unless overwritten by the developer.

Note that it will be the developer's responsibility to restore any overwritten branch names prior to merging.