### PR TITLE
Don't change the casing of model parameters.

### DIFF
--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -1648,7 +1648,6 @@ CLParser::ParseCommandLine(int argc, char** argv)
                 "<name:value:type>.");
           }
 
-          std::for_each(values.begin(), values.end(), ToLowerCase);
           std::string name{values[0]};
           std::string value{values[1]};
           std::string type{values[2]};

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -1651,6 +1651,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
           std::string name{values[0]};
           std::string value{values[1]};
           std::string type{values[2]};
+          ToLowerCase(type);  // to string-match the type
 
           cb::RequestParameter param;
           param.name = name;


### PR DESCRIPTION
cc @debermudez 

I have very low confidence we won't break anything with this change. @nv-hwoo do you remember why this feature from 2 years ago needed to have lower case parameters?