### PR TITLE
Handle missing data in console and csv exporter

### DIFF
--- a/genai-perf/genai_perf/export_data/console_exporter.py
+++ b/genai-perf/genai_perf/export_data/console_exporter.py
@@ -84,14 +84,13 @@ class ConsoleExporter:
             metric_str += f" ({metric.unit})" if metric.unit != "tokens" else ""
             row_values = [metric_str]
             for stat in self.STAT_COLUMN_KEYS:
-                value = self._stats[metric.name][stat]
-                row_values.append(f"{value:,.2f}")
+                value = self._stats[metric.name].get(stat, None)
+                row_values.append(f"{value:,.2f}" if value else "N/A")
 
             table.add_row(*row_values)
 
         for metric in self._metrics.system_metrics:
             metric_str = metric.name.replace("_", " ").capitalize()
-            # metric_str = metric_str.replace("throughput", "tput")
             if metric.name == "request_goodput":
                 if not self._args.goodput:
                     continue

--- a/genai-perf/genai_perf/export_data/csv_exporter.py
+++ b/genai-perf/genai_perf/export_data/csv_exporter.py
@@ -87,8 +87,8 @@ class CsvExporter:
             metric_str += f" ({metric.unit})" if metric.unit != "tokens" else ""
             row_values = [metric_str]
             for stat in self.REQUEST_METRICS_HEADER[1:]:
-                value = self._stats[metric.name][stat]
-                row_values.append(f"{value:,.2f}")
+                value = self._stats[metric.name].get(stat, None)
+                row_values.append(f"{value:,.2f}" if value else "N/A")
 
             csv_writer.writerow(row_values)
 

--- a/src/client_backend/openai/http_client.h
+++ b/src/client_backend/openai/http_client.h
@@ -33,8 +33,8 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <thread>
 #include <string>
+#include <thread>
 
 namespace triton { namespace perfanalyzer { namespace clientbackend {
 namespace openai {


### PR DESCRIPTION
When some statistics are missing (for any reason), handle it by displaying "N/A" instead of throwing an error to the user.

The console output will contain "N/A" if some values are missing
<img width="829" alt="image" src="https://github.com/user-attachments/assets/07d202d8-83ce-4eaa-9e75-8d62ae2c0775">


The CSV output will also contain "N/A"
```
Metric,avg,min,max,p99,p95,p90,p75,p50,p25
Request Latency (ms),205.80,205.40,207.50,207.37,206.84,206.17,205.76,205.58,205.48
Output Sequence Length,N/A,11.00,13.00,13.00,13.00,13.00,12.00,11.00,11.00
Input Sequence Length,N/A,N/A,N/A,N/A,N/A,N/A,N/A,N/A,N/A

Metric,Value
Output Token Throughput (per sec),56.27
Request Throughput (per sec),4.85
```

The JSON exporter does not require any handling since it directly takes the statistics dictionary and saves it without any modification. So any missing data won't be in the final JSON file.