### PR TITLE
Telemetry support for multiple metric endpoints

### DIFF
--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions

--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -415,6 +415,13 @@ Set a custom endpoint that differs from the OpenAI defaults. (default: `None`)
 The endpoint-type to send requests to on the server. This is only used with the
 `openai` service-kind. (default: `None`)
 
+##### `--server-metrics-url <list>`
+
+The list of Triton server metrics URLs. These are used for Telemetry metric
+reporting with the Triton service-kind. Example usage: --server-metrics-url
+http://server1:8002/metrics http://server2:8002/metrics.
+(default: `http://localhost:8002/metrics`)
+
 ##### `--service-kind {triton,openai}`
 
 The kind of service perf_analyzer will generate load for. In order to use

--- a/genai-perf/genai_perf/constants.py
+++ b/genai-perf/genai_perf/constants.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/genai_perf/constants.py
+++ b/genai-perf/genai_perf/constants.py
@@ -27,7 +27,7 @@
 ABBREVIATIONS = ["gpu"]
 DEFAULT_HTTP_URL = "localhost:8000"
 DEFAULT_GRPC_URL = "localhost:8001"
-DEFAULT_TRITON_METRICS_URL = "localhost:8002/metrics"
+DEFAULT_TRITON_METRICS_URL = "http://localhost:8002/metrics"
 
 
 DEFAULT_ARTIFACT_DIR = "artifacts"

--- a/genai-perf/genai_perf/export_data/exporter_config.py
+++ b/genai-perf/genai_perf/export_data/exporter_config.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/genai_perf/export_data/exporter_config.py
+++ b/genai-perf/genai_perf/export_data/exporter_config.py
@@ -26,9 +26,7 @@
 
 
 import argparse as args
-from dataclasses import dataclass
-from dataclasses import field
-from dataclasses import field as default_factory
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict
 

--- a/genai-perf/genai_perf/export_data/exporter_config.py
+++ b/genai-perf/genai_perf/export_data/exporter_config.py
@@ -27,8 +27,10 @@
 
 import argparse as args
 from dataclasses import dataclass
+from dataclasses import field
+from dataclasses import field as default_factory
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from genai_perf.metrics import Metrics
 
@@ -40,4 +42,4 @@ class ExporterConfig:
     args: args.Namespace
     extra_inputs: Dict[str, Any]
     artifact_dir: Path
-    telemetry_stats: Optional[Dict[str, Any]] = None
+    telemetry_stats: Dict[str, Any] = field(default_factory=dict)

--- a/genai-perf/genai_perf/export_data/json_exporter.py
+++ b/genai-perf/genai_perf/export_data/json_exporter.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/genai_perf/export_data/json_exporter.py
+++ b/genai-perf/genai_perf/export_data/json_exporter.py
@@ -28,7 +28,7 @@
 import json
 import os
 from enum import Enum
-from typing import Dict, Optional, Union
+from typing import Dict, Union
 
 import genai_perf.logging as logging
 from genai_perf.export_data import telemetry_data_exporter_util as telem_utils
@@ -44,9 +44,9 @@ class JsonExporter:
 
     def __init__(self, config: ExporterConfig):
         self._stats: Dict = config.stats
-        self._telemetry_stats: Optional[
-            Dict[str, Dict[str, Union[str, Dict[str, float]]]]
-        ] = config.telemetry_stats
+        self._telemetry_stats: Dict[str, Dict[str, Union[str, Dict[str, float]]]] = (
+            config.telemetry_stats
+        )
         self._args = dict(vars(config.args))
         self._extra_inputs = config.extra_inputs
         self._output_dir = config.artifact_dir

--- a/genai-perf/genai_perf/export_data/output_reporter.py
+++ b/genai-perf/genai_perf/export_data/output_reporter.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/genai_perf/export_data/output_reporter.py
+++ b/genai-perf/genai_perf/export_data/output_reporter.py
@@ -25,7 +25,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from argparse import Namespace
-from typing import Optional
 
 from genai_perf.export_data.data_exporter_factory import DataExporterFactory
 from genai_perf.export_data.exporter_config import ExporterConfig

--- a/genai-perf/genai_perf/export_data/output_reporter.py
+++ b/genai-perf/genai_perf/export_data/output_reporter.py
@@ -41,15 +41,14 @@ class OutputReporter:
     def __init__(
         self,
         stats: Statistics,
-        telemetry_stats: Optional[TelemetryStatistics],
+        telemetry_stats: TelemetryStatistics,
         args: Namespace,
     ):
         self.args = args
         self.stats = stats
         self.telemetry_stats = telemetry_stats
         self.stats.scale_data()
-        if self.telemetry_stats:
-            self.telemetry_stats.scale_data()
+        self.telemetry_stats.scale_data()
 
     def report_output(self) -> None:
         factory = DataExporterFactory()
@@ -62,9 +61,7 @@ class OutputReporter:
     def _create_exporter_config(self) -> ExporterConfig:
         assert isinstance(self.stats.metrics, Metrics)
         extra_inputs = get_extra_inputs_as_dict(self.args)
-        telemetry_stats = (
-            self.telemetry_stats.stats_dict if self.telemetry_stats else None
-        )
+        telemetry_stats = self.telemetry_stats.stats_dict
         config = ExporterConfig(
             self.stats.stats_dict,
             self.stats.metrics,

--- a/genai-perf/genai_perf/export_data/telemetry_data_exporter_util.py
+++ b/genai-perf/genai_perf/export_data/telemetry_data_exporter_util.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/genai_perf/export_data/telemetry_data_exporter_util.py
+++ b/genai-perf/genai_perf/export_data/telemetry_data_exporter_util.py
@@ -24,7 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from genai_perf.constants import ABBREVIATIONS
 from rich.console import Console
@@ -59,24 +59,19 @@ TELEMETRY_GROUPS = {
 }
 
 
-def merge_telemetry_stats_json(
-    telemetry_stats: Optional[Dict], stats_and_args: Dict
-) -> None:
-    if telemetry_stats is not None:
-        stats_and_args.update({"telemetry_stats": telemetry_stats})
+def merge_telemetry_stats_json(telemetry_stats: Dict, stats_and_args: Dict) -> None:
+    stats_and_args.update({"telemetry_stats": telemetry_stats})
 
 
-def export_telemetry_stats_csv(telemetry_stats: Optional[Dict], csv_writer) -> None:
-    if telemetry_stats:
-        _write_dynamic_telemetry_stats(telemetry_stats, csv_writer)
-        _write_constant_telemetry_stats(telemetry_stats, csv_writer)
+def export_telemetry_stats_csv(telemetry_stats: Dict, csv_writer) -> None:
+    _write_dynamic_telemetry_stats(telemetry_stats, csv_writer)
+    _write_constant_telemetry_stats(telemetry_stats, csv_writer)
 
 
 def export_telemetry_stats_console(
-    telemetry_stats: Optional[Dict], stat_column_keys: List[str], console: Console
+    telemetry_stats: Dict, stat_column_keys: List[str], console: Console
 ) -> None:
-    if telemetry_stats:
-        _construct_telemetry_stats_table(telemetry_stats, stat_column_keys, console)
+    _construct_telemetry_stats_table(telemetry_stats, stat_column_keys, console)
 
 
 def _construct_telemetry_stats_table(

--- a/genai-perf/genai_perf/metrics/telemetry_metrics.py
+++ b/genai-perf/genai_perf/metrics/telemetry_metrics.py
@@ -27,7 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from collections import defaultdict
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from genai_perf.metrics.metrics import MetricMetadata
 
@@ -58,19 +58,19 @@ class TelemetryMetrics:
 
     def __init__(
         self,
-        gpu_power_usage: Dict[str, List[float]] = defaultdict(list),
-        gpu_power_limit: Dict[str, List[float]] = defaultdict(list),
-        energy_consumption: Dict[str, List[float]] = defaultdict(list),
-        gpu_utilization: Dict[str, List[float]] = defaultdict(list),
-        total_gpu_memory: Dict[str, List[float]] = defaultdict(list),
-        gpu_memory_used: Dict[str, List[float]] = defaultdict(list),
-    ) -> None:
-        self.gpu_power_usage = gpu_power_usage
-        self.gpu_power_limit = gpu_power_limit
-        self.energy_consumption = energy_consumption
-        self.gpu_utilization = gpu_utilization
-        self.total_gpu_memory = total_gpu_memory
-        self.gpu_memory_used = gpu_memory_used
+        gpu_power_usage: Optional[Dict[str, List[float]]] = None,
+        gpu_power_limit: Optional[Dict[str, List[float]]] = None,
+        energy_consumption: Optional[Dict[str, List[float]]] = None,
+        gpu_utilization: Optional[Dict[str, List[float]]] = None,
+        total_gpu_memory: Optional[Dict[str, List[float]]] = None,
+        gpu_memory_used: Optional[Dict[str, List[float]]] = None,
+    ):
+        self.gpu_power_usage = defaultdict(list, gpu_power_usage or {})
+        self.gpu_power_limit = defaultdict(list, gpu_power_limit or {})
+        self.energy_consumption = defaultdict(list, energy_consumption or {})
+        self.gpu_utilization = defaultdict(list, gpu_utilization or {})
+        self.total_gpu_memory = defaultdict(list, total_gpu_memory or {})
+        self.gpu_memory_used = defaultdict(list, gpu_memory_used or {})
 
     def update_metrics(self, measurement_data: dict) -> None:
         for metric in self.TELEMETRY_METRICS:

--- a/genai-perf/genai_perf/metrics/telemetry_metrics.py
+++ b/genai-perf/genai_perf/metrics/telemetry_metrics.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/genai_perf/metrics/telemetry_statistics.py
+++ b/genai-perf/genai_perf/metrics/telemetry_statistics.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -56,21 +56,26 @@ class TelemetryStatistics:
                 self._stats_dict[attr][gpu_index]["avg"] = (
                     self._statistics._calculate_mean(gpu_data)
                 )
-            if not self._is_constant_metric(attr):
-                if gpu_data is None or gpu_index is None:
-                    continue
+                if not self._is_constant_metric(attr):
+                    if gpu_data is None or gpu_index is None:
+                        continue
 
-                percentile_results = self._statistics._calculate_percentiles(gpu_data)
-                for percentile_label, percentile_value in percentile_results.items():
-                    self._stats_dict[attr][gpu_index][
-                        percentile_label
-                    ] = percentile_value
-                min, max = self._statistics._calculate_minmax(gpu_data)
-                self._stats_dict[attr][gpu_index]["min"] = min
-                self._stats_dict[attr][gpu_index]["max"] = max
-                self._stats_dict[attr][gpu_index]["std"] = (
-                    self._statistics._calculate_std(gpu_data)
-                )
+                    percentile_results = self._statistics._calculate_percentiles(
+                        gpu_data
+                    )
+                    for (
+                        percentile_label,
+                        percentile_value,
+                    ) in percentile_results.items():
+                        self._stats_dict[attr][gpu_index][
+                            percentile_label
+                        ] = percentile_value
+                    min, max = self._statistics._calculate_minmax(gpu_data)
+                    self._stats_dict[attr][gpu_index]["min"] = min
+                    self._stats_dict[attr][gpu_index]["max"] = max
+                    self._stats_dict[attr][gpu_index]["std"] = (
+                        self._statistics._calculate_std(gpu_data)
+                    )
 
     def scale_data(self) -> None:
         SCALING_FACTORS = {

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -373,7 +373,7 @@ def _is_valid_url(parser: argparse.ArgumentParser, url: str) -> None:
         or parsed_url.port is None
     ):
         parser.error(
-            "The URL passed for --server-metrics-url is invalid. "
+            "Invalid URL passed for --server-metrics-url: {parsed_url}. "
             "It must use 'http' or 'https', have a valid domain and port, "
             "and contain '/metrics' in the path. The expected structure is: "
             "<scheme>://<netloc>/<path>;<params>?<query>#<fragment>"
@@ -393,12 +393,13 @@ def _check_server_metrics_url(
     parser: argparse.ArgumentParser, args: argparse.Namespace
 ) -> argparse.Namespace:
     """
-    Checks if the server metrics URL passed is valid
+    Checks if each server metrics URL passed is valid
     """
 
-    # Check if the URL is valid and contains the expected path
     if args.service_kind == "triton" and args.server_metrics_url:
-        _is_valid_url(parser, args.server_metrics_url)
+        for url in args.server_metrics_url:
+            # Check if the URL is valid and contains the expected path
+            _is_valid_url(parser, url)
 
     return args
 
@@ -637,11 +638,12 @@ def _add_endpoint_args(parser):
     endpoint_group.add_argument(
         "--server-metrics-url",
         type=str,
-        default=None,
+        nargs="+",
+        default=[],
         required=False,
-        help="The full URL to access the server metrics endpoint. "
-        "This argument is required if the metrics are available on "
-        "a different machine than localhost (where GenAI-Perf is running).",
+        help="List of server metrics URLs for multiple sources. Example "
+        "usage: --server-metrics-url http://server1:8002/metrics "
+        "http://server2:8002/metrics",
     )
 
     endpoint_group.add_argument(

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -355,7 +355,8 @@ def _is_valid_url(parser: argparse.ArgumentParser, url: str) -> None:
     """
     Validates a URL to ensure it meets the following criteria:
     - The scheme must be 'http' or 'https'.
-    - The netloc (domain) must be present OR the URL must be a valid localhost address.
+    - The netloc (domain) must be present OR the URL must be a valid localhost
+    address.
     - The path must contain '/metrics'.
     - The port must be specified.
 
@@ -369,24 +370,26 @@ def _is_valid_url(parser: argparse.ArgumentParser, url: str) -> None:
 
     if parsed_url.scheme not in ["http", "https"]:
         parser.error(
-            f"Invalid scheme '{parsed_url.scheme}' in URL: {url}. Use 'http' or 'https'."
+            f"Invalid scheme '{parsed_url.scheme}' in URL: {url}. Use 'http' "
+            "or 'https'."
         )
 
     valid_localhost = parsed_url.hostname in ["localhost", "127.0.0.1"]
 
     if not parsed_url.netloc and not valid_localhost:
         parser.error(
-            f"Invalid domain in URL: {url}. Use a valid hostname or 'localhost'."
+            f"Invalid domain in URL: {url}. Use a valid hostname or " "'localhost'."
         )
 
     if "/metrics" not in parsed_url.path:
         parser.error(
-            f"Invalid URL path '{parsed_url.path}' in {url}. The path must include '/metrics'."
+            f"Invalid URL path '{parsed_url.path}' in {url}. The path must "
+            "include '/metrics'."
         )
 
     if parsed_url.port is None:
         parser.error(
-            f"Port missing in URL: {url}. A port number is required (e.g., ':8002')."
+            f"Port missing in URL: {url}. A port number is required " "(e.g., ':8002')."
         )
 
 
@@ -408,7 +411,6 @@ def _check_server_metrics_url(
 
     if args.service_kind == "triton" and args.server_metrics_url:
         for url in args.server_metrics_url:
-            # Check if the URL is valid and contains the expected path
             _is_valid_url(parser, url)
 
     return args
@@ -651,7 +653,8 @@ def _add_endpoint_args(parser):
         nargs="+",
         default=[],
         required=False,
-        help="List of server metrics URLs for multiple sources. Example "
+        help="The list of Triton server metrics URLs. These are used for "
+        "Telemetry metric reporting with the Triton service-kind. Example "
         "usage: --server-metrics-url http://server1:8002/metrics "
         "http://server2:8002/metrics",
     )

--- a/genai-perf/genai_perf/subcommand/analyze.py
+++ b/genai-perf/genai_perf/subcommand/analyze.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/genai_perf/subcommand/common.py
+++ b/genai-perf/genai_perf/subcommand/common.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/genai_perf/subcommand/common.py
+++ b/genai-perf/genai_perf/subcommand/common.py
@@ -235,13 +235,15 @@ def merge_telemetry_metrics(metrics_list: List[TelemetryMetrics]) -> TelemetryMe
         TelemetryMetrics: A new TelemetryMetrics instance with merged raw data.
     """
 
-    merged_metrics = TelemetryMetrics()
+    merged_metrics = TelemetryMetrics()  # Create an empty instance
 
     for metrics in metrics_list:
-        for metric_name, gpu_data in metrics.data.items():
-            for gpu_id, values in gpu_data.items():
-                merged_metrics.data[gpu_id][metric_name].extend(
-                    values
-                )  # Merge raw lists
+        for metric in TelemetryMetrics.TELEMETRY_METRICS:
+            metric_key = metric.name
+            metric_dict = getattr(merged_metrics, metric_key)
+            source_dict = getattr(metrics, metric_key)
+
+            for gpu_id, values in source_dict.items():
+                metric_dict[gpu_id].extend(values)
 
     return merged_metrics

--- a/genai-perf/genai_perf/subcommand/common.py
+++ b/genai-perf/genai_perf/subcommand/common.py
@@ -235,7 +235,7 @@ def merge_telemetry_metrics(metrics_list: List[TelemetryMetrics]) -> TelemetryMe
         TelemetryMetrics: A new TelemetryMetrics instance with merged raw data.
     """
 
-    merged_metrics = TelemetryMetrics()  # Create an empty instance
+    merged_metrics = TelemetryMetrics()
 
     for metrics in metrics_list:
         for metric in TelemetryMetrics.TELEMETRY_METRICS:
@@ -245,5 +245,4 @@ def merge_telemetry_metrics(metrics_list: List[TelemetryMetrics]) -> TelemetryMe
 
             for gpu_id, values in source_dict.items():
                 metric_dict[gpu_id].extend(values)
-
     return merged_metrics

--- a/genai-perf/genai_perf/subcommand/profile.py
+++ b/genai-perf/genai_perf/subcommand/profile.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
@@ -69,6 +69,9 @@ class TelemetryDataCollector(ABC):
             self._stop_event.set()
             self._thread.join()
 
+    def get_metrics(self) -> TelemetryMetrics:
+        return self._metrics
+
     def get_statistics(self) -> TelemetryStatistics:
         telemetry_stats = TelemetryStatistics(self._metrics)
         return telemetry_stats

--- a/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/genai_perf/telemetry_data/triton_telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/triton_telemetry_data_collector.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/tests/integration_tests/test_telemetry.py
+++ b/genai-perf/tests/integration_tests/test_telemetry.py
@@ -1,0 +1,157 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import csv
+import json
+from io import StringIO
+from pathlib import Path
+from unittest.mock import create_autospec, mock_open, patch
+
+import genai_perf.parser as parser
+import pytest
+from genai_perf.metrics import Metrics, TelemetryMetrics, TelemetryStatistics
+from genai_perf.metrics.statistics import Statistics
+from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
+from genai_perf.profile_data_parser import ProfileDataParser
+from genai_perf.subcommand.profile import _report_output
+from genai_perf.telemetry_data.triton_telemetry_data_collector import (
+    TelemetryDataCollector,
+)
+from rich.console import Console
+
+
+class TestIntegrationTelemetry:
+
+    @pytest.fixture
+    def telemetry_1(self) -> TelemetryMetrics:
+        telemetry = TelemetryMetrics()
+        telemetry.update_metrics(
+            {
+                "gpu_power_usage": {"gpu0": [10.0, 20.0], "gpu1": [30.0]},
+                "gpu_utilization": {"gpu0": [50.0], "gpu1": [75.0]},
+            }
+        )
+        return telemetry
+
+    @pytest.fixture
+    def telemetry_2(self) -> TelemetryMetrics:
+        telemetry = TelemetryMetrics()
+        telemetry.update_metrics(
+            {
+                "gpu_power_usage": {"gpu0": [40.0], "gpu1": [60.0]},
+                "gpu_utilization": {"gpu0": [80.0], "gpu2": [90.0]},
+            }
+        )
+        return telemetry
+
+    def test_reporting_for_multiple_metric_urls(
+        self, capsys, monkeypatch, telemetry_1, telemetry_2
+    ):
+        """
+        An integration test for reporting Telemetry statistics with multiple metric URLs
+        """
+        test_args = [
+            "genai-perf",
+            "profile",
+            "--model",
+            "test_model",
+            "-v",
+        ]
+        monkeypatch.setattr("sys.argv", test_args)
+        args, _ = parser.parse_args()
+
+        mock_metrics = create_autospec(Metrics, instance=True)
+        mock_statistics = create_autospec(Statistics, instance=True)
+        mock_statistics.metrics = mock_metrics
+
+        mock_parser = create_autospec(ProfileDataParser, instance=True)
+        mock_parser.get_statistics.return_value = mock_statistics
+        mock_parser.metrics = mock_metrics
+
+        telemetry_collectors = [
+            create_autospec(TelemetryDataCollector, instance=True),
+            create_autospec(TelemetryDataCollector, instance=True),
+        ]
+        telemetry_collectors[0].get_metrics.return_value = telemetry_1
+        telemetry_collectors[1].get_metrics.return_value = telemetry_2
+
+        telemetry_collectors[0].get_statistics.return_value = TelemetryStatistics(
+            telemetry_1
+        )
+        telemetry_collectors[1].get_statistics.return_value = TelemetryStatistics(
+            telemetry_2
+        )
+
+        mock_file_open = mock_open()
+        csv_output = StringIO()
+        csv_writer = csv.writer(csv_output)
+        console = Console(record=True)
+
+        with patch("builtins.open", mock_file_open) as mocked_file, patch.object(
+            Path, "exists", return_value=True
+        ), patch("csv.writer", return_value=csv_writer), patch(
+            "rich.console.Console.print", side_effect=console.print
+        ):
+
+            _report_output(mock_parser, telemetry_collectors, args)
+
+            mock_file_open.assert_called()
+
+            assert mock_parser.get_statistics.called
+            assert telemetry_collectors[0].get_metrics.called
+            assert telemetry_collectors[1].get_metrics.called
+
+            written_json = None
+            mock_file_handle = mocked_file.return_value
+            for call in mock_file_handle.write.mock_calls:
+                json_candidate = json.loads(call.args[0])
+                if "telemetry_stats" in json_candidate:
+                    written_json = json_candidate
+                    break
+
+            assert written_json is not None, "JSON output was not generated"
+            assert (
+                "telemetry_stats" in written_json
+            ), "Telemetry statistics missing from JSON"
+            assert (
+                "gpu_power_usage" in written_json["telemetry_stats"]
+            ), "GPU power usage missing from JSON"
+            assert (
+                written_json["telemetry_stats"]["gpu_power_usage"]["gpu1"]["avg"]
+                == 45.0
+            ), "Expected average GPU power missing from JSON"
+
+            csv_output.seek(0)
+            csv_content = csv_output.read()
+            assert "GPU Power Usage" in csv_content, "Missing GPU power usage in CSV"
+            assert "GPU Utilization" in csv_content, "Missing GPU utilization in CSV"
+            assert "75" in csv_content, "Expected GPU utilization missing from CSV"
+
+            captured = capsys.readouterr()
+            assert "Power" in captured.out, "Missing Power section in console output"
+            assert (
+                "GPU Power Usage" in captured.out
+            ), "Missing GPU power usage in console output"
+            assert "75" in captured.out, "Expected GPU utilization missing from console"

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -637,17 +637,66 @@ class TestCLIArguments:
                 [
                     "genai-perf",
                     "profile",
-                    "--model",
+                    "-m",
+                    "test_model",
+                    "--service-kind",
+                    "triton",
+                    "--server-metrics-url",
+                    "ftp://invalid.com:8002/metrics",
+                ],
+                "Invalid scheme 'ftp' in URL: ftp://invalid.com:8002/metrics. Use 'http' or 'https'.",
+            ),
+            (
+                [
+                    "genai-perf",
+                    "profile",
+                    "-m",
+                    "test_model",
+                    "--service-kind",
+                    "triton",
+                    "--server-metrics-url",
+                    "http:///metrics",
+                ],
+                "Invalid domain in URL: http:///metrics. Use a valid hostname or 'localhost'.",
+            ),
+            (
+                [
+                    "genai-perf",
+                    "profile",
+                    "-m",
+                    "test_model",
+                    "--service-kind",
+                    "triton",
+                    "--server-metrics-url",
+                    "http://valid.com:8002/invalidpath",
+                ],
+                "Invalid URL path '/invalidpath' in http://valid.com:8002/invalidpath. The path must include '/metrics'.",
+            ),
+            (
+                [
+                    "genai-perf",
+                    "profile",
+                    "-m",
+                    "test_model",
+                    "--service-kind",
+                    "triton",
+                    "--server-metrics-url",
+                    "http://valid.com/metrics",
+                ],
+                "Port missing in URL: http://valid.com/metrics. A port number is required (e.g., ':8002').",
+            ),
+            (
+                [
+                    "genai-perf",
+                    "profile",
+                    "-m",
                     "test_model",
                     "--service-kind",
                     "triton",
                     "--server-metrics-url",
                     "invalid_url",
                 ],
-                "The URL passed for --server-metrics-url is invalid. "
-                "It must use 'http' or 'https', have a valid domain and port, "
-                "and contain '/metrics' in the path. The expected structure is: "
-                "<scheme>://<netloc>/<path>;<params>?<query>#<fragment>",
+                "Invalid scheme '' in URL: invalid_url. Use 'http' or 'https'.",
             ),
             (
                 [
@@ -984,7 +1033,7 @@ class TestCLIArguments:
                     "--server-metrics-url",
                     test_triton_metrics_url,
                 ],
-                test_triton_metrics_url,
+                [test_triton_metrics_url],
             ),
             # server-metrics-url is not specified
             (
@@ -996,7 +1045,7 @@ class TestCLIArguments:
                     "--service-kind",
                     "triton",
                 ],
-                None,
+                [],
             ),
         ],
     )

--- a/genai-perf/tests/test_collectors/test_create_telemetry_data_collector.py
+++ b/genai-perf/tests/test_collectors/test_create_telemetry_data_collector.py
@@ -30,7 +30,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from genai_perf.constants import DEFAULT_TRITON_METRICS_URL
-from genai_perf.subcommand.common import create_telemetry_data_collector
+from genai_perf.subcommand.common import create_telemetry_data_collectors
 from genai_perf.telemetry_data import TritonTelemetryDataCollector
 from requests import codes as http_codes
 
@@ -60,7 +60,7 @@ class TestCreateTelemetryDataCollector:
         mock_args = MockArgs(
             service_kind="triton", server_metrics_url=server_metrics_url
         )
-        telemetry_data_collector = create_telemetry_data_collector(mock_args)
+        telemetry_data_collector = create_telemetry_data_collectors(mock_args)[0]
 
         assert isinstance(telemetry_data_collector, TritonTelemetryDataCollector)
         assert telemetry_data_collector.metrics_url == expected_url
@@ -81,7 +81,7 @@ class TestCreateTelemetryDataCollector:
         mock_args = MockArgs(
             service_kind="triton", server_metrics_url=server_metrics_url
         )
-        telemetry_data_collector = create_telemetry_data_collector(mock_args)
+        telemetry_data_collector = create_telemetry_data_collectors(mock_args)[0]
 
         assert telemetry_data_collector is None
 
@@ -98,6 +98,6 @@ class TestCreateTelemetryDataCollector:
         mock_args = MockArgs(
             service_kind="openai", server_metrics_url=self.test_triton_metrics_url
         )
-        telemetry_data_collector = create_telemetry_data_collector(mock_args)
+        telemetry_data_collector = create_telemetry_data_collectors(mock_args)[0]
 
         assert telemetry_data_collector is None

--- a/genai-perf/tests/test_common.py
+++ b/genai-perf/tests/test_common.py
@@ -1,0 +1,54 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from genai_perf.subcommand.common import run_perf_analyzer
+
+
+class TestCommon:
+    @patch("genai_perf.subcommand.common.subprocess.run")
+    def test_stdout_verbose(self, mock_subprocess_run):
+        args = MagicMock()
+        args.model = "test_model"
+        args.verbose = True
+        run_perf_analyzer(
+            args=args,
+            extra_args=None,
+        )
+
+        # Check that standard output was not redirected.
+        for call_args in mock_subprocess_run.call_args_list:
+            _, kwargs = call_args
+            assert (
+                "stdout" not in kwargs or kwargs["stdout"] is None
+            ), "With the verbose flag, stdout should not be redirected."
+
+    @patch("genai_perf.subcommand.common.subprocess.run")
+    def test_stdout_not_verbose(self, mock_subprocess_run):
+        args = MagicMock()
+        args.model = "test_model"
+        args.verbose = False
+        run_perf_analyzer(
+            args=args,
+            extra_args=None,
+        )
+
+        # Check that standard output was redirected.
+        for call_args in mock_subprocess_run.call_args_list:
+            _, kwargs = call_args
+            assert (
+                kwargs["stdout"] is subprocess.DEVNULL
+            ), "When the verbose flag is not passed, stdout should be redirected to /dev/null."

--- a/genai-perf/tests/test_exporters/test_json_exporter.py
+++ b/genai-perf/tests/test_exporters/test_json_exporter.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/tests/test_exporters/test_json_exporter.py
+++ b/genai-perf/tests/test_exporters/test_json_exporter.py
@@ -222,7 +222,7 @@ class TestJsonExporter:
           "endpoint": null,
           "endpoint_type": "kserve",
           "service_kind": "triton",
-          "server_metrics_url": null,
+          "server_metrics_url": [],
           "streaming": true,
           "u": null,
           "num_dataset_entries": 100,

--- a/genai-perf/tests/test_exporters/test_telemetry_data_exporter_util.py
+++ b/genai-perf/tests/test_exporters/test_telemetry_data_exporter_util.py
@@ -1,0 +1,93 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
+from genai_perf.subcommand.common import merge_telemetry_metrics
+
+
+class TestMergeTelemetryMetrics:
+
+    @pytest.fixture
+    def telemetry_1(self) -> TelemetryMetrics:
+        telemetry = TelemetryMetrics()
+        telemetry.update_metrics(
+            {
+                "gpu_power_usage": {"gpu0": [10.0, 20.0], "gpu1": [30.0]},
+                "gpu_utilization": {"gpu0": [50.0], "gpu1": [75.0]},
+            }
+        )
+        return telemetry
+
+    @pytest.fixture
+    def telemetry_2(self) -> TelemetryMetrics:
+        telemetry = TelemetryMetrics()
+        telemetry.update_metrics(
+            {
+                "gpu_power_usage": {"gpu0": [40.0], "gpu1": [60.0]},
+                "gpu_utilization": {"gpu0": [80.0], "gpu2": [90.0]},
+            }
+        )
+        return telemetry
+
+    def test_merge_identical_metrics(self, telemetry_1):
+        merged = merge_telemetry_metrics([telemetry_1, telemetry_1])
+
+        assert merged.gpu_power_usage["gpu0"] == [10.0, 20.0, 10.0, 20.0]
+        assert merged.gpu_power_usage["gpu1"] == [30.0, 30.0]
+        assert merged.gpu_utilization["gpu0"] == [50.0, 50.0]
+        assert merged.gpu_utilization["gpu1"] == [75.0, 75.0]
+
+        assert set(merged.gpu_power_usage.keys()) == {"gpu0", "gpu1"}
+        assert set(merged.gpu_utilization.keys()) == {"gpu0", "gpu1"}
+
+    def test_merge_different_gpus(self, telemetry_1, telemetry_2):
+        merged = merge_telemetry_metrics([telemetry_1, telemetry_2])
+
+        assert merged.gpu_power_usage["gpu0"] == [10.0, 20.0, 40.0]
+        assert merged.gpu_utilization["gpu0"] == [50.0, 80.0]
+        assert merged.gpu_power_usage["gpu1"] == [30.0, 60.0]
+        assert merged.gpu_utilization["gpu1"] == [75.0]
+        assert merged.gpu_utilization["gpu2"] == [90.0]
+
+        assert set(merged.gpu_power_usage.keys()) == {"gpu0", "gpu1"}
+        assert set(merged.gpu_utilization.keys()) == {"gpu0", "gpu1", "gpu2"}
+
+    def test_merge_with_empty_telemetry(self, telemetry_1):
+        empty_telemetry = TelemetryMetrics()
+        merged = merge_telemetry_metrics([telemetry_1, empty_telemetry])
+
+        assert merged.gpu_power_usage["gpu0"] == [10.0, 20.0]
+        assert merged.gpu_utilization["gpu1"] == [75.0]
+
+        assert set(merged.gpu_power_usage.keys()) == {"gpu0", "gpu1"}
+        assert set(merged.gpu_utilization.keys()) == {"gpu0", "gpu1"}
+
+    def test_merge_no_metrics(self):
+        merged = merge_telemetry_metrics([])
+        assert isinstance(merged, TelemetryMetrics)
+        assert len(merged.gpu_power_usage) == 0
+        assert len(merged.gpu_utilization) == 0

--- a/genai-perf/tests/test_metrics/test_telemetry_metrics.py
+++ b/genai-perf/tests/test_metrics/test_telemetry_metrics.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/tests/test_statistics/test_statistics.py
+++ b/genai-perf/tests/test_statistics/test_statistics.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/tests/test_statistics/test_telemetry_statistics.py
+++ b/genai-perf/tests/test_statistics/test_telemetry_statistics.py
@@ -1,0 +1,131 @@
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from genai_perf.exceptions import GenAIPerfException
+from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
+from genai_perf.metrics.telemetry_statistics import TelemetryStatistics
+from genai_perf.record.types.gpu_power_usage_avg import GPUPowerUsageAvg
+
+
+class TestTelemetryStatistics:
+
+    @pytest.fixture
+    def mock_metrics(self) -> TelemetryMetrics:
+        telemetry = TelemetryMetrics()
+        telemetry.update_metrics(
+            {
+                "gpu_power_usage": {"gpu0": [10.0, 20.0, 30.0], "gpu1": [40.0, 50.0]},
+                "gpu_utilization": {"gpu0": [60.0, 70.0, 80.0], "gpu1": [90.0]},
+                "energy_consumption": {"gpu0": [1000000.0], "gpu1": [2000000.0]},
+                "total_gpu_memory": {"gpu0": [8000000000.0], "gpu1": [16000000000.0]},
+                "gpu_memory_used": {"gpu0": [4000000000.0], "gpu1": [8000000000.0]},
+            }
+        )
+        return telemetry
+
+    @pytest.fixture
+    def telemetry_statistics(self, mock_metrics) -> TelemetryStatistics:
+        return TelemetryStatistics(mock_metrics)
+
+    def test_initialization(self, telemetry_statistics):
+        stats_dict = telemetry_statistics.stats_dict
+
+        assert "gpu_power_usage" in stats_dict
+        assert "gpu0" in stats_dict["gpu_power_usage"]
+        assert "avg" in stats_dict["gpu_power_usage"]["gpu0"]
+        assert isinstance(stats_dict["gpu_power_usage"]["gpu0"]["avg"], float)
+
+    def test_average_calculation(self, telemetry_statistics):
+        stats_dict = telemetry_statistics.stats_dict
+        assert stats_dict["gpu_power_usage"]["gpu0"]["avg"] == 20.0  # (10+20+30)/3
+        assert stats_dict["gpu_power_usage"]["gpu1"]["avg"] == 45.0  # (40+50)/2
+
+    def test_min_max_calculation(self, telemetry_statistics):
+        stats_dict = telemetry_statistics.stats_dict
+        assert stats_dict["gpu_power_usage"]["gpu0"]["min"] == 10.0
+        assert stats_dict["gpu_power_usage"]["gpu0"]["max"] == 30.0
+        assert stats_dict["gpu_power_usage"]["gpu1"]["min"] == 40.0
+        assert stats_dict["gpu_power_usage"]["gpu1"]["max"] == 50.0
+
+    def test_percentile_calculations(self, telemetry_statistics):
+        stats_dict = telemetry_statistics.stats_dict
+        assert "p99" in stats_dict["gpu_power_usage"]["gpu0"]
+        assert "p95" in stats_dict["gpu_power_usage"]["gpu0"]
+        assert "p90" in stats_dict["gpu_power_usage"]["gpu0"]
+        assert (
+            stats_dict["gpu_power_usage"]["gpu0"]["p99"] == 29.8
+        )  # np.percentile([10, 20, 30], 99)
+
+    def test_scaling_data(self, telemetry_statistics):
+        telemetry_statistics.scale_data()
+        stats_dict = telemetry_statistics.stats_dict
+
+        assert stats_dict["energy_consumption"]["gpu0"]["avg"] == 1.0  # 1 MJ
+        assert stats_dict["energy_consumption"]["gpu1"]["avg"] == 2.0  # 2 MJ
+
+        assert stats_dict["gpu_memory_used"]["gpu0"]["avg"] == 4.0  # 4 GB
+        assert stats_dict["gpu_memory_used"]["gpu1"]["avg"] == 8.0  # 8 GB
+
+    def test_create_records(self, telemetry_statistics):
+        telemetry_statistics._stats_dict = telemetry_statistics.stats_dict
+        telemetry_records = telemetry_statistics.create_records()
+
+        assert "gpu0" in telemetry_records
+        assert "gpu_power_usage_avg" in telemetry_records["gpu0"]
+        assert isinstance(
+            telemetry_records["gpu0"]["gpu_power_usage_avg"], GPUPowerUsageAvg
+        )
+
+    def test_create_records_invalid_key(self, telemetry_statistics):
+        telemetry_statistics._stats_dict["invalid_metric"] = {"gpu0": {"avg": 100}}
+        with pytest.raises(GenAIPerfException):
+            telemetry_statistics.create_records()
+
+    def test_empty_data_handling(self):
+        empty_metrics = TelemetryMetrics()
+        telemetry_statistics = TelemetryStatistics(empty_metrics)
+        assert len(telemetry_statistics.stats_dict) > 0
+        for metric_key, metric_data in telemetry_statistics.stats_dict.items():
+            assert list(metric_data.keys()) == [
+                "unit"
+            ], f"Expected only 'unit' in {metric_key}, but got {metric_data.keys()}"
+
+        assert all(
+            "gpu0" not in metric_data and "gpu1" not in metric_data
+            for metric_data in telemetry_statistics.stats_dict.values()
+        ), "Expected no GPU-specific stats in empty case"
+
+    def test_constant_metrics(self, telemetry_statistics):
+        """Test that constant metrics do not compute unnecessary statistics."""
+        stats_dict = telemetry_statistics.stats_dict
+        assert "min" not in stats_dict["total_gpu_memory"]["gpu0"]
+        assert "max" not in stats_dict["total_gpu_memory"]["gpu0"]
+        assert "std" not in stats_dict["total_gpu_memory"]["gpu0"]
+
+    def test_should_skip(self, telemetry_statistics):
+        assert telemetry_statistics._should_skip({}) is True
+        assert telemetry_statistics._should_skip({"gpu0": [10.0]}) is False

--- a/genai-perf/tests/test_utils.py
+++ b/genai-perf/tests/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/tests/test_utils.py
+++ b/genai-perf/tests/test_utils.py
@@ -73,7 +73,7 @@ def create_default_exporter_config(
     args: Optional[Namespace] = None,
     extra_inputs: Optional[Dict[str, Any]] = None,
     artifact_dir: Optional[Path] = None,
-    telemetry_stats: Optional[Dict[str, Any]] = None,
+    telemetry_stats: Dict[str, Any] = {},
 ) -> ExporterConfig:
     return ExporterConfig(
         stats=stats or {},

--- a/genai-perf/tests/test_wrapper.py
+++ b/genai-perf/tests/test_wrapper.py
@@ -157,7 +157,7 @@ class TestWrapper:
         run_perf_analyzer(
             args=args,
             extra_args=None,
-            telemetry_data_collector=telemetry_data_collector,
+            telemetry_data_collectors=[telemetry_data_collector],
         )
 
         # Check that standard output was not redirected.
@@ -177,7 +177,7 @@ class TestWrapper:
         run_perf_analyzer(
             args=args,
             extra_args=None,
-            telemetry_data_collector=telemetry_data_collector,
+            telemetry_data_collectors=[telemetry_data_collector],
         )
 
         # Check that standard output was redirected.

--- a/genai-perf/tests/test_wrapper.py
+++ b/genai-perf/tests/test_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -24,13 +24,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import subprocess
-from unittest.mock import MagicMock, patch
-
 import pytest
 from genai_perf import parser
 from genai_perf.constants import DEFAULT_GRPC_URL
-from genai_perf.subcommand.common import run_perf_analyzer
 from genai_perf.wrapper import Profiler
 
 
@@ -146,46 +142,6 @@ class TestWrapper:
 
         # Ensure the correct arguments are appended.
         assert cmd_string.count(" -i http") == 1
-
-    @patch("genai_perf.subcommand.common.subprocess.run")
-    @patch("genai_perf.wrapper.TelemetryDataCollector")
-    def test_stdout_verbose(self, mock_telemetry_collector, mock_subprocess_run):
-        args = MagicMock()
-        args.model = "test_model"
-        args.verbose = True
-        telemetry_data_collector = mock_telemetry_collector.return_value
-        run_perf_analyzer(
-            args=args,
-            extra_args=None,
-            telemetry_data_collectors=[telemetry_data_collector],
-        )
-
-        # Check that standard output was not redirected.
-        for call_args in mock_subprocess_run.call_args_list:
-            _, kwargs = call_args
-            assert (
-                "stdout" not in kwargs or kwargs["stdout"] is None
-            ), "With the verbose flag, stdout should not be redirected."
-
-    @patch("genai_perf.subcommand.common.subprocess.run")
-    @patch("genai_perf.wrapper.TelemetryDataCollector")
-    def test_stdout_not_verbose(self, mock_telemetry_collector, mock_subprocess_run):
-        args = MagicMock()
-        args.model = "test_model"
-        args.verbose = False
-        telemetry_data_collector = mock_telemetry_collector.return_value
-        run_perf_analyzer(
-            args=args,
-            extra_args=None,
-            telemetry_data_collectors=[telemetry_data_collector],
-        )
-
-        # Check that standard output was redirected.
-        for call_args in mock_subprocess_run.call_args_list:
-            _, kwargs = call_args
-            assert (
-                kwargs["stdout"] is subprocess.DEVNULL
-            ), "When the verbose flag is not passed, stdout should be redirected to /dev/null."
 
     @pytest.mark.parametrize(
         "header_values, expected_headers",

--- a/templates/genai-perf-templates/README_template
+++ b/templates/genai-perf-templates/README_template
@@ -415,6 +415,13 @@ Set a custom endpoint that differs from the OpenAI defaults. (default: `None`)
 The endpoint-type to send requests to on the server. This is only used with the
 `openai` service-kind. (default: `None`)
 
+##### `--server-metrics-url <list>`
+
+The list of Triton server metrics URLs. These are used for Telemetry metric
+reporting with the Triton service-kind. Example usage: --server-metrics-url
+http://server1:8002/metrics http://server2:8002/metrics.
+(default: `http://localhost:8002/metrics`)
+
 ##### `--service-kind {triton,openai}`
 
 The kind of service perf_analyzer will generate load for. In order to use


### PR DESCRIPTION
Add support for users to pass multiple metrics endpoints. Aggregate the metrics and provide them with the same behavior as a single endpoint.

This will be valuable for cases where more distributed serving is used.

Example:
![image](https://github.com/user-attachments/assets/fbfa06dd-c278-4952-bddc-66137efc1219)
