### PR TITLE
Fix re-rankings payload schema for NIMs

### DIFF
--- a/genai-perf/genai_perf/inputs/converters/rankings_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/rankings_converter.py
@@ -72,11 +72,9 @@ class RankingsConverter(BaseConverter):
                 passages = passage_entry.texts
                 payload = {"query": query, "texts": passages}
             else:
-                passages = [
-                    {"text_input": p} for p in passage_entry.texts if p is not None
-                ]
+                passages = [{"text": p} for p in passage_entry.texts if p is not None]
                 payload = {
-                    "query": query,
+                    "query": {"text": query},
                     "passages": passages,
                     "model": model_name,
                 }

--- a/genai-perf/tests/test_rankings_converter.py
+++ b/genai-perf/tests/test_rankings_converter.py
@@ -81,10 +81,10 @@ class TestRankingsConverter:
                 {
                     "payload": [
                         {
-                            "query": "query 1",
+                            "query": {"text": "query 1"},
                             "passages": [
-                                {"text_input": "passage 1"},
-                                {"text_input": "passage 2"},
+                                {"text": "passage 1"},
+                                {"text": "passage 2"},
                             ],
                             "model": "test_model",
                         }
@@ -93,10 +93,10 @@ class TestRankingsConverter:
                 {
                     "payload": [
                         {
-                            "query": "query 2",
+                            "query": {"text": "query 2"},
                             "passages": [
-                                {"text_input": "passage 3"},
-                                {"text_input": "passage 4"},
+                                {"text": "passage 3"},
+                                {"text": "passage 4"},
                             ],
                             "model": "test_model",
                         }
@@ -135,10 +135,10 @@ class TestRankingsConverter:
                 {
                     "payload": [
                         {
-                            "query": "query 1",
+                            "query": {"text": "query 1"},
                             "passages": [
-                                {"text_input": "passage 1"},
-                                {"text_input": "passage 2"},
+                                {"text": "passage 1"},
+                                {"text": "passage 2"},
                             ],
                             "model": "test_model",
                             "encoding_format": "base64",
@@ -150,10 +150,10 @@ class TestRankingsConverter:
                 {
                     "payload": [
                         {
-                            "query": "query 2",
+                            "query": {"text": "query 2"},
                             "passages": [
-                                {"text_input": "passage 3"},
-                                {"text_input": "passage 4"},
+                                {"text": "passage 3"},
+                                {"text": "passage 4"},
                             ],
                             "model": "test_model",
                             "encoding_format": "base64",
@@ -266,8 +266,8 @@ class TestRankingsConverter:
                         {
                             "payload": [
                                 {
-                                    "query": "query 1",
-                                    "passages": [{"text_input": "passage 1"}],
+                                    "query": {"text": "query 1"},
+                                    "passages": [{"text": "passage 1"}],
                                     "model": "test_model",
                                 }
                             ]
@@ -275,8 +275,8 @@ class TestRankingsConverter:
                         {
                             "payload": [
                                 {
-                                    "query": "query 2",
-                                    "passages": [{"text_input": "passage 2"}],
+                                    "query": {"text": "query 2"},
+                                    "passages": [{"text": "passage 2"}],
                                     "model": "test_model",
                                 }
                             ]
@@ -293,8 +293,8 @@ class TestRankingsConverter:
                         {
                             "payload": [
                                 {
-                                    "query": "query 1",
-                                    "passages": [{"text_input": "passage 1"}],
+                                    "query": {"text": "query 1"},
+                                    "passages": [{"text": "passage 1"}],
                                     "model": "test_model",
                                 }
                             ]


### PR DESCRIPTION
During the inputs modularization work, the payload for benchmarking re-ranking NIMs was broken. Fix the payload schema.

After changes:
![image](https://github.com/user-attachments/assets/71517d59-ca84-406b-a39a-b8e3fba07893)
