### PR TITLE
Miscellaneous fixes for absolute timestamp/ fixed schedule mode

### DIFF
--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -475,11 +475,13 @@ Add a custom header to the requests. Headers must be specified as
 (default: `None`)
 
 ##### `--input-file <path>`
-The input file or directory for profiling. Each line should be a JSON object with a `text` or `image` field
-in JSONL format. Example: `{"text": "Your prompt here"}`. To use synthetic files, prefix with `synthetic:` followed by
-a comma-separated list of filenames without extensions (Example: `synthetic:queries,passages`).
-To use a payload file with a fixed schedule workload, prefix with `payload:` followed by the filename (Example: `payload:input.jsonl`).
-(default: `None`)
+The input file or directory for profiling. Each line should be a JSON object
+with a `text` or `image` field in JSONL format. Example:
+`{"text": "Your prompt here"}`. To use synthetic files, prefix with
+`synthetic:` followed by a comma-separated list of filenames without
+extensions (Example: `synthetic:queries,passages`). To use a payload file with
+a fixed schedule workload, prefix with `payload:` followed by the filename
+(Example: `payload:input.jsonl`). (default: `None`)
 
 ##### `--num-dataset-entries <int>`
 

--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -484,6 +484,10 @@ multiple files, prefix the path with 'synthetic:', followed by a
 comma-separated list of filenames. The synthetic filenames should not have
 extensions. For example, 'synthetic:queries,passages'.
 (default: `None`)
+To use payload file for fixed schedule workload, prefix the
+path with 'payload:', followed by the filename. The payload filename should not
+have an extension. For example, 'payload:input'.
+
 
 ##### `--num-dataset-entries <int>`
 

--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -475,19 +475,11 @@ Add a custom header to the requests. Headers must be specified as
 (default: `None`)
 
 ##### `--input-file <path>`
-
-The input file or directory containing the content to use for
-profiling. Each line should be a JSON object with a 'text' or 'image' field
-in JSONL format. Example: {\"text\": \"Your prompt here\"}"
-To use synthetic files for a converter that needs
-multiple files, prefix the path with 'synthetic:', followed by a
-comma-separated list of filenames. The synthetic filenames should not have
-extensions. For example, 'synthetic:queries,passages'.
+The input file or directory for profiling. Each line should be a JSON object with a `text` or `image` field
+in JSONL format. Example: `{"text": "Your prompt here"}`. To use synthetic files, prefix with `synthetic:` followed by
+a comma-separated list of filenames without extensions (Example: `synthetic:queries,passages`).
+To use a payload file with a fixed schedule workload, prefix with `payload:` followed by the filename (Example: `payload:input.jsonl`).
 (default: `None`)
-To use payload file for fixed schedule workload, prefix the
-path with 'payload:', followed by the filename. The payload filename should not
-have an extension. For example, 'payload:input'.
-
 
 ##### `--num-dataset-entries <int>`
 

--- a/genai-perf/genai_perf/inputs/retrievers/payload_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/payload_input_retriever.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -140,7 +140,7 @@ class PayloadInputRetriever(BaseFileInputRetriever):
         optional_data = {
             k: v
             for k, v in data.items()
-            if k not in ["text", "text_input", "timestamp"]
+            if k not in ["text", "text_input", "timestamp", "hash_ids"]
         }
         return optional_data
 

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -26,6 +26,7 @@
 
 
 import argparse
+import json
 import os
 import sys
 from dataclasses import dataclass
@@ -511,19 +512,22 @@ def _infer_prompt_source(args: argparse.Namespace) -> argparse.Namespace:
             logger.debug(
                 f"Input source is synthetic data: {args.synthetic_input_files}"
             )
+
         elif input_file_str.startswith("payload:"):
             args.prompt_source = ic.PromptSource.PAYLOAD
-            input_file_str = input_file_str.split(":", 1)[1]
-            if not input_file_str:
-                raise ValueError(
-                    f"Invalid payload input: '{input_file_str}' is missing the file path"
-                )
-            args.payload_input_file = Path(f"{input_file_str}.jsonl")
-            if not args.payload_input_file.is_file():
-                raise ValueError(f"'{args.payload_input_file}' is not a valid file")
+            payload_file = Path(input_file_str.split(":", 1)[1])
+            if not payload_file:
+                raise ValueError("Invalid file path: Path is None or empty.")
+
+            if not payload_file.is_file():
+                raise ValueError(f"File not found: {payload_file}")
+
+            args.payload_input_file = payload_file
+
             logger.debug(
                 f"Input source is a payload file with timing information in the following path: {args.payload_input_file}"
             )
+
         else:
             args.prompt_source = ic.PromptSource.FILE
             logger.debug(f"Input source is the following path: {args.input_file}")
@@ -546,7 +550,7 @@ def _convert_str_to_enum_entry(args, option, enum):
 
 
 def file_or_directory(value: str) -> Path:
-    if value.startswith("synthetic:") or value.startswith("payload:"):
+    if value.startswith("synthetic:"):
         return Path(value)
     else:
         path = Path(value)
@@ -828,8 +832,8 @@ def _add_input_args(parser):
         "should not have extensions. For example, "
         "'synthetic:queries,passages'. For payload data, prefix the path with 'payload:', "
         "followed by a JSON string representing a payload object. The payload should "
-        "contain fields such as 'timestamp', 'input_length', 'output_length', "
-        "and you can optionally add 'text_input', 'session_id', 'hash_ids', and 'priority'. "
+        "contain a 'timestamp' field "
+        "and you can optionally add 'input_length', 'output_length','text_input', 'session_id', 'hash_ids', and 'priority'. "
         'Example: \'payload:{"timestamp": 123.45, "input_length": 10, "output_length": 12, '
         '"session_id": 1, "priority": 5, "text_input": "Your prompt here"}\'.',
     )

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -26,7 +26,6 @@
 
 
 import argparse
-import json
 import os
 import sys
 from dataclasses import dataclass

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -549,7 +549,7 @@ def _convert_str_to_enum_entry(args, option, enum):
 
 
 def file_or_directory(value: str) -> Path:
-    if value.startswith("synthetic:"):
+    if value.startswith("synthetic:") or value.startswith("payload"):
         return Path(value)
     else:
         path = Path(value)

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -66,24 +66,7 @@ class Profiler:
     @staticmethod
     def add_payload_args(args: Namespace) -> List[str]:
         cmd = []
-        timings = []
-
-        if args.prompt_source == PromptSource.PAYLOAD:
-            try:
-                with open(args.payload_input_file, "r") as file:
-                    for line in file:
-                        try:
-                            timestamp = float(json.loads(line)["timestamp"])
-                            timings.append(timestamp)
-                        except (KeyError, ValueError) as e:
-                            raise ValueError(
-                                f"Invalid line in payload file: {line.strip()}. Details: {e}"
-                            )
-                cmd += ["--schedule", ",".join(map(str, timings))]
-            except FileNotFoundError:
-                raise FileNotFoundError(
-                    f"Payload input file not found: {args.payload_input_file}"
-                )
+        cmd += ["--fixed-schedule"]
         return cmd
 
     @staticmethod
@@ -138,10 +121,10 @@ class Profiler:
 
         if args.prompt_source == PromptSource.PAYLOAD:
             skip_args += [
-                "request_count",
-                "measurement_interval",
                 "stability_percentage",
                 "warmup_request_count",
+                "request_count",
+                "measurement_interval",
             ]
 
         utils.remove_file(args.profile_export_file)
@@ -155,8 +138,8 @@ class Profiler:
             f"{args.artifact_dir / DEFAULT_INPUT_DATA_JSON}",
         ]
         cmd += Profiler.add_protocol_args(args)
-        cmd += Profiler.add_inference_load_args(args)
         cmd += Profiler.add_payload_args(args)
+        cmd += Profiler.add_inference_load_args(args)
 
         for arg, value in vars(args).items():
             if arg in skip_args:

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -121,10 +121,10 @@ class Profiler:
 
         if args.prompt_source == PromptSource.PAYLOAD:
             skip_args += [
+                "measurement_interval",
+                "request_count",
                 "stability_percentage",
                 "warmup_request_count",
-                "request_count",
-                "measurement_interval",
             ]
 
         utils.remove_file(args.profile_export_file)
@@ -137,9 +137,10 @@ class Profiler:
             f"--input-data",
             f"{args.artifact_dir / DEFAULT_INPUT_DATA_JSON}",
         ]
-        cmd += Profiler.add_protocol_args(args)
-        cmd += Profiler.add_payload_args(args)
+
         cmd += Profiler.add_inference_load_args(args)
+        cmd += Profiler.add_payload_args(args)
+        cmd += Profiler.add_protocol_args(args)
 
         for arg, value in vars(args).items():
             if arg in skip_args:

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -918,12 +918,12 @@ class TestCLIArguments:
                 None,
             ),
             (
-                ["--input-file", "payload:test"],
+                ["--input-file", "payload:test.jsonl"],
                 PromptSource.PAYLOAD,
                 Path("test.jsonl"),
             ),
             (
-                ["--input-file", "synthetic:test"],
+                ["--input-file", "synthetic:test.jsonl"],
                 PromptSource.SYNTHETIC,
                 None,
             ),
@@ -948,7 +948,7 @@ class TestCLIArguments:
         "args",
         [
             (["--input-file", "payload:"]),
-            (["--input-file", "payload:input.jsonl"]),
+            (["--input-file", "payload:input"]),
         ],
     )
     def test_inferred_prompt_source_invalid_payload_input(
@@ -1022,7 +1022,7 @@ class TestCLIArguments:
             "-m",
             "test_model",
             "--input-file",
-            "payload:test",
+            "payload:test.jsonl",
         ] + args
 
         mocker.patch.object(Path, "is_file", return_value=True)
@@ -1039,7 +1039,7 @@ class TestCLIArguments:
             "-m",
             "test_model",
             "--input-file",
-            "payload:test",
+            "payload:test.jsonl",
         ]
         mocker.patch.object(Path, "is_file", return_value=True)
         monkeypatch.setattr("sys.argv", valid_args)

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -462,6 +462,22 @@ class TestCLIArguments:
         args, _ = parser.parse_args()
         assert args.concurrency == 1
 
+    def test_load_manager_args_with_payload(self, monkeypatch, mocker):
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "genai-perf",
+                "profile",
+                "--model",
+                "test_model",
+                "--input-file",
+                "payload:test",
+            ],
+        )
+        mocker.patch.object(Path, "is_file", return_value=True)
+        args, _ = parser.parse_args()
+        assert args.concurrency is None
+
     def test_load_level_mutually_exclusive(self, monkeypatch, capsys):
         monkeypatch.setattr(
             "sys.argv",
@@ -892,57 +908,69 @@ class TestCLIArguments:
         assert str(exc_info.value) == expected_error
 
     @pytest.mark.parametrize(
-        "args, expected_prompt_source, expected_input_file, expect_error",
+        "args, expected_prompt_source, expected_input_file",
         [
-            ([], PromptSource.SYNTHETIC, None, False),
-            (["--input-file", "prompt.txt"], PromptSource.FILE, None, False),
-            ([], PromptSource.SYNTHETIC, None, False),
-            (["--input-file", "prompt.txt"], PromptSource.FILE, None, False),
+            ([], PromptSource.SYNTHETIC, None),
+            (["--input-file", "prompt.txt"], PromptSource.FILE, None),
             (
                 ["--input-file", "prompt.txt", "--synthetic-input-tokens-mean", "10"],
                 PromptSource.FILE,
                 None,
-                False,
             ),
             (
                 ["--input-file", "payload:test"],
                 PromptSource.PAYLOAD,
                 Path("test.jsonl"),
-                False,
             ),
-            (["--input-file", "payload:"], PromptSource.PAYLOAD, [], True),
             (
                 ["--input-file", "synthetic:test"],
                 PromptSource.SYNTHETIC,
                 None,
-                False,
             ),
-            (["--input-file", "invalidinput"], PromptSource.FILE, None, False),
         ],
     )
-    def test_inferred_prompt_source(
+    def test_inferred_prompt_source_valid(
         self,
         monkeypatch,
         mocker,
         args,
         expected_prompt_source,
         expected_input_file,
-        expect_error,
     ):
         mocker.patch.object(Path, "is_file", return_value=True)
         combined_args = ["genai-perf", "profile", "--model", "test_model"] + args
         monkeypatch.setattr("sys.argv", combined_args)
+        parsed_args, _ = parser.parse_args()
+        assert parsed_args.prompt_source == expected_prompt_source
+        assert parsed_args.payload_input_file == expected_input_file
 
-        if expect_error:
-            with pytest.raises(ValueError):
-                parser.parse_args()
-        else:
-            args, _ = parser.parse_args()
+    @pytest.mark.parametrize(
+        "args",
+        [
+            (["--input-file", "payload:"]),
+            (["--input-file", "payload:input.jsonl"]),
+        ],
+    )
+    def test_inferred_prompt_source_invalid_payload_input(
+        self,
+        monkeypatch,
+        mocker,
+        args,
+    ):
+        mocker.patch.object(Path, "is_file", return_value=False)
+        combined_args = ["genai-perf", "profile", "--model", "test_model"] + args
+        monkeypatch.setattr("sys.argv", combined_args)
+        with pytest.raises(ValueError):
+            parser.parse_args()
 
-            assert args.prompt_source == expected_prompt_source
-
-            if expected_input_file is not None:
-                assert args.payload_input_file == expected_input_file
+    def test_inferred_prompt_source_invalid_input(self, monkeypatch, mocker):
+        file_arg = ["--input-file", "invalid_input"]
+        mocker.patch.object(Path, "is_file", return_value=False)
+        mocker.patch.object(Path, "is_dir", return_value=False)
+        combined_args = ["genai-perf", "profile", "--model", "test_model"] + file_arg
+        monkeypatch.setattr("sys.argv", combined_args)
+        with pytest.raises(SystemExit):
+            parser.parse_args()
 
     @pytest.mark.parametrize(
         "args",
@@ -963,6 +991,62 @@ class TestCLIArguments:
 
         with pytest.raises(SystemExit) as excinfo:
             parser.parse_args()
+
+    @pytest.mark.parametrize(
+        "args , expected_error_message",
+        [
+            (
+                ["--concurrency", "10"],
+                "--concurrency cannot be used with payload input.",
+            ),
+            (
+                ["--request-rate", "5"],
+                "--request-rate cannot be used with payload input.",
+            ),
+            (
+                ["--request-count", "3"],
+                "--request-count cannot be used with payload input.",
+            ),
+            (
+                ["--warmup-request-count", "7"],
+                "--warmup-request-count cannot be used with payload input.",
+            ),
+        ],
+    )
+    def test_check_payload_input_args_invalid_args(
+        self, monkeypatch, mocker, capsys, args, expected_error_message
+    ):
+        combined_args = [
+            "genai-perf",
+            "profile",
+            "-m",
+            "test_model",
+            "--input-file",
+            "payload:test",
+        ] + args
+
+        mocker.patch.object(Path, "is_file", return_value=True)
+        monkeypatch.setattr("sys.argv", combined_args)
+        with pytest.raises(SystemExit):
+            parser.parse_args()
+        captured = capsys.readouterr()
+        assert expected_error_message in captured.err
+
+    def test_check_payload_input_args_valid(self, monkeypatch, mocker):
+        valid_args = [
+            "genai-perf",
+            "profile",
+            "-m",
+            "test_model",
+            "--input-file",
+            "payload:test",
+        ]
+        mocker.patch.object(Path, "is_file", return_value=True)
+        monkeypatch.setattr("sys.argv", valid_args)
+        try:
+            parser.parse_args()
+        except SystemExit:
+            pytest.fail("Unexpected error in test")
 
     # ================================================
     # COMPARE SUBCOMMAND

--- a/genai-perf/tests/test_wrapper.py
+++ b/genai-perf/tests/test_wrapper.py
@@ -206,7 +206,7 @@ class TestWrapper:
 
         assert "--fixed-schedule" in cmd_string
 
-    def test_skipped_args_for_payload_input_not_in_cmd(self, monkeypatch, mocker):
+    def test_payload_skipped_args_not_in_cmd(self, monkeypatch, mocker):
         args = [
             "genai-perf",
             "profile",

--- a/genai-perf/tests/test_wrapper.py
+++ b/genai-perf/tests/test_wrapper.py
@@ -195,7 +195,7 @@ class TestWrapper:
             "-m",
             "test_model",
             "--input-file",
-            "payload:input",
+            "payload:input.jsonl",
         ]
         mocker.patch.object(Path, "is_file", return_value=True)
         mocker.patch("genai_perf.utils.remove_file")
@@ -213,7 +213,7 @@ class TestWrapper:
             "-m",
             "test_model",
             "--input-file",
-            "payload:input",
+            "payload:input.jsonl",
         ]
 
         mocker.patch.object(Path, "is_file", return_value=True)

--- a/genai-perf/tests/test_wrapper.py
+++ b/genai-perf/tests/test_wrapper.py
@@ -24,6 +24,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from pathlib import Path
+
 import pytest
 from genai_perf import parser
 from genai_perf.constants import DEFAULT_GRPC_URL
@@ -185,3 +187,47 @@ class TestWrapper:
                 assert (
                     False
                 ), f"Missing expected header flag: {expected_flag} or value: {expected_value}"
+
+    def test_payload_args_in_cmd(self, monkeypatch, mocker):
+        args = [
+            "genai-perf",
+            "profile",
+            "-m",
+            "test_model",
+            "--input-file",
+            "payload:input",
+        ]
+        mocker.patch.object(Path, "is_file", return_value=True)
+        mocker.patch("genai_perf.utils.remove_file")
+        monkeypatch.setattr("sys.argv", args)
+        args, extra_args = parser.parse_args()
+        cmd = Profiler.build_cmd(args, extra_args)
+        cmd_string = " ".join(cmd)
+
+        assert "--fixed-schedule" in cmd_string
+
+    def test_skipped_args_for_payload_input_not_in_cmd(self, monkeypatch, mocker):
+        args = [
+            "genai-perf",
+            "profile",
+            "-m",
+            "test_model",
+            "--input-file",
+            "payload:input",
+        ]
+
+        mocker.patch.object(Path, "is_file", return_value=True)
+        mocker.patch("genai_perf.utils.remove_file")
+        monkeypatch.setattr("sys.argv", args)
+        args, extra_args = parser.parse_args()
+
+        cmd = Profiler.build_cmd(args, extra_args)
+        cmd_string = " ".join(cmd)
+
+        for skipped_arg in [
+            "--stability-percentage",
+            "--warmup-request-count",
+            "--request-count",
+            "--measurement-interval",
+        ]:
+            assert skipped_arg not in cmd_string


### PR DESCRIPTION
This PR does some miscellaneous fixes
1. `concurrency`, `request-rate`, `request-count` and `warmup-request-count` are not passed when using this mode.
2. Unit test for method that payload input is not used with incompatible args mentioned above (covering valid and invalid cases)
3. `request-count`, `warmup-request-count`, `meaurement-interval`, `stability-percentage` with their default values are not added in PA subcommand.
4. Unit test to check if the above to be skipped args are actually skipped in PA subcommand 
5. Remove `--schedule <list of timestamps>` in PA subcommand
6. Add `--fixed-schedule` to PA subcommand as this is how it will be supported in PA from now
7. Unit test to check `--fixed-schedule` is added to PA subcommand when using payload input
8. Exclude `hash_ids` from being added to optional_data
9. Break `test_inferred_prompt_source` unit test in `test_cli.py` into two unit tests (valid and invalid case)
10. Update `input-file` section in `README`
11. Any miscellaneous changes 