### PR TITLE
Add Analyze to Search Parameters

### DIFF
--- a/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
+++ b/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
@@ -48,7 +48,7 @@ class PerfAnalyzerConfig:
         self._parameters: Dict[str, Any] = {}
         for objective in model_objective_parameters.values():
             for name, parameter in objective.items():
-                if parameter.usage == SearchUsage.RUNTIME:
+                if parameter.usage == SearchUsage.RUNTIME_PA:
                     self._parameters[name] = parameter.get_value_based_on_category()
 
     ###########################################################################

--- a/genai-perf/genai_perf/config/generate/search_parameter.py
+++ b/genai-perf/genai_perf/config/generate/search_parameter.py
@@ -23,7 +23,8 @@ ParameterList: TypeAlias = List[Union[int, str]]
 
 class SearchUsage(Enum):
     MODEL = auto()
-    RUNTIME = auto()
+    RUNTIME_PA = auto()
+    RUNTIME_GAP = auto()
     BUILD = auto()
 
 

--- a/genai-perf/genai_perf/config/generate/search_parameters.py
+++ b/genai-perf/genai_perf/config/generate/search_parameters.py
@@ -46,9 +46,9 @@ class SearchParameters:
         "instance_count",
         "max_queue_delay",
     ]
-    runtime_parameters = ["runtime_batch_size", "concurrency", "request_rate"]
+    runtime_pa_parameters = ["runtime_batch_size", "concurrency", "request_rate"]
 
-    all_parameters = model_parameters + runtime_parameters
+    all_parameters = model_parameters + runtime_pa_parameters
 
     def __init__(
         self,
@@ -295,8 +295,8 @@ class SearchParameters:
     def _determine_parameter_usage(self, name: str) -> SearchUsage:
         if name in SearchParameters.model_parameters:
             usage = SearchUsage.MODEL
-        elif name in SearchParameters.runtime_parameters:
-            usage = SearchUsage.RUNTIME
+        elif name in SearchParameters.runtime_pa_parameters:
+            usage = SearchUsage.RUNTIME_PA
         else:
             raise (GenAIPerfException(f"SearchUsage not found for {name}"))
 

--- a/genai-perf/genai_perf/config/generate/search_parameters.py
+++ b/genai-perf/genai_perf/config/generate/search_parameters.py
@@ -22,7 +22,7 @@ from genai_perf.config.generate.search_parameter import (
     SearchParameter,
     SearchUsage,
 )
-from genai_perf.config.input.config_command import ConfigOptimize, Range
+from genai_perf.config.input.config_command import ConfigOptimize, Range, Subcommand
 from genai_perf.exceptions import GenAIPerfException
 
 
@@ -65,7 +65,9 @@ class SearchParameters:
     ):
         self._config = config
         self._subcommand = (
-            "optimize" if isinstance(config, ConfigOptimize) else "analyze"
+            Subcommand.OPTIMIZE
+            if isinstance(config, ConfigOptimize)
+            else Subcommand.ANALYZE
         )
 
         # TODO: OPTIMIZE
@@ -130,7 +132,7 @@ class SearchParameters:
     # Search Parameters
     ###########################################################################
     def _populate_search_parameters(self) -> None:
-        if self._subcommand == "optimize":
+        if self._subcommand == Subcommand.OPTIMIZE:
             self._populate_model_config_parameters()
             self._populate_perf_analyzer_parameters()
             self._populate_genai_perf_parameters()

--- a/genai-perf/genai_perf/config/generate/search_parameters.py
+++ b/genai-perf/genai_perf/config/generate/search_parameters.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from math import log2
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from genai_perf.config.generate.objective_parameter import ObjectiveCategory
 from genai_perf.config.generate.search_parameter import (
@@ -22,7 +22,7 @@ from genai_perf.config.generate.search_parameter import (
     SearchParameter,
     SearchUsage,
 )
-from genai_perf.config.input.config_command import ConfigAnalyze, ConfigOptimize, Range
+from genai_perf.config.input.config_command import ConfigOptimize, Range
 from genai_perf.exceptions import GenAIPerfException
 
 

--- a/genai-perf/genai_perf/config/generate/search_parameters.py
+++ b/genai-perf/genai_perf/config/generate/search_parameters.py
@@ -134,8 +134,8 @@ class SearchParameters:
             self._populate_model_config_parameters()
             self._populate_perf_analyzer_parameters()
             self._populate_genai_perf_parameters()
-        # else:
-        #     self._populate_analyze_parameters()
+        else:
+            self._populate_analyze_parameters()
 
     ###########################################################################
     # Perf Analyzer Parameters
@@ -272,6 +272,29 @@ class SearchParameters:
                 parameter_min_value=self._config.model_config.max_queue_delay.min,
                 parameter_max_value=self._config.model_config.max_queue_delay.max,
             )
+
+    ###########################################################################
+    # Analyze Parameters
+    ###########################################################################
+    def _populate_analyze_parameters(self) -> None:
+        for name, value in self._config.sweep_parameters.items():  # type: ignore
+            if isinstance(value, list):
+                category = (
+                    SearchCategory.STR_LIST
+                    if isinstance(value[0], str)
+                    else SearchCategory.INT_LIST
+                )
+                self._populate_list_parameter(
+                    parameter_name=name,
+                    parameter_list=value,
+                    parameter_category=category,
+                )
+            elif isinstance(value, Range):
+                self._populate_range_parameter(
+                    parameter_name=name,
+                    parameter_min_value=value.min,
+                    parameter_max_value=value.max,
+                )
 
     ###########################################################################
     # Populate Methods

--- a/genai-perf/genai_perf/config/input/config_command.py
+++ b/genai-perf/genai_perf/config/input/config_command.py
@@ -14,9 +14,15 @@
 
 from copy import copy
 from dataclasses import dataclass, field
+from enum import Enum, auto
 from typing import Dict, List, Optional, TypeAlias, Union
 
 from genai_perf.types import ModelName
+
+
+class Subcommand(Enum):
+    ANALYZE = auto()
+    OPTIMIZE = auto()
 
 
 def default_field(obj):

--- a/genai-perf/genai_perf/config/input/config_command.py
+++ b/genai-perf/genai_perf/config/input/config_command.py
@@ -70,6 +70,21 @@ class RunConfigDefaults:
     MAX_AUTO_ADJUSTS = 10
     STABILITY_THRESHOLD = 99.9
 
+    # GAP Input Defaults
+    DATASET = "openorca"
+    FILE = None
+    NUM_PROMPTS = 100
+    SEED = 0
+
+    # GAP Input Synthetic Tokens Defaults
+    INPUT_MEAN = -1
+    INPUT_STDDEV = 0
+
+    # GAP Output Token Defaults
+    OUTPUT_MEAN = -1
+    DETERMINISTIC = False
+    OUTPUT_STDDEV = 0
+
 
 # TODO: OPTIMIZE
 # These are placeholder dataclasses until the real Command Parser is written
@@ -152,10 +167,34 @@ class ConfigPerfAnalyzer:
 
 
 @dataclass
+class ConfigSyntheticTokens:
+    mean: int = default_field(RunConfigDefaults.INPUT_MEAN)
+    stddev: int = default_field(RunConfigDefaults.INPUT_STDDEV)
+
+
+@dataclass
+class ConfigInput:
+    dataset: str = default_field(RunConfigDefaults.DATASET)
+    file: str = default_field(RunConfigDefaults.FILE)
+    num_prompts: int = default_field(RunConfigDefaults.NUM_PROMPTS)
+    seed: int = default_field(RunConfigDefaults.SEED)
+    synthetic_tokens: ConfigSyntheticTokens = ConfigSyntheticTokens()
+
+
+@dataclass
+class ConfigOutputTokens:
+    mean: int = default_field(RunConfigDefaults.OUTPUT_MEAN)
+    deterministic: bool = default_field(RunConfigDefaults.DETERMINISTIC)
+    stddev: int = default_field(RunConfigDefaults.OUTPUT_STDDEV)
+
+
+@dataclass
 class ConfigCommand:
     model_names: List[ModelName]
     optimize: ConfigOptimize = ConfigOptimize()
     perf_analyzer: ConfigPerfAnalyzer = ConfigPerfAnalyzer()
+    input: ConfigInput = ConfigInput()
+    output_tokens: ConfigOutputTokens = ConfigOutputTokens()
 
     def get_max(self, config_value: ConfigRangeOrList) -> int:
         if type(config_value) is list:

--- a/genai-perf/tests/test_optuna_objective_generator.py
+++ b/genai-perf/tests/test_optuna_objective_generator.py
@@ -173,13 +173,13 @@ class TestOptunaObjectiveGenerator(unittest.TestCase):
                     SearchUsage.MODEL, ObjectiveCategory.EXPONENTIAL, 4
                 ),
                 "runtime_batch_size": ObjectiveParameter(
-                    SearchUsage.RUNTIME, ObjectiveCategory.INTEGER, 1
+                    SearchUsage.RUNTIME_PA, ObjectiveCategory.INTEGER, 1
                 ),
                 "instance_count": ObjectiveParameter(
                     SearchUsage.MODEL, ObjectiveCategory.INTEGER, 2
                 ),
                 "concurrency": ObjectiveParameter(
-                    SearchUsage.RUNTIME, ObjectiveCategory.EXPONENTIAL, 6
+                    SearchUsage.RUNTIME_PA, ObjectiveCategory.EXPONENTIAL, 6
                 ),
             }
         }

--- a/genai-perf/tests/test_optuna_objective_generator.py
+++ b/genai-perf/tests/test_optuna_objective_generator.py
@@ -24,7 +24,7 @@ from genai_perf.config.generate.optuna_objective_generator import (
     OptunaObjectiveGenerator,
 )
 from genai_perf.config.generate.search_parameters import SearchParameters, SearchUsage
-from genai_perf.config.input.config_command import ConfigCommand
+from genai_perf.config.input.config_command import ConfigCommand, RunConfigDefaults
 from tests.test_utils import create_perf_metrics, create_run_config_measurement
 
 
@@ -34,7 +34,9 @@ class TestOptunaObjectiveGenerator(unittest.TestCase):
     ###########################################################################
     def setUp(self):
         self._config = ConfigCommand(model_names=["test_model"])
-        self._model_search_parameters = {"test_model": SearchParameters(self._config)}
+        self._model_search_parameters = {
+            "test_model": SearchParameters(self._config.optimize)
+        }
 
         self._perf_metrics = create_perf_metrics(throughput=1000, latency=50)
         self._baseline_rcm = create_run_config_measurement(
@@ -148,6 +150,7 @@ class TestOptunaObjectiveGenerator(unittest.TestCase):
                 "model_batch_size": 4,
                 "runtime_batch_size": 1,
                 "instance_count": 2,
+                "num_prompts": 100,
                 "concurrency": 6,
             }
         }
@@ -173,7 +176,14 @@ class TestOptunaObjectiveGenerator(unittest.TestCase):
                     SearchUsage.MODEL, ObjectiveCategory.EXPONENTIAL, 4
                 ),
                 "runtime_batch_size": ObjectiveParameter(
-                    SearchUsage.RUNTIME_PA, ObjectiveCategory.INTEGER, 1
+                    SearchUsage.RUNTIME_PA,
+                    ObjectiveCategory.INTEGER,
+                    RunConfigDefaults.PA_BATCH_SIZE,
+                ),
+                "num_prompts": ObjectiveParameter(
+                    SearchUsage.RUNTIME_GAP,
+                    ObjectiveCategory.INTEGER,
+                    RunConfigDefaults.NUM_PROMPTS,
                 ),
                 "instance_count": ObjectiveParameter(
                     SearchUsage.MODEL, ObjectiveCategory.INTEGER, 2

--- a/genai-perf/tests/test_perf_analyzer_config.py
+++ b/genai-perf/tests/test_perf_analyzer_config.py
@@ -37,13 +37,13 @@ class TestPerfAnalyzerConfig(unittest.TestCase):
                     SearchUsage.MODEL, ObjectiveCategory.EXPONENTIAL, 4
                 ),
                 "runtime_batch_size": ObjectiveParameter(
-                    SearchUsage.RUNTIME, ObjectiveCategory.INTEGER, 1
+                    SearchUsage.RUNTIME_PA, ObjectiveCategory.INTEGER, 1
                 ),
                 "instance_count": ObjectiveParameter(
                     SearchUsage.MODEL, ObjectiveCategory.INTEGER, 2
                 ),
                 "concurrency": ObjectiveParameter(
-                    SearchUsage.RUNTIME, ObjectiveCategory.EXPONENTIAL, 6
+                    SearchUsage.RUNTIME_PA, ObjectiveCategory.EXPONENTIAL, 6
                 ),
             }
         }

--- a/genai-perf/tests/test_search_parameters.py
+++ b/genai-perf/tests/test_search_parameters.py
@@ -34,7 +34,7 @@ class TestSearchParameters(unittest.TestCase):
     def setUp(self):
         self.config = deepcopy(ConfigCommand(model_names=["test_model"]))
 
-        self.search_parameters = SearchParameters(config=self.config)
+        self.search_parameters = SearchParameters(config=self.config.optimize)
 
         self.search_parameters._add_search_parameter(
             name="concurrency",
@@ -164,7 +164,7 @@ class TestSearchParameters(unittest.TestCase):
         """
 
         config = deepcopy(ConfigCommand(model_names=["test_model"]))
-        search_parameters = SearchParameters(config)
+        search_parameters = SearchParameters(self.config.optimize)
 
         #######################################################################
         # Model Config
@@ -206,7 +206,7 @@ class TestSearchParameters(unittest.TestCase):
         self.assertEqual(SearchUsage.RUNTIME_PA, runtime_batch_size.usage)
         self.assertEqual(SearchCategory.INT_LIST, runtime_batch_size.category)
         self.assertEqual(
-            RunConfigDefaults.PA_BATCH_SIZE, runtime_batch_size.enumerated_list
+            [RunConfigDefaults.PA_BATCH_SIZE], runtime_batch_size.enumerated_list
         )
 
         # Concurrency - this is not set because use_concurrency_formula is True
@@ -227,7 +227,7 @@ class TestSearchParameters(unittest.TestCase):
         config = deepcopy(ConfigCommand(model_names=["test_model"]))
         config.optimize.perf_analyzer.use_concurrency_formula = False
 
-        search_parameters = SearchParameters(config)
+        search_parameters = SearchParameters(config.optimize)
 
         concurrency = search_parameters.get_parameter("concurrency")
         self.assertEqual(SearchUsage.RUNTIME_PA, concurrency.usage)
@@ -242,7 +242,7 @@ class TestSearchParameters(unittest.TestCase):
         config = deepcopy(ConfigCommand(model_names=["test_model"]))
         config.optimize.perf_analyzer.stimulus_type = "request_rate"
 
-        search_parameters = SearchParameters(config)
+        search_parameters = SearchParameters(config.optimize)
 
         request_rate = search_parameters.get_parameter("request_rate")
         self.assertEqual(SearchUsage.RUNTIME_PA, request_rate.usage)
@@ -293,105 +293,6 @@ class TestSearchParameters(unittest.TestCase):
 
         # model_batch_size (8) * instance count (5) * concurrency (11) * size (3)
         self.assertEqual(8 * 5 * 11 * 3, total_num_of_possible_configurations)
-
-    # TODO: OPTIMIZE:
-    # This will be enabled once BLS support is added
-    #
-    # def test_search_parameter_creation_bls_default(self):
-    #     """
-    #     Test that search parameters are correctly created in default BLS optuna case
-    #     """
-
-    #     args = [
-    #         "model-analyzer",
-    #         "profile",
-    #         "--model-repository",
-    #         "cli-repository",
-    #         "-f",
-    #         "path-to-config-file",
-    #         "--run-config-search-mode",
-    #         "optuna",
-    #     ]
-
-    #     yaml_content = """
-    #     profile_models: add_sub
-    #     bls_composing_models: add,sub
-    #     """
-
-    #     config = TestConfig()._evaluate_config(args=args, yaml_content=yaml_content)
-
-    #     analyzer = Analyzer(config, MagicMock(), MagicMock(), MagicMock())
-
-    #     mock_model_config = MockModelConfig()
-    #     mock_model_config.start()
-    #     analyzer._populate_search_parameters(MagicMock(), MagicMock())
-    #     analyzer._populate_composing_search_parameters(MagicMock(), MagicMock())
-    #     mock_model_config.stop()
-
-    #     # ADD_SUB
-    #     # =====================================================================
-    #     # The top level model of a BLS does not search max batch size (always 1)
-
-    #     # max_batch_size
-    #     max_batch_size = analyzer._search_parameters["add_sub"].get_parameter(
-    #         "max_batch_size"
-    #     )
-    #     self.assertIsNone(max_batch_size)
-
-    #     # concurrency
-    #     concurrency = analyzer._search_parameters["add_sub"].get_parameter(
-    #         "concurrency"
-    #     )
-    #     self.assertEqual(SearchUsage.RUNTIME_PA, concurrency.usage)
-    #     self.assertEqual(SearchCategory.EXPONENTIAL, concurrency.category)
-    #     self.assertEqual(
-    #         log2(default.DEFAULT_RUN_CONFIG_MIN_CONCURRENCY), concurrency.min_range
-    #     )
-    #     self.assertEqual(
-    #         log2(default.DEFAULT_RUN_CONFIG_MAX_CONCURRENCY), concurrency.max_range
-    #     )
-
-    #     # instance_group
-    #     instance_group = analyzer._search_parameters["add_sub"].get_parameter(
-    #         "instance_group"
-    #     )
-    #     self.assertEqual(SearchUsage.MODEL, instance_group.usage)
-    #     self.assertEqual(SearchCategory.INTEGER, instance_group.category)
-    #     self.assertEqual(
-    #         default.DEFAULT_RUN_CONFIG_MIN_INSTANCE_COUNT, instance_group.min_range
-    #     )
-    #     self.assertEqual(
-    #         default.DEFAULT_RUN_CONFIG_MAX_INSTANCE_COUNT, instance_group.max_range
-    #     )
-
-    #     # ADD/SUB (composing models)
-    #     # =====================================================================
-    #     # Composing models do not search concurrency and has no max batch size
-
-    #     # max_batch_size
-    #     max_batch_size = analyzer._composing_search_parameters["add"].get_parameter(
-    #         "max_batch_size"
-    #     )
-    #     self.assertIsNone(max_batch_size)
-
-    #     # concurrency
-    #     concurrency = analyzer._composing_search_parameters["sub"].get_parameter(
-    #         "concurrency"
-    #     )
-    #     self.assertIsNone(concurrency)
-
-    #     # instance_group
-    #     instance_group = analyzer._composing_search_parameters["sub"].get_parameter(
-    #         "instance_group"
-    #     )
-    #     self.assertEqual(SearchUsage.MODEL, instance_group.usage)
-    #     self.assertEqual(SearchCategory.INTEGER, instance_group.category)
-    #     self.assertEqual(
-    #         default.DEFAULT_RUN_CONFIG_MIN_INSTANCE_COUNT, instance_group.min_range
-    #     )
-    #     self.assertEqual(
-    #         default.DEFAULT_RUN_CONFIG_MAX_INSTANCE_COUNT, instance_group.max_range
-    #     )
 
 
 if __name__ == "__main__":

--- a/genai-perf/tests/test_search_parameters.py
+++ b/genai-perf/tests/test_search_parameters.py
@@ -38,7 +38,7 @@ class TestSearchParameters(unittest.TestCase):
 
         self.search_parameters._add_search_parameter(
             name="concurrency",
-            usage=SearchUsage.RUNTIME,
+            usage=SearchUsage.RUNTIME_PA,
             category=SearchCategory.EXPONENTIAL,
             min_range=log2(RunConfigDefaults.MIN_CONCURRENCY),
             max_range=log2(RunConfigDefaults.MAX_CONCURRENCY),
@@ -61,7 +61,7 @@ class TestSearchParameters(unittest.TestCase):
 
         parameter = self.search_parameters.get_parameter("concurrency")
 
-        self.assertEqual(SearchUsage.RUNTIME, parameter.usage)
+        self.assertEqual(SearchUsage.RUNTIME_PA, parameter.usage)
         self.assertEqual(SearchCategory.EXPONENTIAL, parameter.category)
         self.assertEqual(log2(RunConfigDefaults.MIN_CONCURRENCY), parameter.min_range)
         self.assertEqual(log2(RunConfigDefaults.MAX_CONCURRENCY), parameter.max_range)
@@ -111,7 +111,7 @@ class TestSearchParameters(unittest.TestCase):
         with self.assertRaises(GenAIPerfException):
             self.search_parameters._add_search_parameter(
                 name="concurrency",
-                usage=SearchUsage.RUNTIME,
+                usage=SearchUsage.RUNTIME_PA,
                 category=SearchCategory.EXPONENTIAL,
                 max_range=10,
             )
@@ -119,7 +119,7 @@ class TestSearchParameters(unittest.TestCase):
         with self.assertRaises(GenAIPerfException):
             self.search_parameters._add_search_parameter(
                 name="concurrency",
-                usage=SearchUsage.RUNTIME,
+                usage=SearchUsage.RUNTIME_PA,
                 category=SearchCategory.EXPONENTIAL,
                 min_range=0,
             )
@@ -127,7 +127,7 @@ class TestSearchParameters(unittest.TestCase):
         with self.assertRaises(GenAIPerfException):
             self.search_parameters._add_search_parameter(
                 name="concurrency",
-                usage=SearchUsage.RUNTIME,
+                usage=SearchUsage.RUNTIME_PA,
                 category=SearchCategory.EXPONENTIAL,
                 min_range=10,
                 max_range=9,
@@ -203,7 +203,7 @@ class TestSearchParameters(unittest.TestCase):
         # Batch size
         # =====================================================================
         runtime_batch_size = search_parameters.get_parameter("runtime_batch_size")
-        self.assertEqual(SearchUsage.RUNTIME, runtime_batch_size.usage)
+        self.assertEqual(SearchUsage.RUNTIME_PA, runtime_batch_size.usage)
         self.assertEqual(SearchCategory.INT_LIST, runtime_batch_size.category)
         self.assertEqual(
             RunConfigDefaults.PA_BATCH_SIZE, runtime_batch_size.enumerated_list
@@ -230,7 +230,7 @@ class TestSearchParameters(unittest.TestCase):
         search_parameters = SearchParameters(config)
 
         concurrency = search_parameters.get_parameter("concurrency")
-        self.assertEqual(SearchUsage.RUNTIME, concurrency.usage)
+        self.assertEqual(SearchUsage.RUNTIME_PA, concurrency.usage)
         self.assertEqual(SearchCategory.EXPONENTIAL, concurrency.category)
         self.assertEqual(log2(RunConfigDefaults.MIN_CONCURRENCY), concurrency.min_range)
         self.assertEqual(log2(RunConfigDefaults.MAX_CONCURRENCY), concurrency.max_range)
@@ -245,7 +245,7 @@ class TestSearchParameters(unittest.TestCase):
         search_parameters = SearchParameters(config)
 
         request_rate = search_parameters.get_parameter("request_rate")
-        self.assertEqual(SearchUsage.RUNTIME, request_rate.usage)
+        self.assertEqual(SearchUsage.RUNTIME_PA, request_rate.usage)
         self.assertEqual(SearchCategory.EXPONENTIAL, request_rate.category)
         self.assertEqual(
             log2(RunConfigDefaults.MIN_REQUEST_RATE), request_rate.min_range
@@ -342,7 +342,7 @@ class TestSearchParameters(unittest.TestCase):
     #     concurrency = analyzer._search_parameters["add_sub"].get_parameter(
     #         "concurrency"
     #     )
-    #     self.assertEqual(SearchUsage.RUNTIME, concurrency.usage)
+    #     self.assertEqual(SearchUsage.RUNTIME_PA, concurrency.usage)
     #     self.assertEqual(SearchCategory.EXPONENTIAL, concurrency.category)
     #     self.assertEqual(
     #         log2(default.DEFAULT_RUN_CONFIG_MIN_CONCURRENCY), concurrency.min_range

--- a/genai-perf/tests/test_sweep_objective_generator.py
+++ b/genai-perf/tests/test_sweep_objective_generator.py
@@ -28,8 +28,8 @@ class TestSweepObjectiveGenerator(unittest.TestCase):
     def setUp(self):
         self._config = ConfigCommand(model_names=["test_modelA", "test_modelB"])
         self._model_search_parameters = {
-            "test_modelA": SearchParameters(self._config),
-            "test_modelB": SearchParameters(self._config),
+            "test_modelA": SearchParameters(self._config.optimize),
+            "test_modelB": SearchParameters(self._config.optimize),
         }
 
         self._sweep_obj_gen = SweepObjectiveGenerator(


### PR DESCRIPTION
Since we are transitioning to supporting Analyze (versus Optimize) first I have added support for Analyze to the SearchParameters class (in addition to adding it to the temporary ConfigCommand class).

Example usage is:

Analyze:
   concurrency: [1, 4, 8, 16]
   num_prompts: 
       min: 10
       max: 100

As part of this I've differentiated between runtime options that are passed to PA and those that are used internally in GAP.
