### PR TITLE
Add multi-file support for synthetic.

### DIFF
--- a/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
@@ -39,7 +39,7 @@ class OpenAIChatCompletionsConverter(BaseConverter):
     def check_config(self, config: InputsConfig) -> None:
         if config.output_format == OutputFormat.IMAGE_RETRIEVAL:
             if config.add_stream:
-                raise GenAIPerfException(f"The --streaming option is not supported for {config.output_format.to_lowercase}.")
+                raise GenAIPerfException(f"The --streaming option is not supported for {config.output_format.to_lowercase()}.")
             # TODO: Confirm that this is required. This may work with synthetic now.
             if config.input_type != PromptSource.FILE:
                 raise GenAIPerfException(
@@ -48,9 +48,9 @@ class OpenAIChatCompletionsConverter(BaseConverter):
                 )
         else:
             if config.batch_size_image != DEFAULT_BATCH_SIZE:
-                raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase}.")
+                raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase()}.")
         if config.batch_size_text != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase}.")
+            raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase()}.")
 
 
     def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict[Any, Any]:

--- a/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
@@ -38,9 +38,9 @@ class OpenAICompletionsConverter(BaseConverter):
 
     def check_config(self, config: InputsConfig) -> None:
         if config.batch_size_image != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase}.")
+            raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase()}.")
         if config.batch_size_text != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase}.")
+            raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase()}.")
 
     def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict[Any, Any]:
         request_body: Dict[str, Any] = {"data": []}

--- a/genai-perf/genai_perf/inputs/converters/openai_embeddings_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_embeddings_converter.py
@@ -36,9 +36,9 @@ class OpenAIEmbeddingsConverter(BaseConverter):
 
     def check_config(self, config: InputsConfig) -> None:
         if config.add_stream:
-            raise GenAIPerfException(f"The --streaming option is not supported for {config.output_format.to_lowercase}.")
+            raise GenAIPerfException(f"The --streaming option is not supported for {config.output_format.to_lowercase()}.")
         if config.batch_size_image != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase}.")
+            raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase()}.")
     
     def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict[Any, Any]:
         request_body: Dict[str, Any] = {"data": []}

--- a/genai-perf/genai_perf/inputs/converters/rankings_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/rankings_converter.py
@@ -36,14 +36,7 @@ class RankingsConverter(BaseConverter):
 
     def check_config(self, config: InputsConfig) -> None:
         if config.add_stream:
-            raise GenAIPerfException(f"The --streaming option is not supported for {config.output_format.to_lowercase}.")
-        if config.batch_size_text != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase}.")
-        if config.input_type != "file":
-            raise GenAIPerfException(
-                f"{config.output_format.to_lowercase()} only supports "
-                "a file as input source."
-            )
+            raise GenAIPerfException(f"The --streaming option is not supported for {config.output_format.to_lowercase()}.")
     
     def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict[Any, Any]:
         provided_filenames = list(generic_dataset.files_data.keys())

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
@@ -41,9 +41,9 @@ class TensorRTLLMConverter(BaseConverter):
 
     def check_config(self, config: InputsConfig) -> None:
         if config.batch_size_image != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase}.")
+            raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase()}.")
         if config.batch_size_text != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase}.")
+            raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase()}.")
     
     def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict[Any, Any]:
         request_body: Dict[str, Any] = {"data": []}

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
@@ -40,9 +40,9 @@ from genai_perf.inputs.input_constants import DEFAULT_BATCH_SIZE
 class TensorRTLLMEngineConverter(BaseConverter):
     def check_config(self, config: InputsConfig) -> None:
         if config.batch_size_image != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase}.")
+            raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase()}.")
         if config.batch_size_text != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase}.")
+            raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase()}.")
     
     def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict[Any, Any]:
         request_body: Dict[str, Any] = {"data": []}

--- a/genai-perf/genai_perf/inputs/converters/vllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/vllm_converter.py
@@ -39,9 +39,9 @@ class VLLMConverter(BaseConverter):
 
     def check_config(self, config: InputsConfig) -> None:
         if config.batch_size_image != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase}.")
+            raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase()}.")
         if config.batch_size_text != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase}.")
+            raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase()}.")
     
     def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict[Any, Any]:
         request_body: Dict[str, Any] = {"data": []}

--- a/genai-perf/genai_perf/inputs/input_constants.py
+++ b/genai-perf/genai_perf/inputs/input_constants.py
@@ -58,6 +58,7 @@ class OutputFormat(Enum):
 ###########################
 DEFAULT_INPUT_DATA_JSON = "inputs.json"
 DEFAULT_RANDOM_SEED = 0
+DEFAULT_SYNTHETIC_FILENAME = "synthetic_data.json"
 
 
 ###########################

--- a/genai-perf/genai_perf/inputs/inputs_config.py
+++ b/genai-perf/genai_perf/inputs/inputs_config.py
@@ -26,7 +26,7 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from genai_perf.inputs.input_constants import (
     DEFAULT_IMAGE_HEIGHT_MEAN,
@@ -72,7 +72,10 @@ class InputsConfig:
     extra_inputs: Dict = field(default_factory=dict)
 
     # The filename where the input data is available
-    input_filename: Path = Path("")
+    input_filename: Optional[Path] = Path("")
+
+    # The filenames used for synthetic data generation
+    synthetic_input_filenames: Optional[List[str]] = field(default_factory=list)
 
     # The compression format of the images.
     image_format: ImageFormat = ImageFormat.PNG

--- a/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
@@ -26,7 +26,7 @@
 
 import random
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import cast, Dict, List, Tuple
 
 from genai_perf import utils
 from genai_perf.exceptions import GenAIPerfException
@@ -56,6 +56,7 @@ class FileInputRetriever(BaseInputRetriever):
         """
 
         files_data: Dict[str, FileData] = {}
+        self.config.input_filename = cast(Path, self.config.input_filename)
         if self.config.input_filename.is_dir():
             jsonl_files = list(self.config.input_filename.glob("*.jsonl"))
             if not jsonl_files:

--- a/genai-perf/genai_perf/inputs/retrievers/input_retriever_factory.py
+++ b/genai-perf/genai_perf/inputs/retrievers/input_retriever_factory.py
@@ -47,5 +47,5 @@ class InputRetrieverFactory:
         input_type = config.input_type
         if input_type not in retrievers:
             raise GenAIPerfException(f"Input source '{input_type}' is not recognized.")
-        retriever_class = retrievers[input_type]()
-        return retriever_class(config)
+        return retrievers[input_type](config)
+        

--- a/genai-perf/genai_perf/main.py
+++ b/genai-perf/genai_perf/main.py
@@ -62,11 +62,6 @@ def create_artifacts_dirs(args: Namespace) -> None:
 
 
 def create_config_options(args: Namespace) -> InputsConfig:
-    if args.input_file:
-        filepath, _ = args.input_file
-        input_filename = Path(filepath)
-    else:
-        input_filename = Path(".")
 
     try:
         extra_input_dict = parser.get_extra_inputs_as_dict(args)
@@ -78,7 +73,8 @@ def create_config_options(args: Namespace) -> InputsConfig:
         output_format=args.output_format,
         model_name=args.model,
         model_selection_strategy=args.model_selection_strategy,
-        input_filename=input_filename,
+        input_filename=args.input_file,
+        synthetic_input_filenames=args.synthetic_input_files,
         starting_index=DEFAULT_STARTING_INDEX,
         length=args.num_prompts,
         prompt_tokens_mean=args.synthetic_input_tokens_mean,

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -102,6 +102,7 @@ class Profiler:
             # required for decoupled models into triton).
             "streaming",
             "subcommand",
+            "synthetic_input_files",
             "synthetic_input_tokens_mean",
             "synthetic_input_tokens_stddev",
             "tokenizer",


### PR DESCRIPTION
Add multi-file support for synthetic. You can now use `--input-file` to select synthetic filenames by prepending `synthetic:` to a comma-separated list. For example `synthetic:passages,rankings`. This makes new converters more easily able to use multiple types of inputs via multi-file inputs via the synthetic path as well.

Additional clean-up:
- Fixed the function call for the error messages in the check_config functions
- Removed unnecessary checks now that this path is supported
- Cleaned up the input file parser help message

Screenshot of the new feature (synthetic multi-file):
<img width="1267" alt="image" src="https://github.com/user-attachments/assets/8427bd1f-2386-4e6e-96c8-9d96a9aaac3f">
