### PR TITLE
fix incorrect token length for long isl

### DIFF
--- a/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
+++ b/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
@@ -113,11 +113,14 @@ class SyntheticPromptGenerator:
 
         start_idx = random.randrange(cls._corpus_length)
 
-        end_idx = start_idx + num_tokens
-        prompt_tokens = cls._tokenized_corpus[start_idx:end_idx]
-        if end_idx > cls._corpus_length:
-            prompt_tokens += cls._tokenized_corpus[: end_idx - cls._corpus_length]
-
+        remaining_tokens = num_tokens
+        prompt_tokens = []
+        while remaining_tokens > 0:
+            length = min(len(cls._corpus_length - start_idx), remaining_tokens)
+            prompt_tokens += cls._tokenized_corpus[start_idx:start_idx + length]
+            start_idx = 0
+            remaining_tokens -= length
+            
         return tokenizer.decode(prompt_tokens)
 
     @classmethod


### PR DESCRIPTION
if isl is long, the corpus needs to be repeated >1 times. 