### PR TITLE
Create RunConfig class

### DIFF
--- a/genai-perf/genai_perf/config/generate/genai_perf_config.py
+++ b/genai-perf/genai_perf/config/generate/genai_perf_config.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from copy import deepcopy
 from dataclasses import dataclass
+from typing import Any, Dict
 
 from genai_perf.config.generate.search_parameter import SearchUsage
 from genai_perf.config.input.config_command import (
     ConfigCommand,
     ConfigInput,
     ConfigOutputTokens,
+    ConfigSyntheticTokens,
 )
 from genai_perf.types import ModelObjectiveParameters
 
@@ -56,3 +59,37 @@ class GenAIPerfConfig:
                         self.input.__setattr__(
                             name, parameter.get_value_based_on_category()
                         )
+
+    ###########################################################################
+    # Checkpoint Methods
+    ###########################################################################
+    def write_to_checkpoint(self) -> Dict[str, Any]:
+        """
+        Converts the class data into a dictionary that can be written to
+        the checkpoint file
+        """
+        genai_perf_config_dict = deepcopy(self.__dict__)
+
+        return genai_perf_config_dict
+
+    @classmethod
+    def read_from_checkpoint(
+        cls, genai_perf_config_dict: Dict[str, Any]
+    ) -> "GenAIPerfConfig":
+        """
+        Takes the checkpoint's representation of the class and creates (and populates)
+        a new instance of a GenAIPerfConfig
+        """
+        genai_perf_config = GenAIPerfConfig(
+            config=ConfigCommand([""]),
+            model_objective_parameters={},
+        )
+        genai_perf_config.input = ConfigInput(**genai_perf_config_dict["input"])
+        genai_perf_config.input.synthetic_tokens = ConfigSyntheticTokens(
+            **genai_perf_config_dict["input"]["synthetic_tokens"]
+        )
+        genai_perf_config.output_tokens = ConfigOutputTokens(
+            **genai_perf_config_dict["output_tokens"]
+        )
+
+        return genai_perf_config

--- a/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
+++ b/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any, Dict, List
 
 from genai_perf.config.generate.search_parameter import SearchUsage
@@ -20,6 +22,7 @@ from genai_perf.exceptions import GenAIPerfException
 from genai_perf.types import ModelName, ModelObjectiveParameters
 
 
+@dataclass
 class PerfAnalyzerConfig:
     """
     Contains all the methods necessary for handling calls
@@ -147,3 +150,35 @@ class PerfAnalyzerConfig:
             cli_str_tokens.pop(removal_index)
 
         return " ".join(cli_str_tokens)
+
+    ###########################################################################
+    # Checkpoint Methods
+    ###########################################################################
+    def write_to_checkpoint(self) -> Dict[str, Any]:
+        """
+        Converts the class data into a dictionary that can be written to
+        the checkpoint file
+        """
+        pa_config_dict = deepcopy(self.__dict__)
+
+        return pa_config_dict
+
+    @classmethod
+    def read_from_checkpoint(
+        cls, perf_analyzer_config_dict: Dict[str, Any]
+    ) -> "PerfAnalyzerConfig":
+        """
+        Takes the checkpoint's representation of the class and creates (and populates)
+        a new instance of a PerfAnalyzerConfig
+        """
+        perf_analyzer_config = PerfAnalyzerConfig(
+            model_name=perf_analyzer_config_dict["_model_name"],
+            config=ConfigCommand([""]),
+            model_objective_parameters={},
+        )
+        perf_analyzer_config._config = ConfigPerfAnalyzer(
+            **perf_analyzer_config_dict["_config"]
+        )
+        perf_analyzer_config._parameters = perf_analyzer_config_dict["_parameters"]
+
+        return perf_analyzer_config

--- a/genai-perf/genai_perf/config/generate/search_parameters.py
+++ b/genai-perf/genai_perf/config/generate/search_parameters.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from math import log2
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from genai_perf.config.generate.objective_parameter import ObjectiveCategory
 from genai_perf.config.generate.search_parameter import (

--- a/genai-perf/genai_perf/config/generate/search_parameters.py
+++ b/genai-perf/genai_perf/config/generate/search_parameters.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from math import log2
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from genai_perf.config.generate.objective_parameter import ObjectiveCategory
 from genai_perf.config.generate.search_parameter import (

--- a/genai-perf/genai_perf/config/run/run_config.py
+++ b/genai-perf/genai_perf/config/run/run_config.py
@@ -1,0 +1,167 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from functools import total_ordering
+from typing import Any, Dict, Optional
+
+from genai_perf.config.generate.genai_perf_config import GenAIPerfConfig
+from genai_perf.config.generate.perf_analyzer_config import PerfAnalyzerConfig
+from genai_perf.measurements.run_config_measurement import RunConfigMeasurement
+from genai_perf.measurements.run_constraints import RunConstraints
+from genai_perf.record.record import Record
+from genai_perf.types import (
+    GpuRecords,
+    MetricObjectives,
+    ModelName,
+    ModelWeights,
+    PerfMetricName,
+    PerfRecords,
+    RunConfigName,
+)
+
+
+@dataclass
+@total_ordering
+class RunConfig:
+    """
+    Encapsulates all the information needed to profile a model
+    and capture the results
+    """
+
+    # TODO: OPTIMIZE
+    # triton_env: Dict[str, Any]
+    # model_run_configs: List[ModelRunConfig]
+
+    name: RunConfigName
+    genai_perf_config: GenAIPerfConfig
+    perf_analyzer_config: PerfAnalyzerConfig
+    measurement: RunConfigMeasurement
+
+    ###########################################################################
+    # Checkpoint Methods
+    ###########################################################################
+    def write_to_checkpoint(self) -> Dict[str, Any]:
+        """
+        Converts the class data into a dictionary that can be written to
+        the checkpoint file
+        """
+        run_config_dict = {
+            "name": self.name,
+            "genai_perf_config": self.genai_perf_config.write_to_checkpoint(),
+            "perf_analyzer_config": self.perf_analyzer_config.write_to_checkpoint(),
+            "measurement": self.measurement.write_to_checkpoint(),
+        }
+
+        return run_config_dict
+
+    @classmethod
+    def read_from_checkpoint(cls, run_config_dict: Dict[str, Any]) -> "RunConfig":
+        """
+        Takes the checkpoint's representation of the class and creates (and populates)
+        a new instance of a RCM
+        """
+        name = run_config_dict["name"]
+        genai_perf_config = GenAIPerfConfig.read_from_checkpoint(
+            run_config_dict["genai_perf_config"]
+        )
+        perf_analyzer_config = PerfAnalyzerConfig.read_from_checkpoint(
+            run_config_dict["perf_analyzer_config"]
+        )
+        measurement = RunConfigMeasurement.read_from_checkpoint(
+            run_config_dict["measurement"]
+        )
+
+        run_config = RunConfig(
+            name, genai_perf_config, perf_analyzer_config, measurement
+        )
+
+        return run_config
+
+    ###########################################################################
+    # Get Accessor Methods
+    ###########################################################################
+    def get_all_gpu_metrics(self) -> GpuRecords:
+        return self.measurement.get_all_gpu_metrics()
+
+    def get_gpu_metric(self, name: str) -> Optional[GpuRecords]:
+        return self.measurement.get_gpu_metric(name)
+
+    def get_all_perf_metrics(self) -> Dict[ModelName, PerfRecords]:
+        return self.measurement.get_all_perf_metrics()
+
+    def get_model_perf_metrics(self, model_name: ModelName) -> Optional[PerfRecords]:
+        return self.measurement.get_model_perf_metrics(model_name)
+
+    def get_model_perf_metric(
+        self, model_name: ModelName, perf_metric_name: PerfMetricName
+    ) -> Optional[Record]:
+        return self.measurement.get_model_perf_metric(model_name, perf_metric_name)
+
+    def get_model_perf_metric_value(
+        self,
+        model_name: ModelName,
+        perf_metric_name: PerfMetricName,
+        return_value: int = 0,
+    ) -> Any:
+        return self.measurement.get_model_perf_metric_value(
+            model_name, perf_metric_name, return_value
+        )
+
+    def get_weighted_perf_metric_values(
+        self,
+        perf_metric_name: PerfMetricName,
+        return_value: int = 0,
+    ) -> Dict[ModelName, Any]:
+        return self.measurement.get_weighted_perf_metric_values(
+            perf_metric_name, return_value
+        )
+
+    ###########################################################################
+    # Set Accessor Methods
+    ###########################################################################
+    def set_model_weighting(self, model_weights: ModelWeights) -> None:
+        self.measurement.set_model_weighting(model_weights)
+
+    def set_gpu_metric_objectives(
+        self, gpu_metric_objectives: Dict[ModelName, MetricObjectives]
+    ) -> None:
+        self.measurement.set_gpu_metric_objectives(gpu_metric_objectives)
+
+    def set_perf_metric_objectives(
+        self, perf_metric_objectives: Dict[ModelName, MetricObjectives]
+    ) -> None:
+        self.measurement.set_perf_metric_objectives(perf_metric_objectives)
+
+    def set_constraints(self, constraints: RunConstraints) -> None:
+        self.measurement.set_constraints(constraints)
+
+    def add_perf_metrics(
+        self,
+        model_name: ModelName,
+        perf_metrics: PerfRecords,
+    ) -> None:
+        self.measurement.add_perf_metrics(model_name, perf_metrics)
+
+    ###########################################################################
+    # Comparison Methods
+    ###########################################################################
+    def __lt__(self, other: "RunConfig") -> bool:
+        return self.measurement < other.measurement
+
+    def __gt__(self, other: "RunConfig") -> bool:
+        return self.measurement > other.measurement
+
+    def __eq__(self, other: "RunConfig") -> bool:  # type: ignore
+        return self.measurement == other.measurement

--- a/genai-perf/genai_perf/measurements/model_config_measurement.py
+++ b/genai-perf/genai_perf/measurements/model_config_measurement.py
@@ -20,7 +20,7 @@ from statistics import mean
 from typing import Any, Dict, Optional, TypeAlias
 
 from genai_perf.record.record import Record
-from genai_perf.types import MetricObjectives, ModelName, PerfRecords
+from genai_perf.types import MetricObjectives, ModelName, PerfMetricName, PerfRecords
 
 ###########################################################################
 # Typing
@@ -66,10 +66,10 @@ class ModelConfigMeasurement:
     def get_perf_metrics(self) -> PerfRecords:
         return self._perf_metrics
 
-    def get_perf_metric(self, name: str) -> Optional[Record]:
+    def get_perf_metric(self, name: PerfMetricName) -> Optional[Record]:
         return self._perf_metrics[name] if name in self._perf_metrics else None
 
-    def get_perf_metric_value(self, name: str, return_value: int = 0) -> Any:
+    def get_perf_metric_value(self, name: PerfMetricName, return_value: int = 0) -> Any:
         metric = self.get_perf_metric(name)
         return metric.value() if metric else return_value
 

--- a/genai-perf/genai_perf/measurements/run_config_measurement.py
+++ b/genai-perf/genai_perf/measurements/run_config_measurement.py
@@ -34,6 +34,7 @@ from genai_perf.types import (
     GpuRecords,
     ModelName,
     ModelWeights,
+    PerfMetricName,
     PerfRecords,
 )
 
@@ -145,7 +146,7 @@ class RunConfigMeasurement:
             return None
 
     def get_model_perf_metric(
-        self, model_name: ModelName, perf_metric_name: str
+        self, model_name: ModelName, perf_metric_name: PerfMetricName
     ) -> Optional[Record]:
         if model_name in self._model_config_measurements:
             return self._model_config_measurements[model_name].get_perf_metric(
@@ -155,7 +156,10 @@ class RunConfigMeasurement:
             return None
 
     def get_model_perf_metric_value(
-        self, model_name: ModelName, perf_metric_name: str, return_value: int = 0
+        self,
+        model_name: ModelName,
+        perf_metric_name: PerfMetricName,
+        return_value: int = 0,
     ) -> Any:
         if model_name in self._model_config_measurements:
             return self._model_config_measurements[model_name].get_perf_metric_value(
@@ -166,7 +170,7 @@ class RunConfigMeasurement:
 
     def get_weighted_perf_metric_values(
         self,
-        perf_metric_name: str,
+        perf_metric_name: PerfMetricName,
         return_value: int = 0,
     ) -> Dict[ModelName, Any]:
         """

--- a/genai-perf/genai_perf/types.py
+++ b/genai-perf/genai_perf/types.py
@@ -37,6 +37,7 @@ GpuId: TypeAlias = str
 TelemetryRecords: TypeAlias = Dict[str, "GPURecord"]  # type: ignore
 GpuRecords: TypeAlias = Dict[GpuId, TelemetryRecords]
 PerfRecords: TypeAlias = Dict[str, "Record"]  # type: ignore
+PerfMetricName: TypeAlias = str
 
 ###########################################################################
 # Constraints
@@ -51,3 +52,8 @@ Constraints: TypeAlias = Dict[ConstraintName, ConstraintValue]
 # Objectives
 ###########################################################################
 MetricObjectives: TypeAlias = Dict[str, float]
+
+###########################################################################
+# Run Config
+###########################################################################
+RunConfigName: TypeAlias = str

--- a/genai-perf/tests/test_genai_perf_config.py
+++ b/genai-perf/tests/test_genai_perf_config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import unittest
 from unittest.mock import patch
 
@@ -26,6 +27,7 @@ from genai_perf.config.input.config_command import (
     ConfigInput,
     ConfigOutputTokens,
 )
+from genai_perf.utils import checkpoint_encoder
 
 
 class TestGenAIPerfConfig(unittest.TestCase):
@@ -70,6 +72,30 @@ class TestGenAIPerfConfig(unittest.TestCase):
 
         self.assertEqual(
             expected_output_tokens_config, self._default_genai_perf_config.output_tokens
+        )
+
+    ###########################################################################
+    # Checkpoint Tests
+    ###########################################################################
+    def test_checkpoint_methods(self):
+        """
+        Checks to ensure checkpoint methods work as intended
+        """
+        genai_perf_config_json = json.dumps(
+            self._default_genai_perf_config, default=checkpoint_encoder
+        )
+
+        genai_perf_config_from_checkpoint = GenAIPerfConfig.read_from_checkpoint(
+            json.loads(genai_perf_config_json)
+        )
+
+        self.assertEqual(
+            genai_perf_config_from_checkpoint.input,
+            self._default_genai_perf_config.input,
+        )
+        self.assertEqual(
+            genai_perf_config_from_checkpoint.output_tokens,
+            self._default_genai_perf_config.output_tokens,
         )
 
 

--- a/genai-perf/tests/test_perf_analyzer_config.py
+++ b/genai-perf/tests/test_perf_analyzer_config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -22,6 +23,7 @@ from genai_perf.config.generate.objective_parameter import (
 from genai_perf.config.generate.perf_analyzer_config import PerfAnalyzerConfig
 from genai_perf.config.generate.search_parameters import SearchUsage
 from genai_perf.config.input.config_command import ConfigCommand, ConfigPerfAnalyzer
+from genai_perf.utils import checkpoint_encoder
 
 
 class TestPerfAnalyzerConfig(unittest.TestCase):
@@ -153,6 +155,37 @@ class TestPerfAnalyzerConfig(unittest.TestCase):
 
         expected_representation = ""
         self.assertEqual(expected_representation, representation)
+
+    ###########################################################################
+    # Checkpoint Tests
+    ###########################################################################
+    def test_checkpoint_methods(self):
+        """
+        Checks to ensure checkpoint methods work as intended
+        """
+        pa_config_json = json.dumps(
+            self._default_perf_analyzer_config, default=checkpoint_encoder
+        )
+
+        pa_config_from_checkpoint = PerfAnalyzerConfig.read_from_checkpoint(
+            json.loads(pa_config_json)
+        )
+
+        self.assertEqual(
+            pa_config_from_checkpoint._model_name,
+            self._default_perf_analyzer_config._model_name,
+        )
+        self.assertEqual(
+            pa_config_from_checkpoint._config,
+            self._default_perf_analyzer_config._config,
+        )
+        self.assertEqual(
+            pa_config_from_checkpoint._parameters,
+            self._default_perf_analyzer_config._parameters,
+        )
+
+        # Catchall in case something new is added
+        self.assertEqual(pa_config_from_checkpoint, self._default_perf_analyzer_config)
 
 
 if __name__ == "__main__":

--- a/genai-perf/tests/test_run_config.py
+++ b/genai-perf/tests/test_run_config.py
@@ -1,0 +1,88 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import unittest
+from unittest.mock import patch
+
+from genai_perf.config.generate.genai_perf_config import GenAIPerfConfig
+from genai_perf.config.generate.perf_analyzer_config import PerfAnalyzerConfig
+from genai_perf.config.input.config_command import ConfigCommand
+from genai_perf.config.run.run_config import RunConfig
+from genai_perf.utils import checkpoint_encoder
+from tests.test_utils import create_perf_metrics, create_run_config_measurement
+
+
+class TestRunConfig(unittest.TestCase):
+    ###########################################################################
+    # Setup & Teardown
+    ###########################################################################
+    def setUp(self):
+        self._config = ConfigCommand(model_names=["test_model"])
+
+        self._baseline_genai_perf_config = GenAIPerfConfig(
+            config=self._config, model_objective_parameters={}
+        )
+        self._baseline_perf_analyzer_config = PerfAnalyzerConfig(
+            model_name="test_model", config=self._config, model_objective_parameters={}
+        )
+
+        self._perf_metrics = create_perf_metrics(throughput=1000, latency=50)
+        self._baseline_rcm = create_run_config_measurement(
+            gpu_power=80, gpu_utilization=70
+        )
+        self._baseline_rcm.add_perf_metrics("test_model", self._perf_metrics)
+
+        self._run_config = RunConfig(
+            name="test_run_config",
+            genai_perf_config=self._baseline_genai_perf_config,
+            perf_analyzer_config=self._baseline_perf_analyzer_config,
+            measurement=self._baseline_rcm,
+        )
+
+    def tearDown(self):
+        patch.stopall()
+
+    ###########################################################################
+    # Checkpoint Tests
+    ###########################################################################
+    def test_checkpoint_methods(self):
+        """
+        Checks to ensure checkpoint methods work as intended
+        """
+        run_config_json = json.dumps(self._run_config, default=checkpoint_encoder)
+
+        run_config_from_checkpoint = RunConfig.read_from_checkpoint(
+            json.loads(run_config_json)
+        )
+
+        self.assertEqual(run_config_from_checkpoint.name, self._run_config.name)
+        self.assertEqual(
+            run_config_from_checkpoint.genai_perf_config,
+            self._run_config.genai_perf_config,
+        )
+        self.assertEqual(
+            run_config_from_checkpoint.perf_analyzer_config,
+            self._run_config.perf_analyzer_config,
+        )
+        self.assertEqual(
+            run_config_from_checkpoint.measurement, self._run_config.measurement
+        )
+
+        # Catchall in case something new is added
+        self.assertEqual(run_config_from_checkpoint, self._run_config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the `RunConfig` class which holds all the state information about a single profile in GAP:

- Run name
- PA config info
- GAP config info
- Measurements (metrics coming back from PA)
- (in the future this will also hold information about triton/endpoint configuration when Optimize is coded)

As part of this story I've also added in the missing checkpoint support for the PA/GAP config classes. 

For high level context: 

Each instance of profiling (calling PA to get metrics) has a corresponding RunConfig and a group of these will be stored in (the next to be coded) `Results` class. The Results are then stored in the checkpoint file which will be read when GAP is called (by any subcommand). 

Built-in to this class are all the methods necessary to get configuration and metrics information for each time the model was profiled. This can be used both as inputs to other subcommands (like Visualize) or to skip over known results when re-profiling a model.