### PR TITLE
Create Generic Dataset

### DIFF
--- a/genai-perf/genai_perf/inputs/converters/base_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/base_converter.py
@@ -25,18 +25,19 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import random
-from typing import Dict, List, Union, cast
+from typing import Dict, List, Union
 
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.inputs.input_constants import ModelSelectionStrategy
 from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 
 
 class BaseConverter:
 
     _CONTENT_NAMES: List[str]
 
-    def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
+    def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict:
         """
         Construct a request body using the endpoint specific request format.
         """
@@ -53,31 +54,27 @@ class BaseConverter:
             )
 
     def _construct_text_payload_batch_agnostic(
-        self, batch_size_text: int, input_data: Union[Dict, List]
+        self, batch_size_text: int, input_data: List
     ) -> Union[str, List]:
         """
         Construct text payload content for non-chat based LLM converters.
         Allow batched and unbatched input data.
         """
         if batch_size_text == 1:
-            input_data = cast(Dict, input_data)
             return self._construct_text_payload(input_data)
         else:
-            input_data = cast(List, input_data)
             return self._construct_batched_text_payload(input_data)
 
-    def _construct_text_payload(self, input_data: Dict) -> str:
+    def _construct_text_payload(self, input_data: List[str]) -> str:
         """
         Construct text payload content for non-chat based LLM converters.
         Since there are no roles or turns in non-chat LLM endpoints, all the
         (pre-defined) text contents are concatenated into a single text prompt.
         """
-        contents = [v for k, v in input_data.items() if k in self._CONTENT_NAMES]
-        return " ".join(contents)
+        return " ".join(input_data)
 
-    def _construct_batched_text_payload(self, input_data: List) -> List:
+    def _construct_batched_text_payload(self, input_data: List[str]) -> List:
         """
         Construct batched text payload content for non-chat based LLM converters.
         """
-        contents = [item["text"] for item in input_data]
-        return contents
+        return input_data

--- a/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
@@ -51,18 +51,19 @@ class OpenAICompletionsConverter(BaseConverter):
     def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict:
         request_body: Dict[str, Any] = {"data": []}
 
-        for index, entry in enumerate(generic_dataset["rows"]):
-            model_name = self._select_model_name(config, index)
-            prompt = self._construct_text_payload(entry)
+        for file_data in generic_dataset.files_data.values():
+            for index, row in enumerate(file_data.rows):
+                model_name = self._select_model_name(config, index)
+                prompt = self._construct_text_payload(row.texts)
 
-            payload = {
-                "model": model_name,
-                "prompt": prompt,
-            }
-            self._add_request_params(payload, config)
-            request_body["data"].append({"payload": [payload]})
+                payload = {
+                    "model": model_name,
+                    "prompt": prompt,
+                }
+                self._add_request_params(payload, config)
+                request_body["data"].append({"payload": [payload]})
 
-        return request_body
+            return request_body
 
     def _add_request_params(self, payload: Dict, config: InputsConfig) -> None:
         if config.add_stream:

--- a/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
@@ -30,6 +30,7 @@ from typing import Any, Dict
 from genai_perf.inputs.converters.base_converter import BaseConverter
 from genai_perf.inputs.input_constants import DEFAULT_OUTPUT_TOKENS_MEAN
 from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 
 
 class OpenAICompletionsConverter(BaseConverter):
@@ -47,7 +48,7 @@ class OpenAICompletionsConverter(BaseConverter):
         "article",
     ]
 
-    def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
+    def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict:
         request_body: Dict[str, Any] = {"data": []}
 
         for index, entry in enumerate(generic_dataset["rows"]):

--- a/genai-perf/genai_perf/inputs/converters/openai_embeddings_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_embeddings_converter.py
@@ -28,6 +28,7 @@ from typing import Any, Dict
 
 from genai_perf.inputs.converters.base_converter import BaseConverter
 from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 
 
 class OpenAIEmbeddingsConverter(BaseConverter):
@@ -36,7 +37,7 @@ class OpenAIEmbeddingsConverter(BaseConverter):
         "text",
     ]
 
-    def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
+    def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict:
         request_body: Dict[str, Any] = {"data": []}
 
         for index, entry in enumerate(generic_dataset["rows"]):

--- a/genai-perf/genai_perf/inputs/converters/output_format_converter_factory.py
+++ b/genai-perf/genai_perf/inputs/converters/output_format_converter_factory.py
@@ -27,7 +27,6 @@
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.inputs.converters import *
 from genai_perf.inputs.input_constants import OutputFormat
-from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 
 
 class OutputFormatConverterFactory:

--- a/genai-perf/genai_perf/inputs/converters/output_format_converter_factory.py
+++ b/genai-perf/genai_perf/inputs/converters/output_format_converter_factory.py
@@ -27,6 +27,7 @@
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.inputs.converters import *
 from genai_perf.inputs.input_constants import OutputFormat
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 
 
 class OutputFormatConverterFactory:

--- a/genai-perf/genai_perf/inputs/converters/rankings_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/rankings_converter.py
@@ -28,11 +28,12 @@ from typing import Any, Dict
 
 from genai_perf.inputs.converters.base_converter import BaseConverter
 from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 
 
 class RankingsConverter(BaseConverter):
 
-    def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
+    def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict:
         request_body: Dict[str, Any] = {"data": []}
 
         for index, entry in enumerate(generic_dataset["rows"]):

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
@@ -33,6 +33,7 @@ from genai_perf.inputs.input_constants import (
     DEFAULT_TENSORRTLLM_MAX_TOKENS,
 )
 from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 
 
 class TensorRTLLMConverter(BaseConverter):
@@ -46,7 +47,7 @@ class TensorRTLLMConverter(BaseConverter):
         "article",
     ]
 
-    def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
+    def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict:
         request_body: Dict[str, Any] = {"data": []}
 
         for index, entry in enumerate(generic_dataset["rows"]):

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
@@ -33,11 +33,12 @@ from genai_perf.inputs.input_constants import (
     DEFAULT_TENSORRTLLM_MAX_TOKENS,
 )
 from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 
 
 class TensorRTLLMEngineConverter(BaseConverter):
 
-    def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
+    def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict:
         request_body: Dict[str, Any] = {"data": []}
 
         for _, entry in enumerate(generic_dataset["rows"]):

--- a/genai-perf/genai_perf/inputs/converters/vllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/vllm_converter.py
@@ -31,6 +31,7 @@ from typing import Any, Dict
 from genai_perf.inputs.converters.base_converter import BaseConverter
 from genai_perf.inputs.input_constants import DEFAULT_OUTPUT_TOKENS_MEAN
 from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 
 
 class VLLMConverter(BaseConverter):
@@ -44,7 +45,7 @@ class VLLMConverter(BaseConverter):
         "article",
     ]
 
-    def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
+    def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict:
         request_body: Dict[str, Any] = {"data": []}
 
         for index, entry in enumerate(generic_dataset["rows"]):

--- a/genai-perf/genai_perf/inputs/inputs.py
+++ b/genai-perf/genai_perf/inputs/inputs.py
@@ -45,7 +45,7 @@ class Inputs:
 
         random.seed(self.config.random_seed)
 
-    def create_inputs(self) -> Dict:
+    def create_inputs(self) -> None:
         """
         Given an input type, input format, and output type. Output a string of LLM Inputs
         (in a JSON dictionary) to a file.
@@ -58,7 +58,6 @@ class Inputs:
             generic_dataset_json,
         )
         self._write_json_to_file(json_in_pa_format)
-        return json_in_pa_format
 
     def _check_for_valid_args(self) -> None:
         self._check_for_supported_input_type()

--- a/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
@@ -28,10 +28,6 @@ import random
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-import random
-from pathlib import Path
-from typing import List, Tuple
-
 from genai_perf.inputs.input_constants import DEFAULT_BATCH_SIZE, OutputFormat
 from genai_perf.inputs.inputs_config import InputsConfig
 from genai_perf.inputs.retrievers.generic_dataset import DataRow, FileData, GenericDataset

--- a/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
@@ -50,8 +50,8 @@ class FileInputRetriever:
         else:
             #TODO: Add multi-file case
             file_data = self._get_input_dataset_from_file(self.config.input_filename)
-            generic_dataset = GenericDataset()
-            generic_dataset.set_file_data(file_data)
+            files_data = {file_data.filename: file_data}
+            generic_dataset = GenericDataset(files_data)
             return generic_dataset
 
     def _read_rankings_input_files(

--- a/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
+++ b/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
@@ -35,9 +35,8 @@ GenericDatasetDict: TypeAlias = Dict[Filename, List[DataRowDict]]
 
 @dataclass
 class DataRow:
-    def __init__(self, texts: List[str], images: List[str]):
-        self.texts = texts
-        self.images = images
+    texts: List[str]
+    images: List[str]
 
     def to_dict(self) -> DataRowDict:
         """

--- a/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
+++ b/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
@@ -25,6 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from typing import Dict, List, TypeAlias
+from dataclasses import dataclass
 
 Filename: TypeAlias = str
 TypeOfData: TypeAlias = str
@@ -32,7 +33,7 @@ ListOfData: TypeAlias = List[str]
 DataRowDict: TypeAlias = Dict[TypeOfData, ListOfData]
 GenericDatasetDict: TypeAlias = Dict[Filename, List[DataRowDict]]
 
-
+@dataclass
 class DataRow:
     def __init__(self, texts: List[str], images: List[str]):
         self.texts = texts
@@ -44,11 +45,10 @@ class DataRow:
         """
         return {"texts": self.texts, "images": self.images}
 
-
+@dataclass
 class FileData:
-    def __init__(self, filename: str, rows: List[DataRow]):
-        self.filename = filename
-        self.rows = rows
+    filename: str
+    rows: List[DataRow]
 
     def to_dict(self) -> Dict[Filename, List[DataRowDict]]:
         """
@@ -63,18 +63,9 @@ class FileData:
         """
         return {self.filename: [row.to_dict() for row in self.rows]}
 
-
+@dataclass
 class GenericDataset:
-    def __init__(self):
-        self.files_data: Dict[str, FileData] = {}
-
-    def set_file_data(self, file_data: FileData):
-        self.files_data[file_data.filename] = file_data
-
-    def set_dataset(self, filename, texts, images):
-        data_row = DataRow(texts, images)
-        files_data = FileData(filename, [data_row])
-        self.set_file_data(files_data)
+    files_data: Dict[str, FileData]
 
     def to_dict(self) -> GenericDatasetDict:
         """

--- a/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
+++ b/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
@@ -1,0 +1,93 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Dict, List, TypeAlias
+
+Filename: TypeAlias = str
+TypeOfData: TypeAlias = str
+ListOfData: TypeAlias = List[str]
+DataRowDict: TypeAlias = Dict[TypeOfData, ListOfData]
+GenericDatasetDict: TypeAlias = Dict[Filename, List[DataRowDict]]
+
+
+class DataRow:
+    def __init__(self, texts: List[str], images: List[str]):
+        self.texts = texts
+        self.images = images
+
+    def to_dict(self) -> DataRowDict:
+        """
+        Converts the DataRow object to a dictionary.
+        """
+        return {"texts": self.texts, "images": self.images}
+
+
+class FileData:
+    def __init__(self, filename: str, rows: List[DataRow]):
+        self.filename = filename
+        self.rows = rows
+
+    def to_dict(self) -> Dict[Filename, List[DataRowDict]]:
+        """
+        Converts the FileData object to a dictionary.
+        Output format example for two payloads from a file:
+        {
+            'file_0': [
+                {'texts': ['text1', 'text2'], 'images': ['image1', 'image2']},
+                {'texts': ['text3', 'text4'], 'images': ['image3', 'image4']}
+            ]
+        }
+        """
+        return {self.filename: [row.to_dict() for row in self.rows]}
+
+
+class GenericDataset:
+    def __init__(self):
+        self.files_data: Dict[str, FileData] = {}
+
+    def set_file_data(self, file_data: FileData):
+        self.files_data[file_data.filename] = file_data
+
+    def set_dataset(self, filename, texts, images):
+        data_row = DataRow(texts, images)
+        files_data = FileData(filename, [data_row])
+        self.set_file_data(files_data)
+
+    def to_dict(self) -> GenericDatasetDict:
+        """
+        Converts the entire DataStructure object to a dictionary.
+        Output format example for one payload from two files:
+        {
+            {
+            'file_0': [{'texts': ['text1', 'text2'], 'images': ['image1', 'image2']}],
+            'file_1': [{'texts': ['text1', 'text2'], 'images': ['image1', 'image2']}]
+        }
+        }
+        """
+        return {
+            filename: file_data.to_dict()[filename]
+            for filename, file_data in self.files_data.items()
+        }

--- a/genai-perf/genai_perf/inputs/retrievers/input_retriever_factory.py
+++ b/genai-perf/genai_perf/inputs/retrievers/input_retriever_factory.py
@@ -89,7 +89,6 @@ class InputRetrieverFactory:
     def _convert_input_synthetic_or_file_dataset_to_generic_json(
         self, dataset: Dict
     ) -> Dict[str, List[Dict]]:
-        raise GenAIPerfException("STOP")
         generic_dataset_json = self._convert_dataset_to_generic_input_json(dataset)
 
         return generic_dataset_json

--- a/genai-perf/genai_perf/inputs/retrievers/input_retriever_factory.py
+++ b/genai-perf/genai_perf/inputs/retrievers/input_retriever_factory.py
@@ -74,7 +74,7 @@ class InputRetrieverFactory:
         else:
             if self.config.input_type == PromptSource.SYNTHETIC:
                 synthetic_retriever = SyntheticDataRetriever(self.config)
-                synthetic_dataset = synthetic_retriever.retrieve_data()
+                input_data = synthetic_retriever.retrieve_data()
                 # synthetic_dataset = self._get_input_dataset_from_synthetic()
             elif self.config.input_type == PromptSource.FILE:
                 # TODO: remove once the factory fully integrates retrievers


### PR DESCRIPTION
This PR pushes the initial work done by @debermudez and me to create a generic dataset class. As a proof of concept, we have added it to work here for the file input case for the chat endpoint.

The target feature branch will contain all of the code changes to support generic dataset class as the new approach. This branch sets up the initial class with this one working pathway, so that the remaining work can be parallelized.

The testing will be broken until all of the pathways are fixed and any relevant tests are updated.

Input command:
```bash
genai-perf profile   -m HuggingFaceH4/zephyr-7b-beta   --service-kind openai   --endpoint-type chat   --synthetic-input-tokens-mean 200   --synthetic-input-tokens-stddev 0   --output-tokens-mean 100   --output-tokens-stddev 0   --streaming   --tokenizer HuggingFaceH4/zephyr-7b-beta --input-file rankings_jsonl/queries.jsonl
```

![image](https://github.com/user-attachments/assets/d898f745-9add-4048-9cef-c4029fa9ea9f)
