### PR TITLE
Convert cuda runtime dependency from dynamic linking to dynamic loading

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -155,6 +155,7 @@ set(
   profile_data_exporter.cc
   periodic_concurrency_manager.cc
   periodic_concurrency_worker.cc
+  cuda_runtime_library_manager.cc
 )
 
 set(
@@ -198,6 +199,7 @@ set(
   periodic_concurrency_manager.h
   periodic_concurrency_worker.h
   thread_config.h
+  cuda_runtime_library_manager.h
 )
 
 add_executable(
@@ -263,10 +265,9 @@ if(TRITON_ENABLE_GPU)
     PUBLIC TRITON_ENABLE_GPU=1
   )
 
-  target_link_libraries(
-    perf_analyzer
-    PRIVATE CUDA::cudart
-  )
+  target_include_directories(perf_analyzer
+                             PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
+
 endif() # TRITON_ENABLE_GPU
 
 if(TRITON_ENABLE_PERF_ANALYZER_C_API)

--- a/src/client_backend/openai/CMakeLists.txt
+++ b/src/client_backend/openai/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -62,12 +62,8 @@ target_link_libraries(
 )
 
 if(${TRITON_ENABLE_GPU})
-  target_include_directories(openai-client-backend-library PUBLIC ${CUDA_INCLUDE_DIRS})
-  target_link_libraries(
-    openai-client-backend-library
-    PRIVATE ${CUDA_LIBRARIES}
-    PRIVATE CUDA::cudart
-  )
+  target_include_directories(openai-client-backend-library
+                             PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
 
   # Need to enable this compilation flag, otherwise, ipc.h
   # will select mock-struct as opposed to the correct cuda

--- a/src/client_backend/tensorflow_serving/CMakeLists.txt
+++ b/src/client_backend/tensorflow_serving/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -121,12 +121,8 @@ target_link_libraries(
 )
 
 if(${TRITON_ENABLE_GPU})
-  target_include_directories(tfs-client-backend-library PUBLIC ${CUDA_INCLUDE_DIRS})
-  target_link_libraries(
-    tfs-client-backend-library
-    PRIVATE ${CUDA_LIBRARIES}
-    PRIVATE CUDA::cudart
-  )
+  target_include_directories(tfs-client-backend-library
+                             PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
 
   # Need to enable this compilation flag, otherwise, ipc.h
   # will select mock-struct as opposed to the correct cuda

--- a/src/client_backend/torchserve/CMakeLists.txt
+++ b/src/client_backend/torchserve/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -60,12 +60,8 @@ target_link_libraries(
 )
 
 if(${TRITON_ENABLE_GPU})
-  target_include_directories(ts-client-backend-library PUBLIC ${CUDA_INCLUDE_DIRS})
-  target_link_libraries(
-    ts-client-backend-library
-    PRIVATE ${CUDA_LIBRARIES}
-    PRIVATE CUDA::cudart
-  )
+  target_include_directories(ts-client-backend-library
+                             PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
 
   # Need to enable this compilation flag, otherwise, ipc.h
   # will select mock-struct as opposed to the correct cuda

--- a/src/client_backend/triton/CMakeLists.txt
+++ b/src/client_backend/triton/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -84,10 +84,9 @@ if(${TRITON_ENABLE_ZLIB})
 endif()
 
 if(${TRITON_ENABLE_GPU})
-  target_link_libraries(
-    triton-client-backend-library
-    PRIVATE CUDA::cudart
-  )
+  target_include_directories(triton-client-backend-library
+                             PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
+
   # Need to enable this compilation flag, otherwise, ipc.h
   # will select mock-struct as opposed to the correct cuda
   # runtime header file.

--- a/src/client_backend/triton_c_api/CMakeLists.txt
+++ b/src/client_backend/triton_c_api/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -83,10 +83,9 @@ target_link_libraries(
 )
 
 if(${TRITON_ENABLE_GPU})
-  target_link_libraries(
-    triton-c-api-backend-library
-    PRIVATE CUDA::cudart
-  )
+  target_include_directories(triton-c-api-backend-library
+                             PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
+
   # Need to enable this compilation flag, otherwise, ipc.h
   # will select mock-struct as opposed to the correct cuda
   # runtime header file.

--- a/src/cuda_runtime_library_manager.cc
+++ b/src/cuda_runtime_library_manager.cc
@@ -30,7 +30,7 @@ namespace triton::perfanalyzer {
 
 CUDARuntimeLibraryManager::CUDARuntimeLibraryManager()
 {
-  handle_ = dlopen("libcudart.so", RTLD_LAZY);
+  handle_ = dlopen("libcudart.so", RTLD_NOW);
   if (handle_ == nullptr) {
     throw std::runtime_error(
         std::string("Cannot open CUDA runtime library: ") + dlerror() + "\n");

--- a/src/cuda_runtime_library_manager.cc
+++ b/src/cuda_runtime_library_manager.cc
@@ -1,0 +1,117 @@
+// Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "cuda_runtime_library_manager.h"
+
+namespace triton::perfanalyzer {
+
+CUDARuntimeLibraryManager::CUDARuntimeLibraryManager()
+{
+  handle_ = dlopen("libcudart.so", RTLD_LAZY);
+  if (handle_ == nullptr) {
+    throw std::runtime_error(
+        std::string("Cannot open CUDA runtime library: ") + dlerror() + "\n");
+  }
+
+  LoadFunctions();
+}
+
+CUDARuntimeLibraryManager::~CUDARuntimeLibraryManager()
+{
+  if (handle_) {
+    dlclose(handle_);
+  }
+}
+
+cudaError_t
+CUDARuntimeLibraryManager::cudaMalloc(void** devPtr, size_t size)
+{
+  return cuda_malloc_func_(devPtr, size);
+}
+
+cudaError_t
+CUDARuntimeLibraryManager::cudaFree(void* devPtr)
+{
+  return cuda_free_func_(devPtr);
+}
+
+const char*
+CUDARuntimeLibraryManager::cudaGetErrorName(cudaError_t error)
+{
+  return cuda_get_error_name_func_(error);
+}
+
+const char*
+CUDARuntimeLibraryManager::cudaGetErrorString(cudaError_t error)
+{
+  return cuda_get_error_string_func_(error);
+}
+
+cudaError_t
+CUDARuntimeLibraryManager::cudaIpcGetMemHandle(
+    cudaIpcMemHandle_t* handle, void* devPtr)
+{
+  return cuda_ipc_get_mem_handle_func_(handle, devPtr);
+}
+
+cudaError_t
+CUDARuntimeLibraryManager::cudaMemcpy(
+    void* dst, const void* src, size_t count, cudaMemcpyKind kind)
+{
+  return cuda_memcpy_func_(dst, src, count, kind);
+}
+
+cudaError_t
+CUDARuntimeLibraryManager::cudaSetDevice(int device)
+{
+  return cuda_set_device_func_(device);
+}
+
+void
+CUDARuntimeLibraryManager::LoadFunctions()
+{
+  *(void**)(&cuda_malloc_func_) = dlsym(handle_, "cudaMalloc");
+  *(void**)(&cuda_free_func_) = dlsym(handle_, "cudaFree");
+  *(void**)(&cuda_get_error_name_func_) = dlsym(handle_, "cudaGetErrorName");
+  *(void**)(&cuda_get_error_string_func_) =
+      dlsym(handle_, "cudaGetErrorString");
+  *(void**)(&cuda_ipc_get_mem_handle_func_) =
+      dlsym(handle_, "cudaIpcGetMemHandle");
+  *(void**)(&cuda_memcpy_func_) = dlsym(handle_, "cudaMemcpy");
+  *(void**)(&cuda_set_device_func_) = dlsym(handle_, "cudaSetDevice");
+
+  if (cuda_malloc_func_ == nullptr || cuda_free_func_ == nullptr ||
+      cuda_get_error_name_func_ == nullptr ||
+      cuda_get_error_string_func_ == nullptr ||
+      cuda_ipc_get_mem_handle_func_ == nullptr ||
+      cuda_memcpy_func_ == nullptr || cuda_set_device_func_ == nullptr) {
+    throw std::runtime_error(
+        std::string("Failed to load one or more CUDA functions: ") + dlerror() +
+        "\n");
+  }
+}
+
+}  // namespace triton::perfanalyzer

--- a/src/cuda_runtime_library_manager.h
+++ b/src/cuda_runtime_library_manager.h
@@ -1,0 +1,68 @@
+// Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <cuda_runtime_api.h>
+#include <dlfcn.h>
+#include <stddef.h>
+
+#include <stdexcept>
+
+namespace triton::perfanalyzer {
+
+class CUDARuntimeLibraryManager {
+ public:
+  CUDARuntimeLibraryManager();
+
+  ~CUDARuntimeLibraryManager();
+
+  // Wrapper functions for CUDA API calls
+  cudaError_t cudaMalloc(void** devPtr, size_t size);
+  cudaError_t cudaFree(void* devPtr);
+  const char* cudaGetErrorName(cudaError_t error);
+  const char* cudaGetErrorString(cudaError_t error);
+  cudaError_t cudaIpcGetMemHandle(cudaIpcMemHandle_t* handle, void* devPtr);
+  cudaError_t cudaMemcpy(
+      void* dst, const void* src, size_t count, cudaMemcpyKind kind);
+  cudaError_t cudaSetDevice(int device);
+
+ private:
+  cudaError_t (*cuda_malloc_func_)(void**, size_t){nullptr};
+  cudaError_t (*cuda_free_func_)(void*){nullptr};
+  const char* (*cuda_get_error_name_func_)(cudaError_t){nullptr};
+  const char* (*cuda_get_error_string_func_)(cudaError_t){nullptr};
+  cudaError_t (*cuda_ipc_get_mem_handle_func_)(cudaIpcMemHandle_t*, void*){
+      nullptr};
+  cudaError_t (*cuda_memcpy_func_)(void*, const void*, size_t, cudaMemcpyKind){
+      nullptr};
+  cudaError_t (*cuda_set_device_func_)(int){nullptr};
+
+  void* handle_{nullptr};
+
+  void LoadFunctions();
+};
+
+}  // namespace triton::perfanalyzer


### PR DESCRIPTION
Currently, if a user tried to run PA on a system without CUDA Runtime library installed, they see this:

```bash
$ perf_analzyer
perf_analyzer: error while loading shared libraries: libcudart.so.12: cannot open shared object file: No such file or directory
```

But PA really only needs the CUDA Runtime library when user uses `--shared-memory=cuda` option.

This PR removes the always-necessary requirement (dynamic linking) of the CUDA Runtime library (libcudart.so).

Before:

```bash
$ ldd $(which perf_analyzer)
...
        libcudart.so.12 => /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.12 (0x00007cea38600000)
...
```

After:

```bash
$ ldd $(which perf_analyzer)
...
        # not libcudart.so
...
```

Instead, PA will dynamically load libcudart.so via dlopen, only when users use `--shared-memory=cuda`.

Which means a single released PA binary can work on user systems _with_ and _without_ cuda installed.