### PR TITLE
Update GenAI-Perf dependencies to include tritonclient for perf_analyzer

### DIFF
--- a/genai-perf/pyproject.toml
+++ b/genai-perf/pyproject.toml
@@ -45,6 +45,7 @@ maintainers = []
 keywords = []
 requires-python = ">=3.10,<4"
 dependencies = [
+  "tritonclient",
   "numpy<2",
   "pytest",
   "rich",


### PR DESCRIPTION
Since we're working towards a `pip install genai-perf`, we need to make `tritonclient`, which has PA in it, a proper dependency.