### PR TITLE
Add multi-file support to file retriever

### DIFF
--- a/genai-perf/genai_perf/inputs/converters/base_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/base_converter.py
@@ -25,18 +25,19 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import random
-from typing import Dict, List, Union, cast
+from typing import Dict, List, Union
 
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.inputs.input_constants import ModelSelectionStrategy
 from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 
 
 class BaseConverter:
 
     _CONTENT_NAMES: List[str]
 
-    def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
+    def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict:
         """
         Construct a request body using the endpoint specific request format.
         """
@@ -53,31 +54,27 @@ class BaseConverter:
             )
 
     def _construct_text_payload_batch_agnostic(
-        self, batch_size_text: int, input_data: Union[Dict, List]
+        self, batch_size_text: int, input_data: List
     ) -> Union[str, List]:
         """
         Construct text payload content for non-chat based LLM converters.
         Allow batched and unbatched input data.
         """
         if batch_size_text == 1:
-            input_data = cast(Dict, input_data)
             return self._construct_text_payload(input_data)
         else:
-            input_data = cast(List, input_data)
             return self._construct_batched_text_payload(input_data)
 
-    def _construct_text_payload(self, input_data: Dict) -> str:
+    def _construct_text_payload(self, input_data: List[str]) -> str:
         """
         Construct text payload content for non-chat based LLM converters.
         Since there are no roles or turns in non-chat LLM endpoints, all the
         (pre-defined) text contents are concatenated into a single text prompt.
         """
-        contents = [v for k, v in input_data.items() if k in self._CONTENT_NAMES]
-        return " ".join(contents)
+        return " ".join(input_data)
 
-    def _construct_batched_text_payload(self, input_data: List) -> List:
+    def _construct_batched_text_payload(self, input_data: List[str]) -> List:
         """
         Construct batched text payload content for non-chat based LLM converters.
         """
-        contents = [item["text"] for item in input_data]
-        return contents
+        return input_data

--- a/genai-perf/genai_perf/inputs/converters/openai_embeddings_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_embeddings_converter.py
@@ -28,6 +28,7 @@ from typing import Any, Dict
 
 from genai_perf.inputs.converters.base_converter import BaseConverter
 from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 
 
 class OpenAIEmbeddingsConverter(BaseConverter):
@@ -36,7 +37,7 @@ class OpenAIEmbeddingsConverter(BaseConverter):
         "text",
     ]
 
-    def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
+    def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict:
         request_body: Dict[str, Any] = {"data": []}
 
         for index, entry in enumerate(generic_dataset["rows"]):

--- a/genai-perf/genai_perf/inputs/converters/rankings_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/rankings_converter.py
@@ -28,11 +28,12 @@ from typing import Any, Dict
 
 from genai_perf.inputs.converters.base_converter import BaseConverter
 from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 
 
 class RankingsConverter(BaseConverter):
 
-    def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
+    def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict:
         request_body: Dict[str, Any] = {"data": []}
 
         for index, entry in enumerate(generic_dataset["rows"]):

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
@@ -33,6 +33,7 @@ from genai_perf.inputs.input_constants import (
     DEFAULT_TENSORRTLLM_MAX_TOKENS,
 )
 from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 
 
 class TensorRTLLMConverter(BaseConverter):
@@ -46,7 +47,7 @@ class TensorRTLLMConverter(BaseConverter):
         "article",
     ]
 
-    def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
+    def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict:
         request_body: Dict[str, Any] = {"data": []}
 
         for index, entry in enumerate(generic_dataset["rows"]):

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
@@ -33,11 +33,12 @@ from genai_perf.inputs.input_constants import (
     DEFAULT_TENSORRTLLM_MAX_TOKENS,
 )
 from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 
 
 class TensorRTLLMEngineConverter(BaseConverter):
 
-    def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
+    def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict:
         request_body: Dict[str, Any] = {"data": []}
 
         for _, entry in enumerate(generic_dataset["rows"]):

--- a/genai-perf/genai_perf/inputs/converters/vllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/vllm_converter.py
@@ -31,6 +31,7 @@ from typing import Any, Dict
 from genai_perf.inputs.converters.base_converter import BaseConverter
 from genai_perf.inputs.input_constants import DEFAULT_OUTPUT_TOKENS_MEAN
 from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 
 
 class VLLMConverter(BaseConverter):
@@ -44,7 +45,7 @@ class VLLMConverter(BaseConverter):
         "article",
     ]
 
-    def convert(self, generic_dataset: Dict, config: InputsConfig) -> Dict:
+    def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict:
         request_body: Dict[str, Any] = {"data": []}
 
         for index, entry in enumerate(generic_dataset["rows"]):

--- a/genai-perf/genai_perf/inputs/inputs.py
+++ b/genai-perf/genai_perf/inputs/inputs.py
@@ -45,7 +45,7 @@ class Inputs:
 
         random.seed(self.config.random_seed)
 
-    def create_inputs(self) -> Dict:
+    def create_inputs(self) -> None:
         """
         Given an input type, input format, and output type. Output a string of LLM Inputs
         (in a JSON dictionary) to a file.
@@ -58,7 +58,6 @@ class Inputs:
             generic_dataset_json,
         )
         self._write_json_to_file(json_in_pa_format)
-        return json_in_pa_format
 
     def _check_for_valid_args(self) -> None:
         self._check_for_supported_input_type()

--- a/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
@@ -30,8 +30,8 @@ from typing import Any, Dict, List, Tuple
 
 from genai_perf.inputs.input_constants import DEFAULT_BATCH_SIZE, OutputFormat
 from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import DataRow, FileData, GenericDataset
 from genai_perf.utils import load_json_str
-
 
 class FileInputRetriever:
     """
@@ -42,20 +42,25 @@ class FileInputRetriever:
     def __init__(self, config: InputsConfig) -> None:
         self.config = config
 
-    # TODO: match return type to retriever interface
-    def retrieve_data(self) -> Dict[str, Any]:
+    def retrieve_data(self) -> GenericDataset:
         if self.config.output_format == OutputFormat.RANKINGS:
             queries_filename = self.config.input_filename / "queries.jsonl"
             passages_filename = self.config.input_filename / "passages.jsonl"
             return self._read_rankings_input_files(queries_filename, passages_filename)
         else:
-            return self._get_input_dataset_from_file()
+            #TODO: Add multi-file case
+            file_data = self._get_input_dataset_from_file(self.config.input_filename)
+            files_data = {file_data.filename: file_data}
+            generic_dataset = GenericDataset(files_data)
+            return generic_dataset
 
     def _read_rankings_input_files(
         self,
         queries_filename: Path,
         passages_filename: Path,
-    ) -> Dict[str, Any]:
+    ) -> GenericDataset:
+        
+        # TODO: Fix rankings retrieval
 
         def __key_exists(line: Dict):
             """Validation function that checks if 'text' key exists."""
@@ -90,7 +95,7 @@ class FileInputRetriever:
             dataset_json["rows"].append({"row": data})
         return dataset_json
 
-    def _get_input_dataset_from_file(self) -> Dict[str, Any]:
+    def _get_input_dataset_from_file(self, filename: Path) -> FileData:
         """
         Returns
         -------
@@ -108,53 +113,25 @@ class FileInputRetriever:
             raise ValueError(
                 "Batch size for texts cannot be larger than the number of available texts"
             )
-
-        dataset_json: Dict[str, Any] = {}
-        dataset_json["features"] = [{"name": "text"}]
-        dataset_json["rows"] = []
+        
+        data_rows: List[DataRow] = []
 
         if (
             self.config.batch_size_text == DEFAULT_BATCH_SIZE
             and self.config.batch_size_image == DEFAULT_BATCH_SIZE
         ):
             for prompt, image in zip(prompts, images):
-                content = {}
-                if prompt is not None:
-                    content["text"] = prompt
-                if image is not None:
-                    content["image"] = image
-                dataset_json["rows"].append({"row": content})
+                data_rows.append(DataRow(texts=[prompt], images=[image]))
         else:
             for _ in range(self.config.num_prompts):
-                content_array = []
-                sampled_image_indices = random.sample(
-                    range(len(prompts)), self.config.batch_size_image
-                )
-                sampled_text_indices = random.sample(
-                    range(len(prompts)), self.config.batch_size_text
-                )
+                sampled_images = random.sample(images, self.config.batch_size_image)
+                sampled_texts = random.sample(prompts, self.config.batch_size_text)
+                data_rows.append(DataRow(texts=sampled_texts, images=sampled_images))
 
-                sampled_images = [images[i] for i in sampled_image_indices]
-                sampled_texts = [prompts[i] for i in sampled_text_indices]
-
-                max_samples = max(len(sampled_texts), len(sampled_images))
-                num_sampled_images = len(sampled_images)
-                num_sampled_texts = len(sampled_texts)
-
-                for i in range(max_samples):
-                    content = {}
-                    if i < num_sampled_images:
-                        content["image"] = sampled_images[i]
-                    if i < num_sampled_texts:
-                        content["text"] = sampled_texts[i]
-
-                    content_array.append(content)
-
-                dataset_json["rows"].append({"row": content_array})
-
-        return dataset_json
+        return FileData(str(filename), data_rows)
 
     def _verify_file(self) -> None:
+        #TODO: Verify directory OR file
         if not self.config.input_filename.exists():
             raise FileNotFoundError(
                 f"The file '{self.config.input_filename}' does not exist."

--- a/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
+++ b/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
@@ -1,0 +1,83 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Dict, List, TypeAlias
+from dataclasses import dataclass
+
+Filename: TypeAlias = str
+TypeOfData: TypeAlias = str
+ListOfData: TypeAlias = List[str]
+DataRowDict: TypeAlias = Dict[TypeOfData, ListOfData]
+GenericDatasetDict: TypeAlias = Dict[Filename, List[DataRowDict]]
+
+@dataclass
+class DataRow:
+    texts: List[str]
+    images: List[str]
+
+    def to_dict(self) -> DataRowDict:
+        """
+        Converts the DataRow object to a dictionary.
+        """
+        return {"texts": self.texts, "images": self.images}
+
+@dataclass
+class FileData:
+    filename: str
+    rows: List[DataRow]
+
+    def to_dict(self) -> Dict[Filename, List[DataRowDict]]:
+        """
+        Converts the FileData object to a dictionary.
+        Output format example for two payloads from a file:
+        {
+            'file_0': [
+                {'texts': ['text1', 'text2'], 'images': ['image1', 'image2']},
+                {'texts': ['text3', 'text4'], 'images': ['image3', 'image4']}
+            ]
+        }
+        """
+        return {self.filename: [row.to_dict() for row in self.rows]}
+
+@dataclass
+class GenericDataset:
+    files_data: Dict[str, FileData]
+
+    def to_dict(self) -> GenericDatasetDict:
+        """
+        Converts the entire DataStructure object to a dictionary.
+        Output format example for one payload from two files:
+        {
+            {
+            'file_0': [{'texts': ['text1', 'text2'], 'images': ['image1', 'image2']}],
+            'file_1': [{'texts': ['text1', 'text2'], 'images': ['image1', 'image2']}]
+        }
+        }
+        """
+        return {
+            filename: file_data.to_dict()[filename]
+            for filename, file_data in self.files_data.items()
+        }

--- a/genai-perf/genai_perf/inputs/retrievers/input_retriever_factory.py
+++ b/genai-perf/genai_perf/inputs/retrievers/input_retriever_factory.py
@@ -24,7 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Any, Dict, List
+from typing import Dict, List
 
 from genai_perf import utils
 from genai_perf.exceptions import GenAIPerfException
@@ -33,13 +33,7 @@ from genai_perf.inputs.inputs_config import InputsConfig
 from genai_perf.inputs.retrievers.file_input_retriever import FileInputRetriever
 from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
 from genai_perf.inputs.retrievers.synthetic_data_retriever import SyntheticDataRetriever
-from genai_perf.inputs.retrievers.synthetic_image_generator import (
-    ImageFormat,
-    SyntheticImageGenerator,
-)
-from genai_perf.inputs.retrievers.synthetic_prompt_generator import (
-    SyntheticPromptGenerator,
-)
+from genai_perf.inputs.retrievers.synthetic_image_generator import ImageFormat
 from PIL import Image
 from requests import Response
 
@@ -75,7 +69,6 @@ class InputRetrieverFactory:
             if self.config.input_type == PromptSource.SYNTHETIC:
                 synthetic_retriever = SyntheticDataRetriever(self.config)
                 input_data = synthetic_retriever.retrieve_data()
-                # synthetic_dataset = self._get_input_dataset_from_synthetic()
             elif self.config.input_type == PromptSource.FILE:
                 # TODO: remove once the factory fully integrates retrievers
                 file_retriever = FileInputRetriever(self.config)
@@ -101,63 +94,6 @@ class InputRetrieverFactory:
                         payload = self._encode_image(image)
                         row.images[i] = payload
 
-    def _convert_input_url_dataset_to_generic_json(self, dataset: Response) -> Dict:
-        dataset_json = dataset.json()
-        try:
-            self._check_for_error_in_json_of_dataset(dataset_json)
-        except Exception as e:
-            raise GenAIPerfException(e)
-
-        generic_dataset_json = self._convert_dataset_to_generic_input_json(dataset_json)
-
-        return generic_dataset_json
-
-    def _get_input_dataset_from_synthetic(self) -> Dict[str, Any]:
-        dataset_json: Dict[str, Any] = {}
-        dataset_json["features"] = [{"name": "text"}]
-        dataset_json["rows"] = []
-        for _ in range(self.config.num_prompts):
-            row: Dict["str", Any] = {"row": {}}
-            synthetic_prompt = self._create_synthetic_prompt()
-            row["row"]["text"] = synthetic_prompt
-
-            if self.config.output_format == OutputFormat.OPENAI_VISION:
-                synthetic_image = self._create_synthetic_image()
-                row["row"]["image"] = synthetic_image
-
-            dataset_json["rows"].append(row)
-
-        return dataset_json
-
-    def _convert_dataset_to_generic_input_json(
-        self, dataset_json: Dict
-    ) -> Dict[str, List[Dict]]:
-        generic_input_json = self._add_features_to_generic_json({}, dataset_json)
-        generic_input_json = self._add_rows_to_generic_json(
-            generic_input_json, dataset_json
-        )
-
-        return generic_input_json
-
-    def _add_features_to_generic_json(
-        self, generic_input_json: Dict, dataset_json: Dict
-    ) -> Dict:
-        if "features" in dataset_json.keys():
-            generic_input_json["features"] = []
-            for feature in dataset_json["features"]:
-                generic_input_json["features"].append(feature["name"])
-
-        return generic_input_json
-
-    def _add_rows_to_generic_json(
-        self, generic_input_json: Dict, dataset_json: Dict
-    ) -> Dict[str, List[Dict]]:
-        generic_input_json["rows"] = []
-        for row in dataset_json["rows"]:
-            generic_input_json["rows"].append(row["row"])
-
-        return generic_input_json
-
     def _encode_image(self, filename: str) -> str:
         img = Image.open(filename)
         if img is None:
@@ -180,19 +116,3 @@ class InputRetrieverFactory:
     def _check_for_error_in_json_of_dataset(self, dataset_json: Dict) -> None:
         if "error" in dataset_json:
             raise GenAIPerfException(dataset_json["error"])
-
-    def _create_synthetic_prompt(self) -> str:
-        return SyntheticPromptGenerator.create_synthetic_prompt(
-            self.config.tokenizer,
-            self.config.prompt_tokens_mean,
-            self.config.prompt_tokens_stddev,
-        )
-
-    def _create_synthetic_image(self) -> str:
-        return SyntheticImageGenerator.create_synthetic_image(
-            image_width_mean=self.config.image_width_mean,
-            image_width_stddev=self.config.image_width_stddev,
-            image_height_mean=self.config.image_height_mean,
-            image_height_stddev=self.config.image_height_stddev,
-            image_format=self.config.image_format,
-        )

--- a/genai-perf/genai_perf/inputs/retrievers/input_retriever_factory.py
+++ b/genai-perf/genai_perf/inputs/retrievers/input_retriever_factory.py
@@ -31,6 +31,8 @@ from genai_perf.exceptions import GenAIPerfException
 from genai_perf.inputs.input_constants import OutputFormat, PromptSource
 from genai_perf.inputs.inputs_config import InputsConfig
 from genai_perf.inputs.retrievers.file_input_retriever import FileInputRetriever
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
+from genai_perf.inputs.retrievers.synthetic_data_retriever import SyntheticDataRetriever
 from genai_perf.inputs.retrievers.synthetic_image_generator import (
     ImageFormat,
     SyntheticImageGenerator,
@@ -46,7 +48,7 @@ class InputRetrieverFactory:
     def __init__(self, config: InputsConfig):
         self.config = config
 
-    def get_input_data(self) -> Dict:
+    def get_input_data(self) -> GenericDataset:
         """
         Retrieve and convert the dataset based on the input type.
 
@@ -56,6 +58,7 @@ class InputRetrieverFactory:
             The generic dataset JSON
         """
 
+        input_data: GenericDataset = None
         if self.config.output_format in [
             OutputFormat.OPENAI_EMBEDDINGS,
             OutputFormat.RANKINGS,
@@ -68,34 +71,20 @@ class InputRetrieverFactory:
             if self.config.output_format == OutputFormat.IMAGE_RETRIEVAL:
                 input_data = self._encode_images_in_input_dataset(input_data)
 
-            generic_dataset_json = (
-                self._convert_input_synthetic_or_file_dataset_to_generic_json(
-                    input_data
-                )
-            )
         else:
             if self.config.input_type == PromptSource.SYNTHETIC:
-                synthetic_dataset = self._get_input_dataset_from_synthetic()
-                generic_dataset_json = (
-                    self._convert_input_synthetic_or_file_dataset_to_generic_json(
-                        synthetic_dataset
-                    )
-                )
+                synthetic_retriever = SyntheticDataRetriever(self.config)
+                input_data = synthetic_retriever.retrieve_data()
+                # synthetic_dataset = self._get_input_dataset_from_synthetic()
             elif self.config.input_type == PromptSource.FILE:
                 # TODO: remove once the factory fully integrates retrievers
                 file_retriever = FileInputRetriever(self.config)
                 input_data = file_retriever.retrieve_data()
-
-                input_file_dataset = self._encode_images_in_input_dataset(input_data)
-                generic_dataset_json = (
-                    self._convert_input_synthetic_or_file_dataset_to_generic_json(
-                        input_file_dataset
-                    )
-                )
+                self._encode_images_in_input_dataset(input_data)
             else:
                 raise GenAIPerfException("Input source is not recognized.")
 
-        return generic_dataset_json
+        return input_data
 
     def _convert_input_synthetic_or_file_dataset_to_generic_json(
         self, dataset: Dict
@@ -104,21 +93,13 @@ class InputRetrieverFactory:
 
         return generic_dataset_json
 
-    def _encode_images_in_input_dataset(self, input_file_dataset: Dict) -> Dict:
-        for row in input_file_dataset["rows"]:
-            if isinstance(row["row"], list):
-                for content in row["row"]:
-                    filename = content.get("image")
-                    if filename:
-                        payload = self._encode_image(filename)
-                        content["image"] = payload
-            else:
-                filename = row["row"].get("image")
-                if filename:
-                    payload = self._encode_image(filename)
-                    row["row"]["image"] = payload
-
-        return input_file_dataset
+    def _encode_images_in_input_dataset(self, input_file_dataset: GenericDataset):
+        for file_data in input_file_dataset.files_data.values():
+            for row in file_data.rows:
+                for i, image in enumerate(row.images):
+                    if image is not None:
+                        payload = self._encode_image(image)
+                        row.images[i] = payload
 
     def _convert_input_url_dataset_to_generic_json(self, dataset: Response) -> Dict:
         dataset_json = dataset.json()

--- a/genai-perf/genai_perf/inputs/retrievers/synthetic_data_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/synthetic_data_retriever.py
@@ -25,9 +25,14 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-from typing import Any, Dict, List
+from typing import List
 
 from genai_perf.inputs.input_constants import OutputFormat
+from genai_perf.inputs.retrievers.generic_dataset import (
+    DataRow,
+    FileData,
+    GenericDataset,
+)
 from genai_perf.inputs.retrievers.synthetic_image_generator import (
     SyntheticImageGenerator,
 )
@@ -44,15 +49,16 @@ class SyntheticDataRetriever:
     def __init__(self, config):
         self.config = config
 
-    def retrieve_data(self) -> List[Dict[str, Any]]:
-        synthetic_dataset = []
+    def retrieve_data(self) -> GenericDataset:
+        data_rows: List[DataRow] = []
         for _ in range(self.config.num_prompts):
+            row = DataRow(texts=[], images=[])
             prompt = SyntheticPromptGenerator.create_synthetic_prompt(
                 self.config.tokenizer,
                 self.config.prompt_tokens_mean,
                 self.config.prompt_tokens_stddev,
             )
-            data = {"text": prompt}
+            row.texts.append(prompt)
 
             if self.config.output_format == OutputFormat.OPENAI_VISION:
                 image = SyntheticImageGenerator.create_synthetic_image(
@@ -62,7 +68,10 @@ class SyntheticDataRetriever:
                     image_height_stddev=self.config.image_height_stddev,
                     image_format=self.config.image_format,
                 )
-                data["image"] = image
+                row.images.append(image)
+            data_rows.append(row)
+        file_name = "synthetic_dataset"
+        file_data = FileData(file_name, data_rows)
+        synthetic_dataset = GenericDataset({file_name: file_data})
 
-            synthetic_dataset.append(data)
         return synthetic_dataset


### PR DESCRIPTION
Add multi-file support to file retriever. Now, an input directory can be passed and all JSONL files will be read in it and passed into GenericDataset.

In addition, this works gets rid of the rankings-specific retrieval code and updates the rankings converter to use GenericDataset.

![image](https://github.com/user-attachments/assets/9a2d0a24-0fe9-4e39-a2ee-a84c73ce654e)
