### PR TITLE
Add python extension in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   "runArgs": ["--gpus=all", "--net=host", "--pull=always"],
   "customizations": {
     "vscode": {
-      "extensions": ["ms-vscode.cpptools", "ms-vscode.cmake-tools", "xaver.clang-format"]
+      "extensions": ["ms-vscode.cpptools", "ms-vscode.cmake-tools", "xaver.clang-format", "ms-python.python"]
     }
   }
 }


### PR DESCRIPTION
Mainly to enable code navigation when using python in the dev container (we use git-commit hooks to run other stuffs).