### PR TITLE
Use ignore_eos when benchmarking Triton + vLLM deterministically

### DIFF
--- a/genai-perf/genai_perf/inputs/converters/vllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/vllm_converter.py
@@ -77,11 +77,12 @@ class VLLMConverter(BaseConverter):
                     lower=1,  # output token must be >= 1
                 )
             )
-            sampling_parameters = {
+            sampling_parameters: Dict[Any, Any] = {
                 "max_tokens": f"{number_of_tokens}",
             }
             if config.output_tokens_deterministic:
                 sampling_parameters["min_tokens"] = f"{number_of_tokens}"
+                sampling_parameters["ignore_eos"] = True
             sampling_parameters_str = json.dumps(sampling_parameters)
             payload["sampling_parameters"] = [sampling_parameters_str]
         for key, value in config.extra_inputs.items():

--- a/genai-perf/tests/test_triton_vllm_converter.py
+++ b/genai-perf/tests/test_triton_vllm_converter.py
@@ -154,7 +154,7 @@ class TestVLLMConverter:
                     "text_input": ["text input one"],
                     "exclude_input_in_output": [True],
                     "sampling_parameters": [
-                        '{"max_tokens": "1234", "min_tokens": "1234"}'
+                        '{"max_tokens": "1234", "min_tokens": "1234", "ignore_eos": true}'
                     ],
                 },
                 {
@@ -162,7 +162,7 @@ class TestVLLMConverter:
                     "text_input": ["text input two"],
                     "exclude_input_in_output": [True],
                     "sampling_parameters": [
-                        '{"max_tokens": "1234", "min_tokens": "1234"}'
+                        '{"max_tokens": "1234", "min_tokens": "1234", "ignore_eos": true}'
                     ],
                 },
             ]


### PR DESCRIPTION
When using the --output-tokens-mean-deterministic flag, use the arg "ignore_eos" for Triton + vLLM, since it supports it and it could result in more accurate benchmarking. 