### PR TITLE
Add client-side batching support for synthetic inputs

### DIFF
--- a/genai-perf/genai_perf/inputs/converters/openai_embeddings_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_embeddings_converter.py
@@ -40,16 +40,14 @@ class OpenAIEmbeddingsConverter(BaseConverter):
     def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict[Any, Any]:
         request_body: Dict[str, Any] = {"data": []}
 
-        for index, entry in enumerate(generic_dataset["rows"]):
-            text = self._construct_text_payload_batch_agnostic(
-                config.batch_size_text, entry
-            )
-            model_name = self._select_model_name(config, index)
+        for file_data in generic_dataset.files_data.values():
+            for index, row in enumerate(file_data.rows):
+                model_name = self._select_model_name(config, index)
 
-            payload = {
-                "model": model_name,
-                "input": text,
-            }
+                payload = {
+                    "model": model_name,
+                    "input": row.texts,
+                }
             self._add_request_params(payload, config)
             request_body["data"].append({"payload": [payload]})
 

--- a/genai-perf/genai_perf/inputs/inputs.py
+++ b/genai-perf/genai_perf/inputs/inputs.py
@@ -76,7 +76,6 @@ class Inputs:
 
     def _check_for_supported_input_type(self) -> None:
         if self.config.output_format in [
-            OutputFormat.OPENAI_EMBEDDINGS,
             OutputFormat.RANKINGS,
             OutputFormat.IMAGE_RETRIEVAL,
         ]:

--- a/genai-perf/genai_perf/inputs/retrievers/input_retriever_factory.py
+++ b/genai-perf/genai_perf/inputs/retrievers/input_retriever_factory.py
@@ -54,7 +54,6 @@ class InputRetrieverFactory:
 
         input_data: GenericDataset = None
         if self.config.output_format in [
-            OutputFormat.OPENAI_EMBEDDINGS,
             OutputFormat.RANKINGS,
             OutputFormat.IMAGE_RETRIEVAL,
         ]:

--- a/genai-perf/genai_perf/inputs/retrievers/synthetic_data_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/synthetic_data_retriever.py
@@ -27,7 +27,7 @@
 
 from typing import List
 
-from genai_perf.inputs.input_constants import OutputFormat
+from genai_perf.inputs.inputs_config import InputsConfig
 from genai_perf.inputs.retrievers.generic_dataset import (
     DataRow,
     FileData,
@@ -47,7 +47,7 @@ class SyntheticDataRetriever:
     """
 
     def __init__(self, config):
-        self.config = config
+        self.config: InputsConfig = config
 
     def retrieve_data(self) -> GenericDataset:
         data_rows: List[DataRow] = []
@@ -58,16 +58,17 @@ class SyntheticDataRetriever:
                 self.config.prompt_tokens_mean,
                 self.config.prompt_tokens_stddev,
             )
-            row.texts.append(prompt)
+            for _ in range(self.config.batch_size_text):
+                row.texts.append(prompt)
 
-            if self.config.output_format == OutputFormat.OPENAI_VISION:
+            for _ in range(self.config.batch_size_image):
                 image = SyntheticImageGenerator.create_synthetic_image(
-                    image_width_mean=self.config.image_width_mean,
-                    image_width_stddev=self.config.image_width_stddev,
-                    image_height_mean=self.config.image_height_mean,
-                    image_height_stddev=self.config.image_height_stddev,
-                    image_format=self.config.image_format,
-                )
+                        image_width_mean=self.config.image_width_mean,
+                        image_width_stddev=self.config.image_width_stddev,
+                        image_height_mean=self.config.image_height_mean,
+                        image_height_stddev=self.config.image_height_stddev,
+                        image_format=self.config.image_format,
+                    )
                 row.images.append(image)
             data_rows.append(row)
         file_name = "synthetic_dataset"


### PR DESCRIPTION
This pull request adds client-side batching support for synthetic inputs. As a proof of concept, it hooks up the embeddings converter, which now works for both file inputs and synthetic inputs with batching.

Batching with synthetic input data:
<img width="1277" alt="image" src="https://github.com/user-attachments/assets/dd21ef09-b1dd-4961-b69e-6d77dccf43f2">

Batching with file input data:
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/367fe5c6-0258-466c-8226-712ef572ff55">
