### PR TITLE
Add ISL/OSL CLI arg aliases

### DIFF
--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -431,6 +431,7 @@ in JSONL format. Example: {\"text\": \"Your prompt here\"}"
 The number of unique prompts to generate as stimulus. (default: `100`)
 
 ##### `--output-tokens-mean <int>`
+##### `--osl`
 
 The mean number of tokens in each output. Ensure the `--tokenizer` value is set
 correctly. (default: `-1`)
@@ -454,6 +455,7 @@ when `--output-tokens-mean` is provided. (default: `0`)
 The seed used to generate random values. (default: `0`)
 
 ##### `--synthetic-input-tokens-mean <int>`
+##### `--isl`
 
 The mean of number of tokens in the generated prompts when using synthetic
 data. (default: `550`)

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -458,6 +458,7 @@ def _add_input_args(parser):
 
     input_group.add_argument(
         "--output-tokens-mean",
+        "--osl",
         type=int,
         default=ic.DEFAULT_OUTPUT_TOKENS_MEAN,
         required=False,
@@ -497,6 +498,7 @@ def _add_input_args(parser):
 
     input_group.add_argument(
         "--synthetic-input-tokens-mean",
+        "--isl",
         type=int,
         default=ic.DEFAULT_PROMPT_TOKENS_MEAN,
         required=False,

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -196,6 +196,10 @@ class TestCLIArguments:
                 {"output_tokens_mean": 6},
             ),
             (
+                ["--osl", "6"],
+                {"output_tokens_mean": 6},
+            ),
+            (
                 ["--output-tokens-mean", "6", "--output-tokens-stddev", "7"],
                 {"output_tokens_stddev": 7},
             ),
@@ -228,6 +232,10 @@ class TestCLIArguments:
             (["--streaming"], {"streaming": True}),
             (
                 ["--synthetic-input-tokens-mean", "6"],
+                {"synthetic_input_tokens_mean": 6},
+            ),
+            (
+                ["--isl", "6"],
                 {"synthetic_input_tokens_mean": 6},
             ),
             (


### PR DESCRIPTION
Input sequence length (ISL) and output sequence length (OSL) are becoming very common paths for users, so add them as aliases to shorten the args --synthetic-input-tokens-mean and --output-tokens-mean.

We plan to simplify the CLI args when GenAI-Perf goes GA. We may also switch to config files. For now, this will aid usability for users who prefer using these aliases.