### PR TITLE
Add more detailed logging to `profile_data_parser`

### DIFF
--- a/genai-perf/genai_perf/logging.py
+++ b/genai-perf/genai_perf/logging.py
@@ -110,6 +110,11 @@ def init_logging() -> None:
                 "level": "DEBUG",
                 "propagate": False,
             },
+            "genai_perf.profile_data_parser": {
+                "handlers": ["console"],
+                "level": "DEBUG",
+                "propagate": False,
+            },
         },
     }
     logging.config.dictConfig(LOGGING_CONFIG)

--- a/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
+++ b/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
@@ -27,12 +27,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
-from tqdm import tqdm
 from itertools import tee
 from pathlib import Path
 from typing import Dict, List, Tuple
 
 from genai_perf.constants import EMPTY_RESPONSE_TOKEN
+from genai_perf.logging import logging
 from genai_perf.metrics import LLMMetrics, Metrics
 from genai_perf.profile_data_parser.profile_data_parser import (
     ProfileDataParser,
@@ -40,7 +40,7 @@ from genai_perf.profile_data_parser.profile_data_parser import (
 )
 from genai_perf.tokenizer import Tokenizer
 from genai_perf.utils import load_json_str, remove_sse_prefix
-from genai_perf.logging import logging
+from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -140,7 +140,9 @@ class LLMProfileDataParser(ProfileDataParser):
 
                 # inter token latencies
                 if total_output_token > 1:
-                    inter_token_latency = (req_latency_ns - ttft) / (total_output_token - 1)
+                    inter_token_latency = (req_latency_ns - ttft) / (
+                        total_output_token - 1
+                    )
                     inter_token_latencies.append(round(inter_token_latency))
 
                 # The new ITL calculation above loses all token-level ITL information
@@ -158,7 +160,7 @@ class LLMProfileDataParser(ProfileDataParser):
                     num_token = 1 if n2 == 0 else n2
                     chunked_inter_token_latency.append(round((t2 - t1) / num_token))
                 chunked_inter_token_latencies.append(chunked_inter_token_latency)
-                
+
                 pbar.update(1)
 
         # request & output token throughput

--- a/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
+++ b/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
@@ -33,6 +33,9 @@ from typing import Dict, List, Optional, Tuple
 from genai_perf.goodput_calculator.llm_goodput_calculator import LLMGoodputCalculator
 from genai_perf.metrics import Metrics, Statistics
 from genai_perf.utils import load_json
+from genai_perf.logging import logging
+
+logger = logging.getLogger(__name__)
 
 
 class ResponseFormat(Enum):
@@ -58,6 +61,7 @@ class ProfileDataParser:
         goodput_constraints: Dict[str, float] = {},
     ) -> None:
         self._goodput_constraints = goodput_constraints
+        logger.info("Loading response data from '%s'", str(filename))
         data = load_json(filename)
         self._get_profile_metadata(data)
         self._parse_profile_data(data)

--- a/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
+++ b/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,9 +31,9 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from genai_perf.goodput_calculator.llm_goodput_calculator import LLMGoodputCalculator
+from genai_perf.logging import logging
 from genai_perf.metrics import Metrics, Statistics
 from genai_perf.utils import load_json
-from genai_perf.logging import logging
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
When running `genai-perf profile` with a configuration that generates a large number of inference responses (i.e., when testing in a production datacenter environment with a significant measurement interval and a high number of concurrent requests), the respective profile export file is large and takes quite a long time to process.

Currently, it appears that no progress is made upon the completion of `perf_analyzer`. It is reasonable to add a progress bar and some other additional logging so that the user is more informed on the current state of the process.

<img width="1704" alt="Screenshot 2025-02-03 at 9 18 33 PM" src="https://github.com/user-attachments/assets/69fd630b-25b5-4405-a9bb-ec0bc849923e" />

Diff without whitespace: https://github.com/triton-inference-server/perf_analyzer/pull/269/files?w=1