### PR TITLE
Fix text input for TRT-LLM

### DIFF
--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
@@ -58,7 +58,7 @@ class TensorRTLLMConverter(BaseConverter):
 
                 payload = {
                     "model": model_name,
-                    "text_input": text,
+                    "text_input": [text],
                     "max_tokens": [DEFAULT_TENSORRTLLM_MAX_TOKENS],  # default
                 }
                 self._add_request_params(payload, config)

--- a/genai-perf/tests/test_triton_tensorrtllm_converter.py
+++ b/genai-perf/tests/test_triton_tensorrtllm_converter.py
@@ -72,12 +72,12 @@ class TestTensorRTLLMConverter:
             "data": [
                 {
                     "model": "test_model",
-                    "text_input": "text input one",
+                    "text_input": ["text input one"],
                     "max_tokens": [DEFAULT_TENSORRTLLM_MAX_TOKENS],
                 },
                 {
                     "model": "test_model",
-                    "text_input": "text input two",
+                    "text_input": ["text input two"],
                     "max_tokens": [DEFAULT_TENSORRTLLM_MAX_TOKENS],
                 },
             ]
@@ -109,7 +109,7 @@ class TestTensorRTLLMConverter:
             "data": [
                 {
                     "model": "test_model",
-                    "text_input": "text input one",
+                    "text_input": ["text input one"],
                     "ignore_eos": [True],
                     "max_tokens": [1234],
                     "stream": [True],
@@ -117,7 +117,7 @@ class TestTensorRTLLMConverter:
                 },
                 {
                     "model": "test_model",
-                    "text_input": "text input two",
+                    "text_input": ["text input two"],
                     "ignore_eos": [True],
                     "max_tokens": [1234],
                     "stream": [True],


### PR DESCRIPTION
The TRT-LLM converter switched to providing text as a string instead of a list, which broke the expected payload. This PR reverts the text input to being a list.

Before:
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/6bc2ae2e-c8fd-42b9-bab3-905d1cbc341c">

After:
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/494d7b9a-d98b-4f21-a740-d0d0444cebf4">
