### PR TITLE
Add the ability to format output using jinja2 template

### DIFF
--- a/.github/workflows/python-package-genai.yml
+++ b/.github/workflows/python-package-genai.yml
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,7 +51,7 @@ jobs:
       run: |
         cd genai-perf/
         python -m pip install --upgrade pip
-        python -m pip install -e .
+        python -m pip install -e .[test]
         python -c "import genai_perf; print(genai_perf.__version__)"
     - name: Test with pytest
       run: |

--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -56,7 +56,13 @@ You can use GenAI-Perf to run performance benchmarks on
 - [Multiple LoRA Adapters](docs/lora.md)
 
 You can also use GenAI-Perf to run benchmarks on your
-[custom APIs](docs/customizable_frontends.md).
+custom APIs using either
+[customizable frontends](docs/customizable_frontends.md)
+or
+[customizable payloads](docs/customizable_payloads.md).
+Customizable frontends provide more customizability,
+while customizable payloads allow you to specify
+specific payload schemas using a Jinja2 template.
 
 > [!Note]
 > GenAI-Perf is currently in early release and under rapid development. While we

--- a/genai-perf/docs/customizable_payloads.md
+++ b/genai-perf/docs/customizable_payloads.md
@@ -1,0 +1,110 @@
+<!--
+Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of NVIDIA CORPORATION nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+# Use Custom Payload Formats
+
+With GenAI-Perf, you can customize how input data is formatted into payloads
+using output templates. This allows you to define how payloads are
+structured when sent to an inference server.
+
+These provide less customizability than a
+[customizable frontend](customizable_frontends.md), which is used when more
+endpoint-specific logic is necessary. Output templates are used when
+the only change necessary is specifying a specific payload schema.
+
+## Table of Contents
+
+- [Use a Named Template (Predefined)](#predefined)
+- [Use a Custom Template (Fully Customizable)](#custom)
+
+## Use a Named Template <a id="predefined"></a>
+
+GenAI-Perf provides common built-in templates to simplify request formatting.
+You can find these in `NAMED_TEMPLATES` in the class
+[template_converter](../genai_perf/inputs/converters/template_converter.py).
+
+One such template is `nv-embedqa`, which structures requests for
+embedding-based models.
+
+### Example: Use the nv-embedqa Named Template
+
+Run the following command:
+
+```bash
+genai-perf profile \
+  --model MY_MODEL \
+  --tokenizer MY_MODEL \
+  --num-payloads 2 \
+  --extra-inputs output_template:nv-embedqa
+```
+
+#### Result
+GenAI-Perf will use the nv-embedqa template to format the input data.
+
+After conversion, the `inputs.json` file would look similar to this:
+
+```json
+{
+    "data": [
+        {"text": ["example1"]},
+        {"text": ["example2"]}
+    ]
+}
+```
+
+## Use a Custom Template <a id="custom"></a>
+
+Sometimes, you may have a custom payload format.
+Custom templates allow you to benchmark using GenAI-Perf.
+
+Here is an example template:
+```
+    {% for item in texts %}
+        {"custom_key": [{{ item|tojson }}]}{% if not loop.last %},{% endif %}
+    {% endfor %}
+```
+
+This tells GenAI-Perf to format input texts like:
+
+```json
+[
+    {"custom_key": ["example1"]},
+    {"custom_key": ["example2"]}
+]
+```
+
+If you the above template is saved in `custom_template.jinja`,
+you can run the command:
+
+```bash
+genai-perf profile \
+  --model MY_MODEL \
+  --tokenizer MY_MODEL \
+  --num-payloads 2 \
+  --extra-inputs output_template:custom_template.jinja
+```

--- a/genai-perf/docs/customizable_payloads.md
+++ b/genai-perf/docs/customizable_payloads.md
@@ -29,13 +29,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # Use Custom Payload Formats
 
 With GenAI-Perf, you can customize how input data is formatted into payloads
-using output templates. This allows you to define how payloads are
+using templates. This allows you to define how payloads are
 structured when sent to an inference server.
 
 These provide less customizability than a
 [customizable frontend](customizable_frontends.md), which is used when more
-endpoint-specific logic is necessary. Output templates are used when
-the only change necessary is specifying a specific payload schema.
+endpoint-specific logic is necessary. Templates are used when
+the only change necessary is specifying a custom payload schema.
 
 ## Table of Contents
 
@@ -60,7 +60,7 @@ genai-perf profile \
   --model MY_MODEL \
   --tokenizer MY_MODEL \
   --num-payloads 2 \
-  --extra-inputs output_template:nv-embedqa
+  --extra-inputs payload_template:nv-embedqa
 ```
 
 #### Result
@@ -106,5 +106,5 @@ genai-perf profile \
   --model MY_MODEL \
   --tokenizer MY_MODEL \
   --num-payloads 2 \
-  --extra-inputs output_template:custom_template.jinja
+  --extra-inputs payload_template:custom_template.jinja
 ```

--- a/genai-perf/genai_perf/export_data/json_exporter.py
+++ b/genai-perf/genai_perf/export_data/json_exporter.py
@@ -66,7 +66,6 @@ class JsonExporter:
     def _prepare_args_for_export(self) -> None:
         self._args.pop("func", None)
         self._args.pop("output_format", None)
-        self._args.pop("output_template", None)
         self._args.pop("input_file", None)
         self._args["profile_export_file"] = str(self._args["profile_export_file"])
         self._args["artifact_dir"] = str(self._args["artifact_dir"])

--- a/genai-perf/genai_perf/export_data/json_exporter.py
+++ b/genai-perf/genai_perf/export_data/json_exporter.py
@@ -66,6 +66,7 @@ class JsonExporter:
     def _prepare_args_for_export(self) -> None:
         self._args.pop("func", None)
         self._args.pop("output_format", None)
+        self._args.pop("output_template", None)
         self._args.pop("input_file", None)
         self._args["profile_export_file"] = str(self._args["profile_export_file"])
         self._args["artifact_dir"] = str(self._args["artifact_dir"])

--- a/genai-perf/genai_perf/inputs/converters/__init__.py
+++ b/genai-perf/genai_perf/inputs/converters/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@ from .openai_chat_completions_converter import OpenAIChatCompletionsConverter
 from .openai_completions_converter import OpenAICompletionsConverter
 from .openai_embeddings_converter import OpenAIEmbeddingsConverter
 from .rankings_converter import RankingsConverter
+from .template_converter import TemplateConverter
 from .tensorrtllm_converter import TensorRTLLMConverter
 from .tensorrtllm_engine_converter import TensorRTLLMEngineConverter
 from .triton_generate_converter import TritonGenerateConverter
@@ -42,6 +43,7 @@ __all__ = [
     "OpenAICompletionsConverter",
     "OpenAIEmbeddingsConverter",
     "RankingsConverter",
+    "TemplateConverter",
     "TensorRTLLMConverter",
     "TensorRTLLMEngineConverter",
     "VLLMConverter",

--- a/genai-perf/genai_perf/inputs/converters/output_format_converter_factory.py
+++ b/genai-perf/genai_perf/inputs/converters/output_format_converter_factory.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,6 +45,7 @@ class OutputFormatConverterFactory:
             OutputFormat.OPENAI_EMBEDDINGS: OpenAIEmbeddingsConverter,
             OutputFormat.OPENAI_VISION: OpenAIChatCompletionsConverter,
             OutputFormat.RANKINGS: RankingsConverter,
+            OutputFormat.TEMPLATE: TemplateConverter,
             OutputFormat.TENSORRTLLM: TensorRTLLMConverter,
             OutputFormat.TENSORRTLLM_ENGINE: TensorRTLLMEngineConverter,
             OutputFormat.VLLM: VLLMConverter,

--- a/genai-perf/genai_perf/inputs/converters/template_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/template_converter.py
@@ -1,0 +1,95 @@
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+from typing import Any, Dict, Optional
+
+from genai_perf.exceptions import GenAIPerfException
+from genai_perf.inputs.converters.base_converter import BaseConverter
+from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
+
+NAMED_TEMPLATES = {
+    "nv-embedqa": """[
+        {% for item in texts %}
+            {"text": [{{ item|tojson }}]}{% if not loop.last %},{% endif %}
+        {% endfor %}
+    ]""",
+}
+
+
+class TemplateConverter(BaseConverter):
+    """Convert a GenericDataset to a request body.
+
+    The template should render a list of text strings, and return a list of payloads.
+    """
+
+    def resolve_template(self, template_name_or_content: Optional[str]):
+        try:
+            import jinja2
+        except ImportError:
+            raise ImportError(
+                "Jinja2 is required for template processing. Install it using: pip install jinja2."
+            )
+
+        environment = jinja2.Environment(
+            autoescape=True,
+            loader=jinja2.DictLoader(NAMED_TEMPLATES),
+        )
+
+        return (
+            environment.get_template(template_name_or_content)
+            if template_name_or_content in NAMED_TEMPLATES
+            else environment.from_string(template_name_or_content)
+        )
+
+    def check_config(self, config: InputsConfig) -> None:
+        if config.output_template:
+            try:
+                template = self.resolve_template(config.output_template)
+                test_texts = ["test1", "test2"]
+                payloads_json = template.render(texts=test_texts)
+                payloads = json.loads(payloads_json)
+                if not isinstance(payloads, list):
+                    raise ValueError(
+                        "Template does not render a list of strings to a list of items. "
+                        f"For example, {test_texts} is rendered into {payloads}."
+                    )
+            except Exception as e:
+                raise GenAIPerfException(e)
+
+    def convert(
+        self, generic_dataset: GenericDataset, config: InputsConfig
+    ) -> Dict[Any, Any]:
+        template = self.resolve_template(config.output_template)
+
+        request_body: Dict[str, Any] = {"data": []}
+
+        for file_data in generic_dataset.files_data.values():
+            for _, row in enumerate(file_data.rows):
+                payloads_json = template.render(texts=row.texts)
+                request_body["data"] += json.loads(payloads_json)
+        return request_body

--- a/genai-perf/genai_perf/inputs/converters/template_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/template_converter.py
@@ -74,16 +74,16 @@ class TemplateConverter(BaseConverter):
         return environment.from_string(template_content)
 
     def check_config(self, config: InputsConfig) -> None:
-        output_template = config.extra_inputs.get("output_template")
-        if not output_template:
+        payload_template = config.extra_inputs.get("payload_template")
+        if not payload_template:
             raise GenAIPerfException(
                 f"The template converter requires the "
-                "extra input output_template, only "
+                "extra input payload_template, only "
                 "detected the following --extra-inputs: "
                 "{config.extra_inputs.keys}."
             )
         try:
-            template = self.resolve_template(output_template)
+            template = self.resolve_template(payload_template)
             test_texts = ["test1", "test2"]
             payloads_json = template.render(texts=test_texts)
             payloads = json.loads(payloads_json)
@@ -98,9 +98,9 @@ class TemplateConverter(BaseConverter):
     def convert(
         self, generic_dataset: GenericDataset, config: InputsConfig
     ) -> Dict[Any, Any]:
-        output_template = config.extra_inputs.get("output_template")
-        output_template = cast(str, output_template)
-        template = self.resolve_template(output_template)
+        payload_template = config.extra_inputs.get("payload_template")
+        payload_template = cast(str, payload_template)
+        template = self.resolve_template(payload_template)
 
         request_body: Dict[str, Any] = {"data": []}
 

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
@@ -102,12 +102,8 @@ class TensorRTLLMEngineConverter(BaseConverter):
         """
         Apply the default TRT-LLM engine chat template to the prompt
         """
-        try:
-            import jinja2
-        except ImportError:
-            raise ImportError(
-                "Jinja2 is required for using TRT-LLM with chat template processing. Install it using: pip install jinja2."
-            )
+        import jinja2
+
         default_template = self._construct_default_template(prompt)
         return config.tokenizer.encode(
             config.tokenizer._tokenizer.apply_chat_template(

--- a/genai-perf/genai_perf/inputs/input_constants.py
+++ b/genai-perf/genai_perf/inputs/input_constants.py
@@ -54,6 +54,7 @@ class OutputFormat(Enum):
     OPENAI_EMBEDDINGS = auto()
     OPENAI_VISION = auto()
     RANKINGS = auto()
+    TEMPLATE = auto()
     TENSORRTLLM_ENGINE = auto()
     TRITON_GENERATE = auto()
 

--- a/genai-perf/genai_perf/inputs/inputs_config.py
+++ b/genai-perf/genai_perf/inputs/inputs_config.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -113,6 +113,9 @@ class InputsConfig:
 
     # Specify the output format
     output_format: OutputFormat = OutputFormat.TENSORRTLLM
+
+    # Supplement the TEMPLATE output format with a template
+    output_template: Optional[str] = None
 
     # If true, the output tokens will set the minimum and maximum tokens to be equivalent.
     output_tokens_deterministic: bool = False

--- a/genai-perf/genai_perf/inputs/inputs_config.py
+++ b/genai-perf/genai_perf/inputs/inputs_config.py
@@ -26,7 +26,7 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from genai_perf.inputs.input_constants import (
     DEFAULT_IMAGE_HEIGHT_MEAN,
@@ -74,7 +74,7 @@ class InputsConfig:
     batch_size_text: int = 1
 
     # If provided, append these inputs to every request
-    extra_inputs: Dict = field(default_factory=dict)
+    extra_inputs: Dict[str, Any] = field(default_factory=dict)
 
     # The filename where the input data is available
     input_filename: Optional[Path] = Path("")
@@ -113,9 +113,6 @@ class InputsConfig:
 
     # Specify the output format
     output_format: OutputFormat = OutputFormat.TENSORRTLLM
-
-    # Supplement the TEMPLATE output format with a template
-    output_template: Optional[str] = None
 
     # If true, the output tokens will set the minimum and maximum tokens to be equivalent.
     output_tokens_deterministic: bool = False

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -39,6 +39,7 @@ import genai_perf.utils as utils
 from genai_perf.config.input.config_command import RunConfigDefaults
 from genai_perf.constants import DEFAULT_ARTIFACT_DIR, DEFAULT_PROFILE_EXPORT_FILE
 from genai_perf.inputs import input_constants as ic
+from genai_perf.inputs.converters.template_converter import NAMED_TEMPLATES
 from genai_perf.inputs.retrievers.synthetic_image_generator import ImageFormat
 from genai_perf.plots.plot_config_parser import PlotConfigParser
 from genai_perf.plots.plot_manager import PlotManager
@@ -245,6 +246,10 @@ def _check_conditional_args(
             parser.error(
                 f"The --generate-plots option is not currently supported with the {args.endpoint_type} endpoint type."
             )
+
+    # Override the output format if the user has specified a template
+    if args.output_template:
+        args.output_format = ic.OutputFormat.TEMPLATE
 
     return args
 
@@ -813,6 +818,17 @@ def _add_input_args(parser):
         "benchmarking models that use a K-V cache.",
     )
 
+    input_group.add_argument(
+        "--output-template",
+        type=str,
+        required=False,
+        help=f"Use a Jinja template to format the output. "
+        "You can provide your own template, or use one of the named templates "
+        f"{set(sorted(NAMED_TEMPLATES.keys()))}. "
+        "The template should be a valid Jinja template string "
+        "transforming a list of text strings into a valid JSON list. "
+        "Each item in the list should be a valid input for the model. ",
+    )
     input_group.add_argument(
         "--output-tokens-mean",
         "--osl",

--- a/genai-perf/genai_perf/subcommand/common.py
+++ b/genai-perf/genai_perf/subcommand/common.py
@@ -174,7 +174,6 @@ def create_config_options(args: Namespace) -> InputsConfig:
     return InputsConfig(
         input_type=args.prompt_source,
         output_format=args.output_format,
-        output_template=args.output_template,
         model_name=args.model,
         model_selection_strategy=args.model_selection_strategy,
         input_filename=args.input_file,

--- a/genai-perf/genai_perf/subcommand/common.py
+++ b/genai-perf/genai_perf/subcommand/common.py
@@ -34,7 +34,7 @@ from genai_perf.config.generate.perf_analyzer_config import PerfAnalyzerConfig
 from genai_perf.constants import DEFAULT_TRITON_METRICS_URL
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.inputs.input_constants import DEFAULT_STARTING_INDEX
-from genai_perf.inputs.inputs import Inputs
+from genai_perf.inputs.inputs import Inputs, OutputFormat
 from genai_perf.inputs.inputs_config import InputsConfig
 from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
 from genai_perf.profile_data_parser import (
@@ -64,6 +64,11 @@ def generate_inputs(config_options: InputsConfig) -> None:
 
 
 def calculate_metrics(args: Namespace, tokenizer: Tokenizer) -> ProfileDataParser:
+    if args.output_format == OutputFormat.TEMPLATE:
+        return ProfileDataParser(
+            args.profile_export_file,
+            goodput_constraints=args.goodput,
+        )
     if args.endpoint_type in ["embeddings", "nvclip", "rankings"]:
         return ProfileDataParser(
             args.profile_export_file,
@@ -169,6 +174,7 @@ def create_config_options(args: Namespace) -> InputsConfig:
     return InputsConfig(
         input_type=args.prompt_source,
         output_format=args.output_format,
+        output_template=args.output_template,
         model_name=args.model,
         model_selection_strategy=args.model_selection_strategy,
         input_filename=args.input_file,

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -89,6 +89,7 @@ class Profiler:
             "num_dataset_entries",
             "num_prefix_prompts",
             "output_format",
+            "output_template",
             "output_tokens_mean",
             "output_tokens_mean_deterministic",
             "output_tokens_stddev",

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -89,7 +89,6 @@ class Profiler:
             "num_dataset_entries",
             "num_prefix_prompts",
             "output_format",
-            "output_template",
             "output_tokens_mean",
             "output_tokens_mean_deterministic",
             "output_tokens_stddev",

--- a/genai-perf/pyproject.toml
+++ b/genai-perf/pyproject.toml
@@ -47,22 +47,23 @@ maintainers = []
 keywords = []
 requires-python = ">=3.10,<4"
 dependencies = [
-  "tritonclient",
-  "numpy",
-  "pytest",
-  "rich",
-  "transformers",
-  "plotly",
-  "pandas",
-  "kaleido",
-  "statsmodels",
-  "pyarrow",
   "fastparquet",
+  "jinja2",
+  "kaleido",
+  "numpy",
+  "optuna==3.6.1",
+  "pandas",
+  "pillow",
+  "plotly",
+  "pyarrow",
+  "pytest",
   "pytest-mock",
   "pyyaml",
   "responses",
-  "pillow",
-  "optuna==3.6.1",
+  "rich",
+  "statsmodels",
+  "transformers",
+  "tritonclient",
 ]
 
 # CLI Entrypoint
@@ -98,7 +99,3 @@ quiet-level = 3
 # Same as Black.
 line-length = 88
 indent-width = 4
-
-[project.optional-dependencies]
-test = ["jinja2"]
-

--- a/genai-perf/pyproject.toml
+++ b/genai-perf/pyproject.toml
@@ -98,3 +98,7 @@ quiet-level = 3
 # Same as Black.
 line-length = 88
 indent-width = 4
+
+[project.optional-dependencies]
+test = ["jinja2"]
+

--- a/genai-perf/tests/test_converters/test_template_converter.py
+++ b/genai-perf/tests/test_converters/test_template_converter.py
@@ -24,13 +24,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import sys
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 import pytest
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.inputs.converters import TemplateConverter
-from genai_perf.inputs.converters.template_converter import NAMED_TEMPLATES
 from genai_perf.inputs.input_constants import OutputFormat
 from genai_perf.inputs.inputs_config import InputsConfig
 from genai_perf.inputs.retrievers.generic_dataset import (
@@ -46,36 +44,161 @@ class TestTemplateConverter:
     def create_generic_dataset(rows) -> GenericDataset:
         return GenericDataset(files_data={"file1": FileData(rows)})
 
-    def test_jinja2_not_installed(self):
-        with patch.dict(sys.modules, {"jinja2": None}, clear=True):
-            with pytest.raises(ImportError):
-                TemplateConverter().resolve_template("dummy")
-
-    @pytest.mark.parametrize(
-        "template", (*NAMED_TEMPLATES.keys(), """[{ "dummy": {{ texts|tojson }} }]""")
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data='[{"custom_key": {{ texts|tojson }} }]',
     )
-    def test_check_config(self, template):
+    def test_check_config_with_file_template(self, mock_open_fn):
+        fake_template_path = "/fake/path/template.jinja2"
+
+        with patch("os.path.isfile", return_value=True):
+            config = InputsConfig(
+                output_format=OutputFormat.TEMPLATE,
+                tokenizer=get_empty_tokenizer(),
+                extra_inputs={"output_template": fake_template_path},
+            )
+
+            converter = TemplateConverter()
+            converter.check_config(config)
+
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data='{ "invalid_format": {{ texts|tojson ]] }',
+    )
+    def test_check_config_invalid_template(self, mock_open_fn):
+        fake_template_path = "/fake/path/invalid_template.jinja2"
         config = InputsConfig(
             output_format=OutputFormat.TEMPLATE,
-            output_template=template,
             tokenizer=get_empty_tokenizer(),
+            extra_inputs={"output_template": fake_template_path},
         )
 
         template_converter = TemplateConverter()
-        template_converter.check_config(config)
 
-    @pytest.mark.parametrize("template", ("unknown", """[] {{ texts }} }]"""))
-    def test_check_config_invalid_template(self, template):
+        with patch("os.path.isfile", return_value=True):
+            with pytest.raises(GenAIPerfException, match="unexpected ']'"):
+                template_converter.check_config(config)
+
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data='{ "invalid_format": {{ texts|tojson }} }',
+    )
+    def test_check_config_invalid_type_conversion(self, mock_open_fn):
+        fake_template_path = "/fake/path/invalid_template.jinja2"
+
         config = InputsConfig(
             output_format=OutputFormat.TEMPLATE,
             tokenizer=get_empty_tokenizer(),
-            output_template=template,
+            extra_inputs={"output_template": fake_template_path},
         )
 
-        template_converter = TemplateConverter()
+        converter = TemplateConverter()
 
-        with pytest.raises(GenAIPerfException):
-            template_converter.check_config(config)
+        with patch("os.path.isfile", return_value=True):
+            with pytest.raises(
+                GenAIPerfException,
+                match="Template does not render a list of strings to a list of items",
+            ):
+                converter.check_config(config)
+
+    def test_check_config_missing_output_template(self):
+        config = InputsConfig(
+            output_format=OutputFormat.TEMPLATE,
+            tokenizer=get_empty_tokenizer(),
+            extra_inputs={},  # Missing 'output_template'
+        )
+
+        converter = TemplateConverter()
+
+        with pytest.raises(
+            GenAIPerfException,
+            match="The template converter requires the extra input output_template",
+        ):
+            converter.check_config(config)
+
+    def test_check_config_with_named_template(self):
+        config = InputsConfig(
+            output_format=OutputFormat.TEMPLATE,
+            tokenizer=get_empty_tokenizer(),
+            extra_inputs={"output_template": "nv-embedqa"},
+        )
+
+        converter = TemplateConverter()
+        converter.check_config(config)
+
+    def test_check_config_with_nonexistent_template_file(self):
+        fake_template_path = "/nonexistent/path/template.jinja2"
+
+        with patch("os.path.isfile", return_value=False):  # Simulate missing file
+            config = InputsConfig(
+                output_format=OutputFormat.TEMPLATE,
+                tokenizer=get_empty_tokenizer(),
+                extra_inputs={"output_template": fake_template_path},
+            )
+
+            converter = TemplateConverter()
+
+            with pytest.raises(
+                GenAIPerfException,
+                match=f"Template file not found: {fake_template_path}",
+            ):
+                converter.check_config(config)
+
+    @patch("builtins.open", side_effect=IOError("File read error"))
+    def test_check_config_with_unreadable_template_file(self, mock_open_fn):
+        fake_template_path = "/fake/path/template.jinja2"
+
+        with patch("os.path.isfile", return_value=True):  # Simulate file exists
+            config = InputsConfig(
+                output_format=OutputFormat.TEMPLATE,
+                tokenizer=get_empty_tokenizer(),
+                extra_inputs={"output_template": fake_template_path},
+            )
+
+            converter = TemplateConverter()
+
+            with pytest.raises(
+                GenAIPerfException, match="Error reading template file: File read error"
+            ):
+                converter.check_config(config)
+
+    @patch("builtins.open", new_callable=mock_open)
+    def test_convert_custom_template(self, mock_open_fn):
+        template_content = """[{ "dummy": {{ texts|tojson }} }]"""
+        mock_open_fn.return_value.read.return_value = template_content
+
+        with patch("os.path.isfile", return_value=True):
+            fake_template_path = "/fake/path/template.jinja2"
+
+            generic_dataset = self.create_generic_dataset(
+                [
+                    DataRow(texts=["sample_prompt_1"]),
+                    DataRow(texts=["sample_prompt_2", "sample_prompt_3"]),
+                ]
+            )
+
+            config = InputsConfig(
+                output_format=OutputFormat.TEMPLATE,
+                tokenizer=get_empty_tokenizer(),
+                extra_inputs={"output_template": fake_template_path},
+            )
+
+            converter = TemplateConverter()
+            result = converter.convert(generic_dataset, config)
+
+            expected_result = {
+                "data": [
+                    {"dummy": ["sample_prompt_1"]},
+                    {"dummy": ["sample_prompt_2", "sample_prompt_3"]},
+                ]
+            }
+
+            assert (
+                result == expected_result
+            ), f"Expected {expected_result}, but got {result}"
 
     def test_convert_named_template_nvembedqa(self):
         generic_dataset = self.create_generic_dataset(
@@ -87,7 +210,7 @@ class TestTemplateConverter:
         config = InputsConfig(
             output_format=OutputFormat.TEMPLATE,
             tokenizer=get_empty_tokenizer(),
-            output_template="nv-embedqa",
+            extra_inputs={"output_template": "nv-embedqa"},
         )
         converter = TemplateConverter()
         result = converter.convert(generic_dataset, config)
@@ -100,25 +223,13 @@ class TestTemplateConverter:
         }
         assert result == expected_result
 
-    def test_convert_custom_template(self):
-        output_template = """[{ "dummy": {{ texts|tojson }} }]"""
-        generic_dataset = self.create_generic_dataset(
-            [
-                DataRow(texts=["sample_prompt_1"]),
-                DataRow(texts=["sample_prompt_2", "sample_prompt_3"]),
-            ]
-        )
-        config = InputsConfig(
-            output_format=OutputFormat.TEMPLATE,
-            tokenizer=get_empty_tokenizer(),
-            output_template=output_template,
-        )
-        converter = TemplateConverter()
-        result = converter.convert(generic_dataset, config)
-        expected_result = {
-            "data": [
-                {"dummy": ["sample_prompt_1"]},
-                {"dummy": ["sample_prompt_2", "sample_prompt_3"]},
-            ]
-        }
-        assert result == expected_result
+    @patch("builtins.open", new_callable=mock_open)
+    def test_render_template_file(self, mock_open_fn):
+
+        fake_template_content = '[{"custom_key": {{ texts|tojson }} }]'
+        with patch("builtins.open", mock_open(read_data=fake_template_content)), patch(
+            "os.path.isfile", return_value=True
+        ):
+            converter = TemplateConverter()
+            template = converter.resolve_template("/path/to/template.jinja2")
+            assert template.render(texts=["sample"]) == '[{"custom_key": ["sample"] }]'

--- a/genai-perf/tests/test_converters/test_template_converter.py
+++ b/genai-perf/tests/test_converters/test_template_converter.py
@@ -56,7 +56,7 @@ class TestTemplateConverter:
             config = InputsConfig(
                 output_format=OutputFormat.TEMPLATE,
                 tokenizer=get_empty_tokenizer(),
-                extra_inputs={"output_template": fake_template_path},
+                extra_inputs={"payload_template": fake_template_path},
             )
 
             converter = TemplateConverter()
@@ -72,7 +72,7 @@ class TestTemplateConverter:
         config = InputsConfig(
             output_format=OutputFormat.TEMPLATE,
             tokenizer=get_empty_tokenizer(),
-            extra_inputs={"output_template": fake_template_path},
+            extra_inputs={"payload_template": fake_template_path},
         )
 
         template_converter = TemplateConverter()
@@ -92,7 +92,7 @@ class TestTemplateConverter:
         config = InputsConfig(
             output_format=OutputFormat.TEMPLATE,
             tokenizer=get_empty_tokenizer(),
-            extra_inputs={"output_template": fake_template_path},
+            extra_inputs={"payload_template": fake_template_path},
         )
 
         converter = TemplateConverter()
@@ -104,18 +104,18 @@ class TestTemplateConverter:
             ):
                 converter.check_config(config)
 
-    def test_check_config_missing_output_template(self):
+    def test_check_config_missing_payload_template(self):
         config = InputsConfig(
             output_format=OutputFormat.TEMPLATE,
             tokenizer=get_empty_tokenizer(),
-            extra_inputs={},  # Missing 'output_template'
+            extra_inputs={},  # Missing 'payload_template'
         )
 
         converter = TemplateConverter()
 
         with pytest.raises(
             GenAIPerfException,
-            match="The template converter requires the extra input output_template",
+            match="The template converter requires the extra input payload_template",
         ):
             converter.check_config(config)
 
@@ -123,7 +123,7 @@ class TestTemplateConverter:
         config = InputsConfig(
             output_format=OutputFormat.TEMPLATE,
             tokenizer=get_empty_tokenizer(),
-            extra_inputs={"output_template": "nv-embedqa"},
+            extra_inputs={"payload_template": "nv-embedqa"},
         )
 
         converter = TemplateConverter()
@@ -136,7 +136,7 @@ class TestTemplateConverter:
             config = InputsConfig(
                 output_format=OutputFormat.TEMPLATE,
                 tokenizer=get_empty_tokenizer(),
-                extra_inputs={"output_template": fake_template_path},
+                extra_inputs={"payload_template": fake_template_path},
             )
 
             converter = TemplateConverter()
@@ -155,7 +155,7 @@ class TestTemplateConverter:
             config = InputsConfig(
                 output_format=OutputFormat.TEMPLATE,
                 tokenizer=get_empty_tokenizer(),
-                extra_inputs={"output_template": fake_template_path},
+                extra_inputs={"payload_template": fake_template_path},
             )
 
             converter = TemplateConverter()
@@ -183,7 +183,7 @@ class TestTemplateConverter:
             config = InputsConfig(
                 output_format=OutputFormat.TEMPLATE,
                 tokenizer=get_empty_tokenizer(),
-                extra_inputs={"output_template": fake_template_path},
+                extra_inputs={"payload_template": fake_template_path},
             )
 
             converter = TemplateConverter()
@@ -210,7 +210,7 @@ class TestTemplateConverter:
         config = InputsConfig(
             output_format=OutputFormat.TEMPLATE,
             tokenizer=get_empty_tokenizer(),
-            extra_inputs={"output_template": "nv-embedqa"},
+            extra_inputs={"payload_template": "nv-embedqa"},
         )
         converter = TemplateConverter()
         result = converter.convert(generic_dataset, config)

--- a/genai-perf/tests/test_converters/test_template_converter.py
+++ b/genai-perf/tests/test_converters/test_template_converter.py
@@ -1,0 +1,124 @@
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+from unittest.mock import patch
+
+import pytest
+from genai_perf.exceptions import GenAIPerfException
+from genai_perf.inputs.converters import TemplateConverter
+from genai_perf.inputs.converters.template_converter import NAMED_TEMPLATES
+from genai_perf.inputs.input_constants import OutputFormat
+from genai_perf.inputs.inputs_config import InputsConfig
+from genai_perf.inputs.retrievers.generic_dataset import (
+    DataRow,
+    FileData,
+    GenericDataset,
+)
+from genai_perf.tokenizer import get_empty_tokenizer
+
+
+class TestTemplateConverter:
+    @staticmethod
+    def create_generic_dataset(rows) -> GenericDataset:
+        return GenericDataset(files_data={"file1": FileData(rows)})
+
+    def test_jinja2_not_installed(self):
+        with patch.dict(sys.modules, {"jinja2": None}, clear=True):
+            with pytest.raises(ImportError):
+                TemplateConverter().resolve_template("dummy")
+
+    @pytest.mark.parametrize(
+        "template", (*NAMED_TEMPLATES.keys(), """[{ "dummy": {{ texts|tojson }} }]""")
+    )
+    def test_check_config(self, template):
+        config = InputsConfig(
+            output_format=OutputFormat.TEMPLATE,
+            output_template=template,
+            tokenizer=get_empty_tokenizer(),
+        )
+
+        template_converter = TemplateConverter()
+        template_converter.check_config(config)
+
+    @pytest.mark.parametrize("template", ("unknown", """[] {{ texts }} }]"""))
+    def test_check_config_invalid_template(self, template):
+        config = InputsConfig(
+            output_format=OutputFormat.TEMPLATE,
+            tokenizer=get_empty_tokenizer(),
+            output_template=template,
+        )
+
+        template_converter = TemplateConverter()
+
+        with pytest.raises(GenAIPerfException):
+            template_converter.check_config(config)
+
+    def test_convert_named_template_nvembedqa(self):
+        generic_dataset = self.create_generic_dataset(
+            [
+                DataRow(texts=["sample_prompt_1"]),
+                DataRow(texts=["sample_prompt_2", "sample_prompt_3"]),
+            ]
+        )
+        config = InputsConfig(
+            output_format=OutputFormat.TEMPLATE,
+            tokenizer=get_empty_tokenizer(),
+            output_template="nv-embedqa",
+        )
+        converter = TemplateConverter()
+        result = converter.convert(generic_dataset, config)
+        expected_result = {
+            "data": [
+                {"text": ["sample_prompt_1"]},
+                {"text": ["sample_prompt_2"]},
+                {"text": ["sample_prompt_3"]},
+            ]
+        }
+        assert result == expected_result
+
+    def test_convert_custom_template(self):
+        output_template = """[{ "dummy": {{ texts|tojson }} }]"""
+        generic_dataset = self.create_generic_dataset(
+            [
+                DataRow(texts=["sample_prompt_1"]),
+                DataRow(texts=["sample_prompt_2", "sample_prompt_3"]),
+            ]
+        )
+        config = InputsConfig(
+            output_format=OutputFormat.TEMPLATE,
+            tokenizer=get_empty_tokenizer(),
+            output_template=output_template,
+        )
+        converter = TemplateConverter()
+        result = converter.convert(generic_dataset, config)
+        expected_result = {
+            "data": [
+                {"dummy": ["sample_prompt_1"]},
+                {"dummy": ["sample_prompt_2", "sample_prompt_3"]},
+            ]
+        }
+        assert result == expected_result

--- a/templates/genai-perf-templates/README_template
+++ b/templates/genai-perf-templates/README_template
@@ -56,7 +56,13 @@ You can use GenAI-Perf to run performance benchmarks on
 - [Multiple LoRA Adapters](docs/lora.md)
 
 You can also use GenAI-Perf to run benchmarks on your
-[custom APIs](docs/customizable_frontends.md).
+custom APIs using either
+[customizable frontends](docs/customizable_frontends.md)
+or
+[customizable payloads](docs/customizable_payloads.md).
+Customizable frontends provide more customizability,
+while customizable payloads allow you to specify
+specific payload schemas using a Jinja2 template.
 
 > [!Note]
 > GenAI-Perf is currently in early release and under rapid development. While we


### PR DESCRIPTION
With this change, we can format how the input data is converted into payloads using the `--output-template` option in the CLI. There are two ways of using this feature:

1. Use one of the named templates (e.g. `nv-embedqa`).
2. Provide a [Jinja](https://jinja.palletsprojects.com/en/stable/) template for formatting the payloads. See below for an example of how the conversion works.


### Usage 1: Named template


```bash
genai-perf profile --verbose --input-file /tmp/data.jsonl --concurrency 5 --artifact-dir results/genai-perf/run_20250205-234426 --model MY_MODEL --url localhost:8001 --batch-size 5 --extra-inputs output-template:nv-embedqa

# translates into

perf_analyzer -m MY_MODEL --async --input-data results/genai-perf/run_20250205-234426/inputs.json -i grpc --streaming --concurrency-range 5 --service-kind triton -u localhost:8001 --request-count 0 --warmup-request-count 0 --verbose --profile-export-file results/genai-perf/run_20250205-234426/profile_export.json --measurement-interval 10000 --stability-percentage 999
```

### Usage 2: Jinja template

The jinja template below will produce the same payload (i.e. `inputs.json`), and the resolved  `perf_analyzer` command is the same as above
```bash
template='
[
    {% for item in texts %}
        {"text": [{{ item|tojson }}]}{% if not loop.last %},{% endif %}
    {% endfor %}
]
'
```

This is saved in `custom_template.jinja`. Then, the command to run is:

```bash
genai-perf profile --verbose --input-file /tmp/data.jsonl --concurrency 5 --artifact-dir results/genai-perf/run_20250205-234426 --model MY_MODEL --url localhost:8001 --batch-size 5 --extra-inputs custom_template.jinja.
```

For example, if each row of data contains the following:
```
texts = ["example1", "example2"]
```
the formatted payload will look like

```
 [
    {"text: ["example1"]},
    {"text: ["example2"]}
 ]
```

the resulting `inputs.json` will look like
```
{
    "data": [
        {"text: ["example1"]},
        {"text: ["example2"]},
        ...
    ]
}
``` 