### PR TITLE
Fix GAP OSL issue due to PA not removing first 4 bytes from output

### DIFF
--- a/src/client_backend/triton_c_api/triton_loader.cc
+++ b/src/client_backend/triton_c_api/triton_loader.cc
@@ -1048,10 +1048,6 @@ TritonLoader::GetOutputs(
 
     std::string data_type{datatype};
     std::vector<uint8_t> data_copy;
-    if (data_type == "BYTES" && byte_size >= 4) {
-      base = static_cast<const uint8_t*>(base) + 4;
-      byte_size -= 4;
-    }
 
     if (memory_type == TRITONSERVER_MEMORY_GPU) {
       CUDARuntimeLibraryManager cuda_manager;

--- a/src/infer_context.cc
+++ b/src/infer_context.cc
@@ -220,6 +220,10 @@ InferContext::GetOutputs(const cb::InferResult& infer_result)
     std::vector<uint8_t> buf{};
     infer_result.RawData(requested_output->Name(), buf);
 
+    if (data_type == "BYTES" && buf.size() >= 4) {
+      buf.erase(buf.begin(), buf.begin() + 4);
+    }
+
     output.emplace(
         requested_output->Name(), RecordData(std::move(buf), data_type));
   }


### PR DESCRIPTION
PA removes first 4 bytes from output when datatype is BYTES.

When fixing L0_CApi segfault, this piece of code was moved to another file, to reduce overhead by avoiding vector resizing. Hence, PA removes first 4 bytes only when using Triton CAPI mode, which caused OSL increase.


This PR fixes the above issue by placing back the code in the original file.