### PR TITLE
Remove duplicate function

### DIFF
--- a/genai-perf/genai_perf/inputs/converters/nvclip_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/nvclip_converter.py
@@ -60,9 +60,6 @@ class NVClipConverter(BaseConverter):
                     "input": input_items,
                 }
 
-                for key, value in config.extra_inputs.items():
-                    payload[key] = value
-
                 self._add_request_params(payload, config)
                 request_body["data"].append({"payload": [payload]})
 


### PR DESCRIPTION
Remove duplicate function call. The add_request_params call after the loop already iterates over the extra_inputs and adds them to the payload, so the for loop is a duplicate.