### PR TITLE
Add headers as a native arg in GenAI-Perf

### DIFF
--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -343,12 +343,10 @@ AUTHENTICATION
 
 GenAI-Perf can benchmark secure endpoints such as OpenAI, which require API
 key authentication. To do so, you must add your API key directly in the command.
-At the end of your command, append the below flags. Replace the key with your
-API key. The `--` flag allows arguments to pass directly into Perf Analyzer in
-superuser mode. The `-H` flag is used to add HTTP headers.
+Add the following flag to your command.
 
 ```bash
--- -H "Authorization: Bearer ${API_KEY}" -H "Accept: text/event-stream"
+-h "Authorization: Bearer ${API_KEY}" -H "Accept: text/event-stream"
 ```
 
 </br>
@@ -376,6 +374,13 @@ the inference server.
 | <span id="request_throughput_metric">Request Throughput</span> | Number of final responses from benchmark divided by benchmark duration | None–one value per benchmark |
 
 </br>
+
+### Telemetry Metrics
+
+When using the Triton service kind, Telemetry metrics will be reported in
+the GenAI-Perf profile export files. These include GPU power usage, GPU
+utilization, energy consumption, total GPU memory, and more. If you would like
+these to be printed as output, you can use the `--verbose` flag.
 
 <!--
 ======================
@@ -459,6 +464,12 @@ image retrieval endpoint type.
 Provide additional inputs to include with every request. You can repeat this
 flag for multiple inputs. Inputs should be in an input_name:value format.
 Alternatively, a string representing a json formatted dict can be provided.
+(default: `None`)
+
+##### `--header <str>`
+##### `--h <str>`
+Add a custom header to the requests. Headers must be specified as
+'Header:Value'. You can repeat this flag for multiple headers.
 (default: `None`)
 
 ##### `--input-file <path>`

--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -346,7 +346,7 @@ key authentication. To do so, you must add your API key directly in the command.
 Add the following flag to your command.
 
 ```bash
--h "Authorization: Bearer ${API_KEY}" -H "Accept: text/event-stream"
+-H "Authorization: Bearer ${API_KEY}" -H "Accept: text/event-stream"
 ```
 
 </br>
@@ -467,7 +467,7 @@ Alternatively, a string representing a json formatted dict can be provided.
 (default: `None`)
 
 ##### `--header <str>`
-##### `--h <str>`
+##### `--H <str>`
 Add a custom header to the requests. Headers must be specified as
 'Header:Value'. You can repeat this flag for multiple headers.
 (default: `None`)

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -753,7 +753,7 @@ def _add_input_args(parser):
 
     input_group.add_argument(
         "--header",
-        "-h",
+        "-H",
         action="append",
         help="Add a custom header to the requests. "
         "Headers must be specified as 'Header:Value'. "

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -734,7 +734,7 @@ def _add_input_args(parser):
         "--extra-inputs",
         action="append",
         help="Provide additional inputs to include with every request. "
-        "You can repeat this flag for multiple inputs. Inputs should be in an input_name:value format. "
+        "You can repeat this flag for multiple inputs. Inputs should be in an 'input_name:value' format. "
         "Alternatively, a string representing a json formatted dict can be provided.",
     )
 
@@ -749,6 +749,15 @@ def _add_input_args(parser):
         "either milliseconds or a throughput value per second. For example, "
         "'request_latency:300' or 'output_token_throughput_per_request:600'. "
         "Multiple key:value pairs can be provided, separated by spaces. ",
+    )
+
+    input_group.add_argument(
+        "--header",
+        "-h",
+        action="append",
+        help="Add a custom header to the requests. "
+        "Headers must be specified as 'Header:Value'. "
+        "You can repeat this flag for multiple headers.",
     )
 
     input_group.add_argument(

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -140,6 +140,9 @@ class Profiler:
             # against tensorrtllm engine.
             elif arg == "service_kind" and value == "tensorrtllm_engine":
                 cmd += ["--service-kind", "triton_c_api", "--streaming"]
+            elif arg == "header":
+                for header in value:
+                    cmd += ["-H", header]
             else:
                 if len(arg) == 1:
                     cmd += [f"-{arg}", f"{value}"]

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -186,7 +186,7 @@ class TestCLIArguments:
                     ]
                 },
             ),
-            (["-h", "header_name:value"], {"header": ["header_name:value"]}),
+            (["-H", "header_name:value"], {"header": ["header_name:value"]}),
             (["--header", "header_name:value"], {"header": ["header_name:value"]}),
             (
                 ["--header", "header_name:value", "--header", "header_name_2:value_2"],

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -186,6 +186,12 @@ class TestCLIArguments:
                     ]
                 },
             ),
+            (["-h", "header_name:value"], {"header": ["header_name:value"]}),
+            (["--header", "header_name:value"], {"header": ["header_name:value"]}),
+            (
+                ["--header", "header_name:value", "--header", "header_name_2:value_2"],
+                {"header": ["header_name:value", "header_name_2:value_2"]},
+            ),
             (["--measurement-interval", "100"], {"measurement_interval": 100}),
             (
                 ["--model-selection-strategy", "random"],

--- a/genai-perf/tests/test_exporters/test_json_exporter.py
+++ b/genai-perf/tests/test_exporters/test_json_exporter.py
@@ -253,6 +253,7 @@ class TestJsonExporter:
           "tokenizer_trust_remote_code": false,
           "verbose": false,
           "goodput": null,
+          "header": null,
           "subcommand": "profile",
           "prompt_source": "synthetic",
           "extra_inputs": {

--- a/templates/genai-perf-templates/README_template
+++ b/templates/genai-perf-templates/README_template
@@ -332,12 +332,10 @@ AUTHENTICATION
 
 GenAI-Perf can benchmark secure endpoints such as OpenAI, which require API
 key authentication. To do so, you must add your API key directly in the command.
-At the end of your command, append the below flags. Replace the key with your
-API key. The `--` flag allows arguments to pass directly into Perf Analyzer in
-superuser mode. The `-H` flag is used to add HTTP headers.
+Add the following flag to your command.
 
 ```bash
--- -H "Authorization: Bearer ${API_KEY}" -H "Accept: text/event-stream"
+-h "Authorization: Bearer ${API_KEY}" -H "Accept: text/event-stream"
 ```
 
 </br>
@@ -365,6 +363,13 @@ the inference server.
 | <span id="request_throughput_metric">Request Throughput</span> | Number of final responses from benchmark divided by benchmark duration | None–one value per benchmark |
 
 </br>
+
+### Telemetry Metrics
+
+When using the Triton service kind, Telemetry metrics will be reported in
+the GenAI-Perf profile export files. These include GPU power usage, GPU
+utilization, energy consumption, total GPU memory, and more. If you would like
+these to be printed as output, you can use the `--verbose` flag.
 
 <!--
 ======================
@@ -448,6 +453,12 @@ image retrieval endpoint type.
 Provide additional inputs to include with every request. You can repeat this
 flag for multiple inputs. Inputs should be in an input_name:value format.
 Alternatively, a string representing a json formatted dict can be provided.
+(default: `None`)
+
+##### `--header <str>`
+##### `--h <str>`
+Add a custom header to the requests. Headers must be specified as
+'Header:Value'. You can repeat this flag for multiple headers.
 (default: `None`)
 
 ##### `--input-file <path>`


### PR DESCRIPTION
Headers are increasingly used for authentication. These should be moved from superuser args to GenAI-Perf-native args. This pull request adds the flag `--header`/`-h` for users within GenAI-Perf.

This also adds documentation for Telemetry metrics.

Screenshot of generated PA command with headers:
![image](https://github.com/user-attachments/assets/8eee2858-4b4b-4338-b990-86e0d955f0ad)
