### PR TITLE
Remove unnecessary filename field in FileData

### DIFF
--- a/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
@@ -64,8 +64,9 @@ class FileInputRetriever(BaseInputRetriever):
         if self.config.input_filename.is_dir():
             files_data = self._get_input_datasets_from_dir()
         else:
-            file_data = self._get_input_dataset_from_file(self.config.input_filename)
-            files_data = {file_data.filename: file_data}
+            input_file = self.config.input_filename
+            file_data = self._get_input_dataset_from_file(input_file)
+            files_data = {str(input_file): file_data}
 
         return GenericDataset(files_data)
 
@@ -274,4 +275,4 @@ class FileInputRetriever(BaseInputRetriever):
                 for image in images:
                     data_rows.append(DataRow(texts=[], images=[image]))
 
-        return FileData(str(filename), data_rows)
+        return FileData(data_rows)

--- a/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
+++ b/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
@@ -52,14 +52,12 @@ class FileData:
 
     def to_list(self) -> List[DataRowDict]:
         """
-        Converts the FileData object to a dictionary.
+        Converts the FileData object to a list.
         Output format example for two payloads from a file:
-        {
-            'file_0': [
-                {'texts': ['text1', 'text2'], 'images': ['image1', 'image2']},
-                {'texts': ['text3', 'text4'], 'images': ['image3', 'image4']}
-            ]
-        }
+        [
+            {'texts': ['text1', 'text2'], 'images': ['image1', 'image2']},
+            {'texts': ['text3', 'text4'], 'images': ['image3', 'image4']}
+        ]
         """
         return [row.to_dict() for row in self.rows]
 

--- a/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
+++ b/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
@@ -48,10 +48,9 @@ class DataRow:
 
 @dataclass
 class FileData:
-    filename: str
     rows: List[DataRow]
 
-    def to_dict(self) -> Dict[Filename, List[DataRowDict]]:
+    def to_list(self) -> List[DataRowDict]:
         """
         Converts the FileData object to a dictionary.
         Output format example for two payloads from a file:
@@ -62,7 +61,7 @@ class FileData:
             ]
         }
         """
-        return {self.filename: [row.to_dict() for row in self.rows]}
+        return [row.to_dict() for row in self.rows]
 
 
 @dataclass
@@ -81,6 +80,6 @@ class GenericDataset:
         }
         """
         return {
-            filename: file_data.to_dict()[filename]
+            filename: file_data.to_list()
             for filename, file_data in self.files_data.items()
         }

--- a/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
+++ b/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
@@ -71,10 +71,8 @@ class GenericDataset:
         Converts the entire DataStructure object to a dictionary.
         Output format example for one payload from two files:
         {
-            {
             'file_0': [{'texts': ['text1', 'text2'], 'images': ['image1', 'image2']}],
             'file_1': [{'texts': ['text1', 'text2'], 'images': ['image1', 'image2']}]
-        }
         }
         """
         return {

--- a/genai-perf/genai_perf/inputs/retrievers/synthetic_data_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/synthetic_data_retriever.py
@@ -76,7 +76,7 @@ class SyntheticDataRetriever(BaseInputRetriever):
 
                 data_rows.append(row)
 
-            file_data = FileData(file, data_rows)
+            file_data = FileData(data_rows)
 
             synthetic_dataset.files_data[file] = file_data
 

--- a/genai-perf/tests/test_embeddings_converter.py
+++ b/genai-perf/tests/test_embeddings_converter.py
@@ -58,7 +58,6 @@ class TestOpenAIEmbeddingsConverter:
         generic_dataset = GenericDataset(
             files_data={
                 "file1": FileData(
-                    filename="file1",
                     rows=[DataRow(texts=["text_1"]), DataRow(texts=["text_2"])],
                 )
             }
@@ -101,7 +100,6 @@ class TestOpenAIEmbeddingsConverter:
         generic_dataset = GenericDataset(
             files_data={
                 "file1": FileData(
-                    filename="file1",
                     rows=[
                         DataRow(texts=["text_1", "text_2"]),
                         DataRow(texts=["text_3", "text_4"]),
@@ -149,7 +147,6 @@ class TestOpenAIEmbeddingsConverter:
         generic_dataset = GenericDataset(
             files_data={
                 "file1": FileData(
-                    filename="file1",
                     rows=[DataRow(texts=["text_1"]), DataRow(texts=["text_2"])],
                 )
             }

--- a/genai-perf/tests/test_file_input_retriever.py
+++ b/genai-perf/tests/test_file_input_retriever.py
@@ -104,7 +104,6 @@ class TestFileInputRetriever:
         )
 
         assert file_data is not None
-        assert file_data.filename == "single_image.jsonl"
         assert len(file_data.rows) == 1
         assert file_data.rows[0].images[0] == "mock_base64_image"
 
@@ -131,7 +130,6 @@ class TestFileInputRetriever:
         )
 
         assert file_data is not None
-        assert file_data.filename == "multiple_images.jsonl"
         assert len(file_data.rows) == 3
         expected_images = [
             "mock_base64_image1",
@@ -157,7 +155,6 @@ class TestFileInputRetriever:
         )
 
         assert file_data is not None
-        assert file_data.filename == "single_prompt.jsonl"
         assert len(file_data.rows) == 1
         assert file_data.rows[0].texts[0] == "What is the capital of France?"
 
@@ -177,7 +174,6 @@ class TestFileInputRetriever:
         )
 
         assert file_data is not None
-        assert file_data.filename == "multiple_prompts.jsonl"
         assert len(file_data.rows) == 3
         expected_prompts = [
             "What is the capital of France?",
@@ -210,7 +206,6 @@ class TestFileInputRetriever:
         )
 
         assert file_data is not None
-        assert file_data.filename == "multi_modal.jsonl"
         assert len(file_data.rows) == 2
         assert file_data.rows[0].texts[0] == "What is this image?"
         assert file_data.rows[0].images[0] == "mock_base64_image"
@@ -231,7 +226,6 @@ class TestFileInputRetriever:
         )
 
         assert file_data is not None
-        assert file_data.filename == "deprecated_text_input.jsonl"
         assert len(file_data.rows) == 2
         assert file_data.rows[0].texts[0] == "Who is Albert Einstein?"
         assert file_data.rows[1].texts[0] == "What is the speed of light?"
@@ -317,14 +311,12 @@ class TestFileInputRetriever:
 
         assert len(file_data) == 4
 
-        assert file_data["single_prompt"].filename == "single_prompt.jsonl"
         assert len(file_data["single_prompt"].rows) == 1
         assert (
             file_data["single_prompt"].rows[0].texts[0]
             == "What is the capital of France?"
         )
 
-        assert file_data["multiple_prompts"].filename == "multiple_prompts.jsonl"
         assert len(file_data["multiple_prompts"].rows) == 3
         expected_prompts = [
             "What is the capital of France?",
@@ -334,11 +326,9 @@ class TestFileInputRetriever:
         for i, prompt in enumerate(expected_prompts):
             assert file_data["multiple_prompts"].rows[i].texts[0] == prompt
 
-        assert file_data["single_image"].filename == "single_image.jsonl"
         assert len(file_data["single_image"].rows) == 1
         assert file_data["single_image"].rows[0].images[0] == "mock_base64_image"
 
-        assert file_data["multi_modal"].filename == "multi_modal.jsonl"
         assert len(file_data["multi_modal"].rows) == 2
         assert file_data["multi_modal"].rows[0].texts[0] == "What is this image?"
         assert file_data["multi_modal"].rows[0].images[0] == "mock_base64_image"

--- a/genai-perf/tests/test_inputs.py
+++ b/genai-perf/tests/test_inputs.py
@@ -50,7 +50,6 @@ class TestInputs:
         generic_dataset = GenericDataset(
             files_data={
                 "file1.jsonl": FileData(
-                    filename="file1.jsonl",
                     rows=[DataRow(texts=["test input"], images=[])],
                 )
             }
@@ -97,7 +96,6 @@ class TestInputs:
         generic_dataset = GenericDataset(
             files_data={
                 "file1.jsonl": FileData(
-                    filename="file1.jsonl",
                     rows=[DataRow(texts=["test input one"], images=[])],
                 )
             }

--- a/genai-perf/tests/test_nvclip_converter.py
+++ b/genai-perf/tests/test_nvclip_converter.py
@@ -41,9 +41,7 @@ class TestNVClipConverter:
 
     @staticmethod
     def create_generic_dataset(rows) -> GenericDataset:
-        return GenericDataset(
-            files_data={"file1": FileData(filename="file1", rows=rows)}
-        )
+        return GenericDataset(files_data={"file1": FileData(rows)})
 
     def test_convert_default(self):
         generic_dataset = self.create_generic_dataset(

--- a/genai-perf/tests/test_openai_chat_converter.py
+++ b/genai-perf/tests/test_openai_chat_converter.py
@@ -61,7 +61,6 @@ class TestOpenAIChatCompletionsConverter:
         return GenericDataset(
             files_data={
                 "file1": FileData(
-                    filename="file1",
                     rows=[
                         DataRow(texts=clean_text(row), images=clean_image(row))
                         for row in rows

--- a/genai-perf/tests/test_openai_completions_converter.py
+++ b/genai-perf/tests/test_openai_completions_converter.py
@@ -47,7 +47,6 @@ class TestOpenAICompletionsConverter:
         return GenericDataset(
             files_data={
                 "file1": FileData(
-                    filename="file1",
                     rows=[
                         DataRow(texts=["text input one"]),
                         DataRow(texts=["text input two"]),

--- a/genai-perf/tests/test_rankings_converter.py
+++ b/genai-perf/tests/test_rankings_converter.py
@@ -49,13 +49,11 @@ class TestRankingsConverter:
 
         if queries_data is not None:
             files_data["queries"] = FileData(
-                filename="queries",
                 rows=[DataRow(texts=query) for query in queries_data],
             )
 
         if passages_data is not None:
             files_data["passages"] = FileData(
-                filename="passages",
                 rows=[DataRow(texts=passage) for passage in passages_data],
             )
 

--- a/genai-perf/tests/test_tensorrtllm_engine_converter.py
+++ b/genai-perf/tests/test_tensorrtllm_engine_converter.py
@@ -49,7 +49,6 @@ class TestTensorRTLLMEngineConverter:
         return GenericDataset(
             files_data={
                 "file1": FileData(
-                    filename="file1",
                     rows=[
                         DataRow(texts=["text input one"]),
                         DataRow(texts=["text input two"]),

--- a/genai-perf/tests/test_triton_tensorrtllm_converter.py
+++ b/genai-perf/tests/test_triton_tensorrtllm_converter.py
@@ -47,7 +47,6 @@ class TestTensorRTLLMConverter:
         return GenericDataset(
             files_data={
                 "file1": FileData(
-                    filename="file1",
                     rows=[
                         DataRow(texts=["text input one"]),
                         DataRow(texts=["text input two"]),

--- a/genai-perf/tests/test_triton_vllm_converter.py
+++ b/genai-perf/tests/test_triton_vllm_converter.py
@@ -45,7 +45,6 @@ class TestVLLMConverter:
         return GenericDataset(
             files_data={
                 "file1": FileData(
-                    filename="file1",
                     rows=[
                         DataRow(texts=["text input one"]),
                         DataRow(texts=["text input two"]),


### PR DESCRIPTION
Remove the field in FileData that holds a reference to the file's name. It is not needed, since GenericDatastructure holds a dictionary of filenames to file data and is the way that file data are referenced. The field results in duplication, which could mask bugs.