### PR TITLE
Forward error messages from OpenAI client

### DIFF
--- a/src/client_backend/openai/openai_client.h
+++ b/src/client_backend/openai/openai_client.h
@@ -65,7 +65,8 @@ class ChatCompletionResult : public InferResult {
   {
     if ((http_code_ >= 400) && (http_code_ <= 599)) {
       return Error(
-          "OpenAI response returns HTTP code " + std::to_string(http_code_));
+          "OpenAI response returns HTTP code " + std::to_string(http_code_) +
+          ": " + serialized_response_);
     }
     return Error::Success;
   }


### PR DESCRIPTION
Perf Analyzer returns the error code when there is an OpenAI error returned. It does not return the message. This makes debugging harder for users, since they do not know what went wrong.

This pull request makes it so that PA forwards the error message back to the user.

Before:
![image](https://github.com/user-attachments/assets/c71e6d19-8dab-456e-8baf-c6195cc344a8)

After:
![image](https://github.com/user-attachments/assets/47305024-eed9-4e67-975e-2e0ee2019f04)
