### PR TITLE
Allow image retrieval endpoint to use synthetic data

### DIFF
--- a/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
@@ -40,9 +40,11 @@ class OpenAIChatCompletionsConverter(BaseConverter):
         if config.output_format == OutputFormat.IMAGE_RETRIEVAL:
             if config.add_stream:
                 raise GenAIPerfException(f"The --streaming option is not supported for {config.output_format.to_lowercase()}.")
-        elif config.output_format == OutputFormat.OPENAI_CHAT_COMPLETIONS:
+        else:
             if config.batch_size_text != DEFAULT_BATCH_SIZE:
                 raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase()}.")
+            if config.batch_size_image != DEFAULT_BATCH_SIZE:
+                raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase()}.")
 
 
     def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict[Any, Any]:

--- a/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
@@ -40,17 +40,9 @@ class OpenAIChatCompletionsConverter(BaseConverter):
         if config.output_format == OutputFormat.IMAGE_RETRIEVAL:
             if config.add_stream:
                 raise GenAIPerfException(f"The --streaming option is not supported for {config.output_format.to_lowercase()}.")
-            # TODO: Confirm that this is required. This may work with synthetic now.
-            if config.input_type != PromptSource.FILE:
-                raise GenAIPerfException(
-                    f"{config.output_format.to_lowercase()} only supports "
-                    "a file as input source."
-                )
-        else:
-            if config.batch_size_image != DEFAULT_BATCH_SIZE:
-                raise GenAIPerfException(f"The --batch-size-image flag is not supported for {config.output_format.to_lowercase()}.")
-        if config.batch_size_text != DEFAULT_BATCH_SIZE:
-            raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase()}.")
+        elif config.output_format == OutputFormat.OPENAI_CHAT_COMPLETIONS:
+            if config.batch_size_text != DEFAULT_BATCH_SIZE:
+                raise GenAIPerfException(f"The --batch-size-text flag is not supported for {config.output_format.to_lowercase()}.")
 
 
     def convert(self, generic_dataset: GenericDataset, config: InputsConfig) -> Dict[Any, Any]:


### PR DESCRIPTION
Synthetic now supports client-side batching, so image retrieval can use the synthetic path. 