### PR TITLE
Add request count as a metric

### DIFF
--- a/genai-perf/genai_perf/metrics/metrics.py
+++ b/genai-perf/genai_perf/metrics/metrics.py
@@ -51,6 +51,7 @@ class Metrics:
         # (TMA-1977) Make the unit consistent with statistics dict (e.g. tokens/sec)
         MetricMetadata("request_throughput", "per sec"),
         MetricMetadata("request_goodput", "per sec"),
+        MetricMetadata("request_count", "count"),
     ]
 
     def __init__(
@@ -62,10 +63,12 @@ class Metrics:
         self.request_throughputs = request_throughputs
         self.request_latencies = request_latencies
         self.request_goodputs = request_goodputs
+        self.request_count = [len(request_latencies)]
         self._base_names = {
             "request_throughputs": "request_throughput",
             "request_latencies": "request_latency",
             "request_goodputs": "request_goodput",
+            "request_count": "request_count",
         }
 
     def __repr__(self):

--- a/genai-perf/genai_perf/metrics/statistics.py
+++ b/genai-perf/genai_perf/metrics/statistics.py
@@ -127,6 +127,8 @@ class Statistics:
             self._stats_dict[key]["unit"] = "ms"
         elif key in ["request_throughput", "request_goodput"]:
             self._stats_dict[key]["unit"] = "requests/sec"
+        elif key == "request_count":
+            self._stats_dict[key]["unit"] = "count"
         elif key == "image_throughput":
             self._stats_dict[key]["unit"] = "pages/sec"
         elif key.startswith("output_token_throughput"):

--- a/genai-perf/genai_perf/record/types/request_count_avg.py
+++ b/genai-perf/genai_perf/record/types/request_count_avg.py
@@ -1,0 +1,50 @@
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.record import IncreasingRecord, ReductionFactor
+
+
+@total_ordering
+class RequestCountAvg(IncreasingRecord):
+    """
+    A record avg request count metric
+    """
+
+    tag = "request_count_avg"
+    reduction_factor = ReductionFactor.NONE
+
+    def __init__(self, value, timestamp=0):
+        super().__init__(value, timestamp)
+
+    @staticmethod
+    def value_function():
+        return sum
+
+    @staticmethod
+    def header(aggregation_tag=False) -> str:
+        return "Request Count (requests/sec)"
+
+    def __eq__(self, other: "RequestCountAvg") -> bool:  # type: ignore
+        return self.value() == other.value()
+
+    def __lt__(self, other: "RequestCountAvg") -> bool:
+        return self.value() < other.value()
+
+    def __add__(self, other: "RequestCountAvg") -> "RequestCountAvg":
+        return self.__class__(value=(self.value() + other.value()))
+
+    def __sub__(self, other: "RequestCountAvg") -> "RequestCountAvg":
+        return self.__class__(value=(self.value() - other.value()))

--- a/genai-perf/tests/test_exporters/test_console_exporter.py
+++ b/genai-perf/tests/test_exporters/test_console_exporter.py
@@ -91,6 +91,7 @@ class TestConsoleExporter:
             "│             Input sequence length │ 6.00 │ 5.00 │ 7.00 │ 6.98 │  6.80 │ 6.50 │\n"
             "│ Output token throughput (per sec) │ 456… │  N/A │  N/A │  N/A │   N/A │  N/A │\n"
             "│      Request throughput (per sec) │ 123… │  N/A │  N/A │  N/A │   N/A │  N/A │\n"
+            "│             Request count (count) │ 3.00 │  N/A │  N/A │  N/A │   N/A │  N/A │\n"
             "└───────────────────────────────────┴──────┴──────┴──────┴──────┴───────┴──────┘\n"
         )
 
@@ -142,6 +143,7 @@ class TestConsoleExporter:
             "│             Input sequence length │  6.00 │ 5.00 │ 7.00 │ 6.98 │ 6.80 │ 6.50 │\n"
             "│ Output token throughput (per sec) │ 456.… │  N/A │  N/A │  N/A │  N/A │  N/A │\n"
             "│      Request throughput (per sec) │ 123.… │  N/A │  N/A │  N/A │  N/A │  N/A │\n"
+            "│             Request count (count) │  3.00 │  N/A │  N/A │  N/A │  N/A │  N/A │\n"
             "└───────────────────────────────────┴───────┴──────┴──────┴──────┴──────┴──────┘\n"
         )
 
@@ -183,6 +185,7 @@ class TestConsoleExporter:
             "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━┩\n"
             "│         Request latency (ms) │   5.00 │ 4.00 │ 6.00 │ 5.98 │ 5.80 │ 5.50 │\n"
             "│ Request throughput (per sec) │ 123.00 │  N/A │  N/A │  N/A │  N/A │  N/A │\n"
+            "│        Request count (count) │   3.00 │  N/A │  N/A │  N/A │  N/A │  N/A │\n"
             "└──────────────────────────────┴────────┴──────┴──────┴──────┴──────┴──────┘\n"
         )
 
@@ -241,6 +244,7 @@ class TestConsoleExporter:
             "│ Output token throughput (per sec) │ 456… │  N/A │  N/A │  N/A │   N/A │  N/A │\n"
             "│      Request throughput (per sec) │ 123… │  N/A │  N/A │  N/A │   N/A │  N/A │\n"
             "│         Request goodput (per sec) │ 100… │  N/A │  N/A │  N/A │   N/A │  N/A │\n"
+            "│             Request count (count) │ 3.00 │  N/A │  N/A │  N/A │   N/A │  N/A │\n"
             "└───────────────────────────────────┴──────┴──────┴──────┴──────┴───────┴──────┘\n"
         )
         returned_data = capsys.readouterr().out
@@ -299,6 +303,7 @@ class TestConsoleExporter:
             "│ Output token throughput (per sec) │ 456… │  N/A │  N/A │  N/A │   N/A │  N/A │\n"
             "│      Request throughput (per sec) │ 123… │  N/A │  N/A │  N/A │   N/A │  N/A │\n"
             "│         Request goodput (per sec) │ -1.… │  N/A │  N/A │  N/A │   N/A │  N/A │\n"
+            "│             Request count (count) │ 3.00 │  N/A │  N/A │  N/A │   N/A │  N/A │\n"
             "└───────────────────────────────────┴──────┴──────┴──────┴──────┴───────┴──────┘\n"
         )
         returned_data = capsys.readouterr().out
@@ -412,6 +417,7 @@ class TestConsoleExporter:
             "│             Input sequence length │ 6.00 │ 5.00 │ 7.00 │ 6.98 │  6.80 │ 6.50 │\n"
             "│ Output token throughput (per sec) │ 456… │  N/A │  N/A │  N/A │   N/A │  N/A │\n"
             "│      Request throughput (per sec) │ 123… │  N/A │  N/A │  N/A │   N/A │  N/A │\n"
+            "│             Request count (count) │ 3.00 │  N/A │  N/A │  N/A │   N/A │  N/A │\n"
             "└───────────────────────────────────┴──────┴──────┴──────┴──────┴───────┴──────┘\n"
             "                NVIDIA GenAI-Perf | Power Metrics                \n"
             "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n"
@@ -519,6 +525,7 @@ class TestConsoleExporter:
             "│             Input sequence length │   N/A │  N/A │  N/A │  N/A │  N/A │  N/A │\n"
             "│ Output token throughput (per sec) │ 456.… │  N/A │  N/A │  N/A │  N/A │  N/A │\n"
             "│      Request throughput (per sec) │ 123.… │  N/A │  N/A │  N/A │  N/A │  N/A │\n"
+            "│             Request count (count) │  3.00 │  N/A │  N/A │  N/A │  N/A │  N/A │\n"
             "└───────────────────────────────────┴───────┴──────┴──────┴──────┴──────┴──────┘\n"
         )
 

--- a/genai-perf/tests/test_exporters/test_csv_exporter.py
+++ b/genai-perf/tests/test_exporters/test_csv_exporter.py
@@ -125,6 +125,7 @@ class TestCsvExporter:
             "Metric,Value\r\n",
             "Output Token Throughput (per sec),456.00\r\n",
             "Request Throughput (per sec),123.00\r\n",
+            "Request Count (count),3.00\r\n",
         ]
         expected_filename = "profile_export_genai_perf.csv"
         returned_data = [
@@ -178,6 +179,7 @@ class TestCsvExporter:
             "Metric,Value\r\n",
             "Output Token Throughput (per sec),456.00\r\n",
             "Request Throughput (per sec),123.00\r\n",
+            "Request Count (count),3.00\r\n",
         ]
         returned_data = [
             data for filename, data in mock_read_write if filename == expected_filename
@@ -222,6 +224,7 @@ class TestCsvExporter:
             "\r\n",
             "Metric,Value\r\n",
             "Request Throughput (per sec),123.00\r\n",
+            "Request Count (count),3.00\r\n",
         ]
         returned_data = [data for _, data in mock_read_write]
         assert returned_data == expected_content
@@ -275,7 +278,7 @@ class TestCsvExporter:
             if os.path.basename(filename) == expected_filename
         ]
 
-        assert returned_data[-1] == expected_content
+        assert returned_data[-2] == expected_content
 
     def test_invalid_goodput_csv_output(
         self, monkeypatch, mock_read_write: pytest.MonkeyPatch
@@ -327,7 +330,7 @@ class TestCsvExporter:
             if os.path.basename(filename) == expected_filename
         ]
 
-        assert returned_data[-1] == expected_content
+        assert returned_data[-2] == expected_content
 
     def test_triton_telemetry_output(
         self, monkeypatch, mock_read_write: pytest.MonkeyPatch, llm_metrics: LLMMetrics
@@ -380,6 +383,7 @@ class TestCsvExporter:
             "Metric,Value\r\n",
             "Output Token Throughput (per sec),456.00\r\n",
             "Request Throughput (per sec),123.00\r\n",
+            "Request Count (count),3.00\r\n",
             "\r\n",
             "Metric,GPU,avg,min,max,p99,p95,p90,p75,p50,p25\r\n",
             "GPU Power Usage (W),gpu0,45.85,45.20,46.50,46.49,46.44,46.37,46.17,45.85,45.53\r\n",
@@ -448,6 +452,7 @@ class TestCsvExporter:
             "Metric,Value\r\n",
             "Output Token Throughput (per sec),456.00\r\n",
             "Request Throughput (per sec),123.00\r\n",
+            "Request Count (count),3.00\r\n",
         ]
         returned_data = [
             data for filename, data in mock_read_write if filename == expected_filename

--- a/genai-perf/tests/test_metrics/test_llm_metrics.py
+++ b/genai-perf/tests/test_metrics/test_llm_metrics.py
@@ -115,13 +115,16 @@ class TestLLMMetrics:
         )
 
         sys_metrics = m.system_metrics
-        assert len(sys_metrics) == 3
+        assert len(sys_metrics) == 4
         assert sys_metrics[0].name == "output_token_throughput"
         assert sys_metrics[0].unit == "per sec"
         assert sys_metrics[1].name == "request_throughput"
         assert sys_metrics[1].unit == "per sec"
         assert sys_metrics[2].name == "request_goodput"
         assert sys_metrics[2].unit == "per sec"
+        assert sys_metrics[3].name == "request_count"
+        assert sys_metrics[3].unit == "count"
+        assert m.data.get("request_count") == [2]
 
     def test_llm_metrics_get_base_name(self) -> None:
         """Test get_base_name method in LLMMetrics class."""

--- a/genai-perf/tests/test_metrics/test_metrics.py
+++ b/genai-perf/tests/test_metrics/test_metrics.py
@@ -50,11 +50,14 @@ class TestMetrics:
             request_goodputs=[9.88, 10.22],
         )
         sys_metrics = m.system_metrics
-        assert len(sys_metrics) == 2
+        assert len(sys_metrics) == 3
         assert sys_metrics[0].name == "request_throughput"
         assert sys_metrics[0].unit == "per sec"
         assert sys_metrics[1].name == "request_goodput"
         assert sys_metrics[1].unit == "per sec"
+        assert sys_metrics[2].name == "request_count"
+        assert sys_metrics[2].unit == "count"
+        assert m.data.get("request_count") == [2]
 
     def test_metrics_get_base_name(self) -> None:
         """Test get_base_name method in Metrics class."""
@@ -66,5 +69,6 @@ class TestMetrics:
         assert metrics.get_base_name("request_throughputs") == "request_throughput"
         assert metrics.get_base_name("request_latencies") == "request_latency"
         assert metrics.get_base_name("request_goodputs") == "request_goodput"
+        assert metrics.get_base_name("request_count") == "request_count"
         with pytest.raises(KeyError):
             metrics.get_base_name("hello1234")

--- a/genai-perf/tests/test_record.py
+++ b/genai-perf/tests/test_record.py
@@ -113,6 +113,7 @@ class TestRecord(unittest.TestCase):
             for t in [
                 "request_throughput_avg",
                 "request_goodput_avg",
+                "request_count_avg",
                 "output_token_throughput_avg",
                 "output_token_throughput_per_request_min",
                 "output_token_throughput_per_request_max",


### PR DESCRIPTION
GenAI-Perf should print request count as a metric to help with validation, similar to how it is printed for PA. This pull request makes it so that request count is exported.

Example of updated output table:
![image](https://github.com/user-attachments/assets/b6d9db3f-bab7-44c3-8e40-3e21362f1ac5)
