### PR TITLE
Allow direct payloads to be passed into GenAI-Perf

### DIFF
--- a/genai-perf/genai_perf/inputs/inputs_config.py
+++ b/genai-perf/genai_perf/inputs/inputs_config.py
@@ -129,6 +129,12 @@ class InputsConfig:
     # The directory where all arifacts are saved
     output_dir: Path = Path("")
 
+    # If true, the input data is a direct payload
+    payload_mode: bool = False
+
+    # Path to the direct payload file
+    payload_path: Optional[str] = None
+
     ########################################
     # Synthetic Prompt Generation Parameters
     ########################################

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -496,7 +496,7 @@ def _convert_str_to_enum_entry(args, option, enum):
 
 
 def file_or_directory(value: str) -> Path:
-    if value.startswith("synthetic:"):
+    if value.startswith("synthetic:") or value.startswith("payload:"):
         return Path(value)
     else:
         path = Path(value)
@@ -761,6 +761,9 @@ def _add_input_args(parser):
         "You can repeat this flag for multiple headers.",
     )
 
+    ## TODO: Update this to have an option for --input-file
+    ## payload:<path_to_payload_file>. Not doing this now to
+    ## avoid making it harder to rebase the delay feature branch.
     input_group.add_argument(
         "--input-file",
         type=file_or_directory,

--- a/genai-perf/genai_perf/subcommand/common.py
+++ b/genai-perf/genai_perf/subcommand/common.py
@@ -154,6 +154,14 @@ def create_config_options(args: Namespace) -> InputsConfig:
     except ValueError as e:
         raise GenAIPerfException(e)
 
+    input_file = str(args.input_file)
+    if input_file.startswith("payload:"):
+        payload_mode = True
+        payload_path = input_file.split("payload:")[1]
+    else:
+        payload_mode = False
+        payload_path = None
+
     return InputsConfig(
         input_type=args.prompt_source,
         output_format=args.output_format,
@@ -185,6 +193,8 @@ def create_config_options(args: Namespace) -> InputsConfig:
         output_dir=args.artifact_dir,
         num_prefix_prompts=args.num_prefix_prompts,
         prefix_prompt_length=args.prefix_prompt_length,
+        payload_mode=payload_mode,
+        payload_path=payload_path,
     )
 
 


### PR DESCRIPTION
Allow direct payloads to be passed into GenAI-Perf as a JSONL file.

If we proceed with this feature, we'll need to update the parser descriptions and docs. We'll want to add unit testing and a CI test.

**Example:**

Server run command: `docker run -it --net=host --gpus=all vllm/vllm-openai:latest --model gpt2 --dtype float16 --max-model-len 1024`

Direct payload file (JSONL):
```jsonl
{"model": "gpt2", "prompt": ["Generate an example of a user profile."], "stream": false, "temperature": 0.0}
```

Example command: `genai-perf profile -v -m gpt2 --service-kind openai --endpoint-type completions --input-file payload:direct_payload_example.jsonl`

Output:
![image](https://github.com/user-attachments/assets/e20b167d-acd8-4288-b669-43b626cbcb66)
