### PR TITLE
Allow plural form of --server-metrics-url

### DIFF
--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -415,10 +415,10 @@ Set a custom endpoint that differs from the OpenAI defaults. (default: `None`)
 The endpoint-type to send requests to on the server. This is only used with the
 `openai` service-kind. (default: `None`)
 
-##### `--server-metrics-url <list>`
+##### `--server-metrics-urls <list>`
 
 The list of Triton server metrics URLs. These are used for Telemetry metric
-reporting with the Triton service-kind. Example usage: --server-metrics-url
+reporting with the Triton service-kind. Example usage: --server-metrics-urls
 http://server1:8002/metrics http://server2:8002/metrics.
 (default: `http://localhost:8002/metrics`)
 

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -649,6 +649,7 @@ def _add_endpoint_args(parser):
 
     endpoint_group.add_argument(
         "--server-metrics-url",
+        "--server-metrics-urls",
         type=str,
         nargs="+",
         default=[],

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -1035,6 +1035,19 @@ class TestCLIArguments:
                 ],
                 [test_triton_metrics_url],
             ),
+            (
+                [
+                    "genai-perf",
+                    "profile",
+                    "--model",
+                    "test_model",
+                    "--service-kind",
+                    "triton",
+                    "--server-metrics-urls",
+                    test_triton_metrics_url,
+                ],
+                [test_triton_metrics_url],
+            ),
             # server-metrics-url is not specified
             (
                 [

--- a/templates/genai-perf-templates/README_template
+++ b/templates/genai-perf-templates/README_template
@@ -415,10 +415,10 @@ Set a custom endpoint that differs from the OpenAI defaults. (default: `None`)
 The endpoint-type to send requests to on the server. This is only used with the
 `openai` service-kind. (default: `None`)
 
-##### `--server-metrics-url <list>`
+##### `--server-metrics-urls <list>`
 
 The list of Triton server metrics URLs. These are used for Telemetry metric
-reporting with the Triton service-kind. Example usage: --server-metrics-url
+reporting with the Triton service-kind. Example usage: --server-metrics-urls
 http://server1:8002/metrics http://server2:8002/metrics.
 (default: `http://localhost:8002/metrics`)
 


### PR DESCRIPTION
Context: https://github.com/triton-inference-server/perf_analyzer/pull/252#discussion_r1931281688

Update --server-metrics-url to accept --server-metrics-urls. This allows the more semantically correct option now that GenAI-Perf accepts a list of URLs while not breaking previous commands.