### PR TITLE
Make template work with Triton service-kind

### DIFF
--- a/genai-perf/docs/customizable_payloads.md
+++ b/genai-perf/docs/customizable_payloads.md
@@ -32,6 +32,8 @@ With GenAI-Perf, you can customize how input data is formatted into payloads
 using templates. This allows you to define how payloads are
 structured when sent to an inference server.
 
+This feature is only available for the Triton service-kind currently.
+
 These provide less customizability than a
 [customizable frontend](customizable_frontends.md), which is used when more
 endpoint-specific logic is necessary. Templates are used when
@@ -59,6 +61,7 @@ Run the following command:
 genai-perf profile \
   --model MY_MODEL \
   --tokenizer MY_MODEL \
+  --service-kind triton \
   --num-payloads 2 \
   --extra-inputs payload_template:nv-embedqa
 ```
@@ -105,6 +108,7 @@ you can run the command:
 genai-perf profile \
   --model MY_MODEL \
   --tokenizer MY_MODEL \
+  --service-kind triton \
   --num-payloads 2 \
   --extra-inputs payload_template:custom_template.jinja
 ```

--- a/genai-perf/docs/customizable_payloads.md
+++ b/genai-perf/docs/customizable_payloads.md
@@ -62,6 +62,7 @@ genai-perf profile \
   --model MY_MODEL \
   --tokenizer MY_MODEL \
   --service-kind triton \
+  --endpoint-type template \
   --num-payloads 2 \
   --extra-inputs payload_template:nv-embedqa
 ```
@@ -109,6 +110,7 @@ genai-perf profile \
   --model MY_MODEL \
   --tokenizer MY_MODEL \
   --service-kind triton \
+  --endpoint-type template \
   --num-payloads 2 \
   --extra-inputs payload_template:custom_template.jinja
 ```

--- a/genai-perf/genai_perf/inputs/converters/template_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/template_converter.py
@@ -77,10 +77,10 @@ class TemplateConverter(BaseConverter):
         payload_template = config.extra_inputs.get("payload_template")
         if not payload_template:
             raise GenAIPerfException(
-                f"The template converter requires the "
+                "The template converter requires the "
                 "extra input payload_template, only "
                 "detected the following --extra-inputs: "
-                "{config.extra_inputs.keys}."
+                f"{list(config.extra_inputs.keys())}."
             )
         try:
             template = self.resolve_template(payload_template)

--- a/genai-perf/genai_perf/inputs/converters/template_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/template_converter.py
@@ -74,6 +74,12 @@ class TemplateConverter(BaseConverter):
         return environment.from_string(template_content)
 
     def check_config(self, config: InputsConfig) -> None:
+        for key, value in config.extra_inputs.items():
+            if key != "payload_template":
+                raise GenAIPerfException(
+                    "Template only supports the extra input 'payload_template'. "
+                )
+
         payload_template = config.extra_inputs.get("payload_template")
         if not payload_template:
             raise GenAIPerfException(

--- a/genai-perf/genai_perf/inputs/input_constants.py
+++ b/genai-perf/genai_perf/inputs/input_constants.py
@@ -25,7 +25,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from enum import Enum, auto
-from typing import Dict
 
 
 class ModelSelectionStrategy(Enum):

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -26,7 +26,6 @@
 
 
 import argparse
-import os
 import sys
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -199,9 +198,10 @@ def _check_conditional_args(
         if endpoint_config.endpoint:
             args.endpoint = endpoint_config.endpoint.format(MODEL_NAME=model_name)
 
-    if args.service_kind == "triton" and args.endpoint_type == "kserve":
+    if args.service_kind == "triton" and args.endpoint_type in ["kserve", "template"]:
         args = _convert_str_to_enum_entry(args, "backend", ic.OutputFormat)
-        args.output_format = args.backend
+        if args.endpoint_type == "kserve":
+            args.output_format = args.backend
     else:
         if args.backend is not ic.DEFAULT_BACKEND:
             parser.error(

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -97,7 +97,7 @@ _endpoint_type_map = {
         "v2/models/{MODEL_NAME}/generate", "triton", ic.OutputFormat.TRITON_GENERATE
     ),
     "kserve": EndpointConfig(None, "triton", ic.OutputFormat.TENSORRTLLM),
-    "template": EndpointConfig(None, "template", ic.OutputFormat.TEMPLATE),
+    "template": EndpointConfig(None, "triton", ic.OutputFormat.TEMPLATE),
     "tensorrtllm_engine": EndpointConfig(
         None, "tensorrtllm_engine", ic.OutputFormat.TENSORRTLLM_ENGINE
     ),
@@ -436,7 +436,7 @@ def _set_artifact_paths(args: argparse.Namespace) -> argparse.Namespace:
         if args.service_kind == "openai":
             name += [f"{args.service_kind}-{args.endpoint_type}"]
         elif args.service_kind == "triton":
-            name += [f"{args.service_kind}-{args.backend.to_lowercase()}"]
+            name += [f"{args.service_kind}-{args.backend}"]
         elif args.service_kind == "tensorrtllm_engine":
             name += [f"{args.service_kind}"]
         else:

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -436,7 +436,7 @@ def _set_artifact_paths(args: argparse.Namespace) -> argparse.Namespace:
         if args.service_kind == "openai":
             name += [f"{args.service_kind}-{args.endpoint_type}"]
         elif args.service_kind == "triton":
-            name += [f"{args.service_kind}-{args.backend}"]
+            name += [f"{args.service_kind}-{args.backend.to_lowercase()}"]
         elif args.service_kind == "tensorrtllm_engine":
             name += [f"{args.service_kind}"]
         else:

--- a/genai-perf/genai_perf/utils.py
+++ b/genai-perf/genai_perf/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -103,7 +103,7 @@ def convert_option_name(name: str) -> str:
     return name.replace("_", "-")
 
 
-def get_enum_names(enum: Type[Enum]) -> List:
+def get_enum_names(enum: Type[Enum]) -> List[str]:
     names = []
     for e in enum:
         names.append(e.name.lower())

--- a/genai-perf/tests/test_wrapper.py
+++ b/genai-perf/tests/test_wrapper.py
@@ -79,8 +79,6 @@ class TestWrapper:
             "profile",
             "-m",
             "test_model",
-            "--service-kind",
-            "triton",
         ] + arg
         monkeypatch.setattr("sys.argv", args)
         args, extra_args = parser.parse_args()


### PR DESCRIPTION
The template converter was previously having issues due to not having a valid service-kind that can be input. Fix that by making it work with the Triton service-kind.