### PR TITLE
Remove libb64 dynamic library dependency and add source to build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,11 +104,19 @@ include_directories(${Protobuf_INCLUDE_DIRS})
 add_subdirectory(client_backend)
 
 include(FetchContent)
+
 FetchContent_Declare(
   googletest
   URL https://github.com/google/googletest/archive/9406a60c7839052e4944ea4dbc8344762a89f9bd.zip
 )
 FetchContent_MakeAvailable(googletest)
+
+FetchContent_Declare(
+  libb64
+  GIT_REPOSITORY https://git.code.sf.net/p/libb64/git
+  GIT_TAG master
+)
+FetchContent_MakeAvailable(libb64)
 
 find_package(Git REQUIRED)
 
@@ -199,13 +207,25 @@ add_executable(
   ${PERF_ANALYZER_HDRS}
 )
 
+target_sources(
+  perf_analyzer
+  PRIVATE
+    ${libb64_SOURCE_DIR}/src/cdecode.c
+    ${libb64_SOURCE_DIR}/src/cencode.c
+)
+
+target_include_directories(
+  perf_analyzer
+  PRIVATE
+    ${libb64_SOURCE_DIR}/include
+)
+
 target_link_libraries(
   perf_analyzer
   PRIVATE
     ${TRITON_HTTP_STATIC_LIB}
     ${TRITON_GRPC_STATIC_LIB}
     client-backend-library
-    -lb64
     ${CMAKE_DL_LIBS}
 )
 
@@ -332,11 +352,19 @@ add_executable(
   ${TEST_HTTP_CLIENT}
 )
 
-# -Wno-write-strings is needed for the unit tests in order to statically create
-# input argv cases in the CommandLineParser unit test
-#
-set_target_properties(perf_analyzer_unit_tests
-  PROPERTIES COMPILE_FLAGS "-Wno-write-strings")
+target_sources(
+  perf_analyzer_unit_tests
+  PRIVATE
+    ${libb64_SOURCE_DIR}/src/cdecode.c
+    ${libb64_SOURCE_DIR}/src/cencode.c
+)
+
+target_include_directories(
+  perf_analyzer_unit_tests
+  PRIVATE
+    client_backend
+    ${libb64_SOURCE_DIR}/include
+)
 
 if(TRITON_RHEL_BUILD)
   target_compile_definitions(
@@ -345,10 +373,12 @@ if(TRITON_RHEL_BUILD)
   )
 endif(TRITON_RHEL_BUILD)
 
-target_include_directories(
+# -Wno-write-strings is needed for the unit tests in order to statically create
+# input argv cases in the CommandLineParser unit test
+target_compile_options(
   perf_analyzer_unit_tests
   PRIVATE
-    client_backend
+    -Wno-write-strings
 )
 
 target_link_libraries(
@@ -356,7 +386,6 @@ target_link_libraries(
   PRIVATE
     gmock
     client-backend-library
-    -lb64
 )
 
 install(

--- a/src/data_loader.cc
+++ b/src/data_loader.cc
@@ -26,13 +26,9 @@
 
 #include "data_loader.h"
 
-#ifdef TRITON_RHEL_BUILD
 #define BUFFERSIZE BUFSIZ
 #include <b64/decode.h>
 #undef BUFFERSIZE
-#else
-#include <b64/decode.h>
-#endif
 
 #include <rapidjson/filereadstream.h>
 


### PR DESCRIPTION
Perf Analyzer previously expected users to have libb64 installed on their system (e.g. via `apt install libb64-0d`) before being able to run.

This PR removes that runtime dependency by including the libb64 source files in our build.