### PR TITLE
Remove extra printing for copyright hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,6 +84,4 @@ repos:
     name: Add License
     entry: python tools/add_copyright.py
     language: python
-    stages: [pre-commit]
-    verbose: true
     require_serial: true

--- a/tools/add_copyright.py
+++ b/tools/add_copyright.py
@@ -263,14 +263,6 @@ def add_copyrights(paths):
                 f"WARNING: No handler registered for file: {path}. Please add a new handler to {__file__}!"
             )
 
-    # Don't automatically 'git add' changes for now, make it more clear which
-    # files were changed and have ability to see 'git diff' on them.
-    # Note that this means the hook will modify files and then cancel the commit, which you will then
-    # have to manually make again.
-    # subprocess.run(["git", "add"] + paths)
-
-    print(f"Processed copyright headers for {len(paths)} file(s).")
-
 
 def main() -> int:
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
Make the copyright hook not print out extra statements after running

Updated:
![image](https://github.com/user-attachments/assets/649a1b53-db1b-4139-8041-954207140a60)
