### PR TITLE
Allow user to specify the tokenizer for compare

### DIFF
--- a/genai-perf/genai_perf/plots/plot_config_parser.py
+++ b/genai-perf/genai_perf/plots/plot_config_parser.py
@@ -36,7 +36,11 @@ import yaml  # type: ignore
 from genai_perf.metrics import Statistics
 from genai_perf.plots.plot_config import PlotConfig, PlotType, ProfileRunData
 from genai_perf.profile_data_parser import LLMProfileDataParser
-from genai_perf.tokenizer import DEFAULT_TOKENIZER, get_tokenizer
+from genai_perf.tokenizer import (
+    DEFAULT_TOKENIZER,
+    DEFAULT_TOKENIZER_REVISION,
+    get_tokenizer,
+)
 from genai_perf.utils import load_yaml, scale
 
 logger = logging.getLogger(__name__)
@@ -48,7 +52,12 @@ class PlotConfigParser:
     def __init__(self, filename: Path) -> None:
         self._filename = filename
 
-    def generate_configs(self, tokenizer: str = DEFAULT_TOKENIZER) -> List[PlotConfig]:
+    def generate_configs(
+        self,
+        tokenizer: str = DEFAULT_TOKENIZER,
+        tokenizer_trust_remote_code: bool = False,
+        tokenizer_revision: str = DEFAULT_TOKENIZER_REVISION,
+    ) -> List[PlotConfig]:
         """Load YAML configuration file and convert to PlotConfigs."""
         logger.info(
             f"Generating plot configurations by parsing {self._filename}. "
@@ -61,7 +70,9 @@ class PlotConfigParser:
             # Collect profile run data
             profile_data: List[ProfileRunData] = []
             for filepath in config["paths"]:
-                stats = self._get_statistics(filepath, tokenizer)
+                stats = self._get_statistics(
+                    filepath, tokenizer, tokenizer_trust_remote_code, tokenizer_revision
+                )
                 profile_data.append(
                     ProfileRunData(
                         name=self._get_run_name(Path(filepath)),
@@ -85,11 +96,19 @@ class PlotConfigParser:
 
         return plot_configs
 
-    def _get_statistics(self, filepath: str, tokenizer: str) -> Statistics:
+    def _get_statistics(
+        self,
+        filepath: str,
+        tokenizer: str,
+        tokenizer_trust_remote_code: bool = False,
+        tokenizer_revision: str = DEFAULT_TOKENIZER_REVISION,
+    ) -> Statistics:
         """Extract a single profile run data."""
         data_parser = LLMProfileDataParser(
             filename=Path(filepath),
-            tokenizer=get_tokenizer(tokenizer),
+            tokenizer=get_tokenizer(
+                tokenizer, tokenizer_trust_remote_code, tokenizer_revision
+            ),
         )
         load_info = data_parser.get_profile_load_info()
 

--- a/genai-perf/genai_perf/subcommand/compare.py
+++ b/genai-perf/genai_perf/subcommand/compare.py
@@ -43,7 +43,7 @@ def compare_handler(args: Namespace) -> None:
         args.config = output_dir / "config.yaml"
 
     config_parser = PlotConfigParser(args.config)
-    plot_configs = config_parser.generate_configs()
+    plot_configs = config_parser.generate_configs(args.tokenizer)
     plot_manager = PlotManager(plot_configs)
     plot_manager.generate_plots()
 

--- a/genai-perf/genai_perf/subcommand/profile.py
+++ b/genai-perf/genai_perf/subcommand/profile.py
@@ -101,6 +101,8 @@ def _create_plots(args: Namespace) -> None:
         output_dir=plot_dir,
     )
     config_parser = PlotConfigParser(plot_dir / "config.yaml")
-    plot_configs = config_parser.generate_configs(args.tokenizer)
+    plot_configs = config_parser.generate_configs(
+        args.tokenizer, args.tokenizer_trust_remote_code, args.tokenizer_revision
+    )
     plot_manager = PlotManager(plot_configs)
     plot_manager.generate_plots()

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -996,3 +996,22 @@ class TestCLIArguments:
         monkeypatch.setattr("sys.argv", args_list)
         args, _ = parser.parse_args()
         assert args.server_metrics_url == expected_url
+
+    def test_tokenizer_args(self, monkeypatch):
+        args = [
+            "genai-perf",
+            "profile",
+            "--model",
+            "test_model",
+            "--tokenizer",
+            "test_tokenizer",
+            "--tokenizer-trust-remote-code",
+            "--tokenizer-revision",
+            "test_revision",
+        ]
+        monkeypatch.setattr("sys.argv", args)
+        parsed_args, _ = parser.parse_args()
+
+        assert parsed_args.tokenizer == "test_tokenizer"
+        assert parsed_args.tokenizer_trust_remote_code
+        assert parsed_args.tokenizer_revision == "test_revision"


### PR DESCRIPTION
A user mentioned that compare does not work with a non-default tokenizer: https://github.com/triton-inference-server/perf_analyzer/issues/174

This pull request enables passing in a tokenizer for compare to have more accurate token counts.

A couple of clean-up items:
- Allowing the other tokenizer args (trust_remote_code, tokenizer_revision) to be passed in via profile for the profile parsing
- Alphabetizing the functions for adding the CLI arg groups to make it easier to navigate the code and help menu

**Before the change**
Command: `genai-perf compare -f artifacts/HuggingFaceH4_zephyr-7b-beta-openai-chat-concurrency1/profile_export.json artifacts/HuggingFaceH4_zephyr-7b-beta-openai-chat-concurrency2/profile_export.json`
Graph:
![image](https://github.com/user-attachments/assets/452ae167-9e5f-48b8-a07a-d9f49ed7fb10)

**After the change (with tokenizer specified):**
Command: `genai-perf compare --tokenizer HuggingFaceH4/zephyr-7b-beta -f artifacts/HuggingFaceH4_zephyr-7b-beta-openai-chat-concurrency1/profile_export.json artifacts/HuggingFaceH4_zephyr-7b-beta-openai-chat-concurrency2/profile_export.json`
Graph:
![image](https://github.com/user-attachments/assets/4fd0c777-3aae-4b6d-9e76-08b94963b570)
