### PR TITLE
test: Fix L0_perf_analyzer_doc_links

### DIFF
--- a/docs/measurements_metrics.md
+++ b/docs/measurements_metrics.md
@@ -111,18 +111,7 @@ NOTE: The rows in the CSV file are sorted in an increasing order of throughput
 (Inferences/Second).
 
 You can import the CSV file into a spreadsheet to help visualize the latency vs
-inferences/second tradeoff as well as see some components of the latency. Follow
-these steps:
-
-- Open
-  [this spreadsheet](https://docs.google.com/spreadsheets/d/1S8h0bWBBElHUoLd2SOvQPzZzRiQ55xjyqodm_9ireiw)
-- Make a copy from the File menu "Make a copy..."
-- Open the copy
-- Select the A1 cell on the "Raw Data" tab
-- From the File menu select "Import..."
-- Select "Upload" and upload the file
-- Select "Replace data at selected cell" and then select the "Import data"
-  button
+inferences/second tradeoff as well as see some components of the latency.
 
 ## Server-side Prometheus metrics
 


### PR DESCRIPTION
Fixes broken spreadsheet link by removing spreadsheet section - I don't think we need to tell people how to import CSV to Google Sheets in our documentation.

We can also update the spreadsheet link if we have a new one, I don't mind either way.

---

Error:
```
++ grep 'invalid url' /opt/tritonserver/qa/L0_perf_analyzer_doc_links/doc_links.log
+ [[ ! -z invalid url - https://docs.google.com/spreadsheets/d/1S8h0bWBBElHUoLd2SOvQPzZzRiQ55xjyqodm_9ireiw [410] [measurements_metrics.md] ]]
+ cat /opt/tritonserver/qa/L0_perf_analyzer_doc_links/doc_links.log
invalid url - https://docs.google.com/spreadsheets/d/1S8h0bWBBElHUoLd2SOvQPzZzRiQ55xjyqodm_9ireiw [410] [measurements_metrics.md]
+ RET=1
```

Test: https://github.com/triton-inference-server/server/blob/main/qa/L0_doc_links/test.sh