### PR TITLE
Support client-side batching for legacy completions endpoint

### DIFF
--- a/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
@@ -64,7 +64,7 @@ class OpenAIChatCompletionsConverter(BaseConverter):
                 if config.output_format == OutputFormat.OPENAI_CHAT_COMPLETIONS:
                     content = row.texts[0]
                 else:
-                    content += self._add_multi_modal_content(content)
+                    content += self._add_multi_modal_content(row)
 
                 payload = {
                     "model": model_name,

--- a/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
@@ -37,10 +37,7 @@ from genai_perf.inputs.input_constants import DEFAULT_BATCH_SIZE
 class OpenAICompletionsConverter(BaseConverter):
 
     def check_config(self, config: InputsConfig) -> None:
-        if config.batch_size_image != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase()}.")
-        if config.batch_size_text != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase()}.")
+        pass
 
     def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict[Any, Any]:
         request_body: Dict[str, Any] = {"data": []}
@@ -48,7 +45,7 @@ class OpenAICompletionsConverter(BaseConverter):
         for file_data in generic_dataset.files_data.values():
             for index, row in enumerate(file_data.rows):
                 model_name = self._select_model_name(config, index)
-                prompt = row.texts[0]
+                prompt = row.texts
 
                 payload = {
                     "model": model_name,

--- a/genai-perf/genai_perf/inputs/converters/openai_embeddings_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_embeddings_converter.py
@@ -36,9 +36,7 @@ class OpenAIEmbeddingsConverter(BaseConverter):
 
     def check_config(self, config: InputsConfig) -> None:
         if config.add_stream:
-            raise GenAIPerfException(f"The --streaming option is not supported for {config.output_format.to_lowercase()}.")
-        if config.batch_size_image != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase()}.")
+            raise GenAIPerfException(f"The --streaming option is not supported for {config.output_format.to_lowercase}.")
     
     def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict[Any, Any]:
         request_body: Dict[str, Any] = {"data": []}

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
@@ -40,8 +40,6 @@ from genai_perf.inputs.input_constants import DEFAULT_BATCH_SIZE
 class TensorRTLLMConverter(BaseConverter):
 
     def check_config(self, config: InputsConfig) -> None:
-        if config.batch_size_image != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase()}.")
         if config.batch_size_text != DEFAULT_BATCH_SIZE:
             raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase()}.")
     

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
@@ -39,8 +39,6 @@ from genai_perf.inputs.input_constants import DEFAULT_BATCH_SIZE
 
 class TensorRTLLMEngineConverter(BaseConverter):
     def check_config(self, config: InputsConfig) -> None:
-        if config.batch_size_image != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase()}.")
         if config.batch_size_text != DEFAULT_BATCH_SIZE:
             raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase()}.")
     

--- a/genai-perf/genai_perf/inputs/converters/vllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/vllm_converter.py
@@ -38,8 +38,6 @@ from genai_perf.inputs.input_constants import DEFAULT_BATCH_SIZE
 class VLLMConverter(BaseConverter):
 
     def check_config(self, config: InputsConfig) -> None:
-        if config.batch_size_image != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase()}.")
         if config.batch_size_text != DEFAULT_BATCH_SIZE:
             raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase()}.")
     

--- a/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
+++ b/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
@@ -25,7 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from typing import Dict, List, TypeAlias
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 Filename: TypeAlias = str
 TypeOfData: TypeAlias = str
@@ -35,8 +35,8 @@ GenericDatasetDict: TypeAlias = Dict[Filename, List[DataRowDict]]
 
 @dataclass
 class DataRow:
-    texts: List[str]
-    images: List[str]
+    texts: List[str] = field(default_factory=list)
+    images: List[str] = field(default_factory=list)
 
     def to_dict(self) -> DataRowDict:
         """

--- a/genai-perf/genai_perf/inputs/retrievers/input_retriever_factory.py
+++ b/genai-perf/genai_perf/inputs/retrievers/input_retriever_factory.py
@@ -48,4 +48,3 @@ class InputRetrieverFactory:
         if input_type not in retrievers:
             raise GenAIPerfException(f"Input source '{input_type}' is not recognized.")
         return retrievers[input_type](config)
-        

--- a/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
+++ b/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
@@ -246,7 +246,7 @@ class LLMProfileDataParser(ProfileDataParser):
         if self._response_format == ResponseFormat.OPENAI_CHAT_COMPLETIONS:
             return payload["messages"][0]["content"]
         elif self._response_format == ResponseFormat.OPENAI_COMPLETIONS:
-            return "".join(payload["prompt"])
+            return " ".join(payload["prompt"])
         elif self._response_format == ResponseFormat.OPENAI_VISION:
             content = payload["messages"][0]["content"]
             return " ".join(c["text"] for c in content if c["type"] == "text")

--- a/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
+++ b/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
@@ -246,7 +246,7 @@ class LLMProfileDataParser(ProfileDataParser):
         if self._response_format == ResponseFormat.OPENAI_CHAT_COMPLETIONS:
             return payload["messages"][0]["content"]
         elif self._response_format == ResponseFormat.OPENAI_COMPLETIONS:
-            return payload["prompt"]
+            return "".join(payload["prompt"])
         elif self._response_format == ResponseFormat.OPENAI_VISION:
             content = payload["messages"][0]["content"]
             return " ".join(c["text"] for c in content if c["type"] == "text")


### PR DESCRIPTION
The OpenAI completions legacy endpoint supports client-side batching, so add support for it.

In addition, the following cleanup:
- Remove irrelevant batching checks
- Fix add_multi_model_content to use the correct input arg so that chat completions endpoint works for multi-modal models

Screenshot of client-side batching working for completions endpoint:
<img width="1288" alt="image" src="https://github.com/user-attachments/assets/5de4ae71-0f8c-4f57-acfb-6c1c8d7d991f">
