### PR TITLE
Add yml handler to copyright pre-commit hook

### DIFF
--- a/tools/add_copyright.py
+++ b/tools/add_copyright.py
@@ -216,7 +216,7 @@ def register(match: Callable[[str], bool]):
 
 @register(
     any_of(
-        has_ext([".py", ".pyi", ".sh", ".bash", ".yaml", ".pbtxt"]),
+        has_ext([".py", ".pyi", ".sh", ".bash", ".yaml", ".yml", ".pbtxt"]),
         basename_is("CMakeLists.txt"),
         path_contains("Dockerfile"),
     )


### PR DESCRIPTION
Previously, the pre-commit hook only handled files with a yaml extension. This PR makes it handle a yml extension too.

Example:
![image](https://github.com/user-attachments/assets/0d8d94ab-9323-48ba-8108-2604b352e921)

![image](https://github.com/user-attachments/assets/89049a26-e7a6-43f4-b39e-ddd90d508d4f)
