### PR TITLE
Enable support for Ubuntu 24.04

### DIFF
--- a/genai-perf/pyproject.toml
+++ b/genai-perf/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: Unix",
 ]
 authors = []

--- a/src/base_queue_ctx_id_tracker.h
+++ b/src/base_queue_ctx_id_tracker.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <queue>
+#include <stdexcept>
 
 #include "ictx_id_tracker.h"
 

--- a/src/client_backend/openai/http_client.h
+++ b/src/client_backend/openai/http_client.h
@@ -34,6 +34,7 @@
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <string>
 
 namespace triton { namespace perfanalyzer { namespace clientbackend {
 namespace openai {


### PR DESCRIPTION
This PR enables support for Ubuntu 24.04 by adding a new job to the CI workflow.