### PR TITLE
Fixing IWYU problem, causing a build issue.

### DIFF
--- a/src/client_backend/openai/http_client.h
+++ b/src/client_backend/openai/http_client.h
@@ -33,6 +33,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
 
 namespace triton { namespace perfanalyzer { namespace clientbackend {


### PR DESCRIPTION
We probably had `string` being included transitively, which is basically UB.

See https://gitlab-master.nvidia.com/dl/triton/perf_analyzer_ci/-/jobs/122143789#L4216