### PR TITLE
Add endpoint_type_map section to customizable frontend tutorial

### DIFF
--- a/genai-perf/docs/customizable_frontends.md
+++ b/genai-perf/docs/customizable_frontends.md
@@ -123,6 +123,20 @@ converters = {
 }
 ```
 
+## Map an Endpoint Type to the Output Format
+
+Open `genai_perf/parser.py`.
+Add an mapping for your new endpoint type in the `_endpoint_type_map`.
+
+For example, see the code below.
+
+```python
+_endpoint_type_map = {
+    # Existing mappings
+    "NEW-ENDPOINT": EndpointConfig("v1/endpoint", "openai", ic.OutputFormat.NEW_ENDPOINT),
+}
+```
+
 ## Update the Metrics Parser
 
 GenAI-Perf needs to know which metrics format your API uses. Go to
@@ -142,7 +156,7 @@ After implementing your converter, you can run it against your server to
 ensure it works:
 
 ```bash
-genai-perf profile -m TEST_MODEL --endpoint NEW-ENDPOINT
+genai-perf profile -m TEST_MODEL --endpoint-type NEW-ENDPOINT
 ```
 
 You can also write unit tests to ensure it works as expected.

--- a/templates/genai-perf-templates/customizable_frontends_template
+++ b/templates/genai-perf-templates/customizable_frontends_template
@@ -123,6 +123,20 @@ converters = {
 }
 ```
 
+## Map an Endpoint Type to the Output Format
+
+Open `genai_perf/parser.py`.
+Add an mapping for your new endpoint type in the `_endpoint_type_map`.
+
+For example, see the code below.
+
+```python
+_endpoint_type_map = {
+    # Existing mappings
+    "NEW-ENDPOINT": EndpointConfig("v1/endpoint", "openai", ic.OutputFormat.NEW_ENDPOINT),
+}
+```
+
 ## Update the Metrics Parser
 
 GenAI-Perf needs to know which metrics format your API uses. Go to
@@ -142,7 +156,7 @@ After implementing your converter, you can run it against your server to
 ensure it works:
 
 ```bash
-genai-perf profile -m TEST_MODEL --endpoint NEW-ENDPOINT
+genai-perf profile -m TEST_MODEL --endpoint-type NEW-ENDPOINT
 ```
 
 You can also write unit tests to ensure it works as expected.


### PR DESCRIPTION
After a [recent PR](https://github.com/triton-inference-server/perf_analyzer/pull/206/files#diff-531d67ceb8ef974e32746d3e8b7b2cd958bac761568f74220ef436b018cacf99R210) updated the endpoint mapping in the parser, add a section to the customizable frontend tutorial. This section will cover the step of mapping an endpoint-type name to the output format.