### PR TITLE
Make PA CLI errors easier to parse

### DIFF
--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -93,10 +93,6 @@ CLParser::FormatMessage(std::string str, int offset) const
 void
 CLParser::Usage(const std::string& msg)
 {
-  if (!msg.empty()) {
-    std::cerr << "Error: " << msg << std::endl;
-  }
-
   std::cerr << "Usage: " << argv_[0] << " [options]" << std::endl;
   std::cerr << "==== SYNOPSIS ====\n \n";
   std::cerr << "\t--version " << std::endl;
@@ -836,6 +832,10 @@ CLParser::Usage(const std::string& msg)
              "the RPC to use when sending requests to the server.",
              18)
       << std::endl;
+
+  if (!msg.empty()) {
+    std::cerr << "Error: " << msg << std::endl;
+  }
   throw pa::PerfAnalyzerException(GENERIC_ERROR);
 }
 

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -945,6 +945,7 @@ CLParser::ParseCommandLine(int argc, char** argv)
   // Parse commandline...
   bool using_deprecated_concurrency{false};
   int opt;
+  opterr = 0;
   while ((opt = getopt_long(
               argc, argv, "vdazc:u:m:x:b:t:p:i:H:l:r:s:f:", long_options,
               NULL)) != -1) {
@@ -1836,7 +1837,17 @@ CLParser::ParseCommandLine(int argc, char** argv)
           params_->filename = optarg;
           break;
         case '?':
-          Usage();
+          if (optopt) {
+            Usage(
+                "Error: Invalid short option: '-" +
+                std::string(1, static_cast<char>(optopt)) + "'");
+          } else if (optind > 1 && argv[optind - 1][0] == '-') {
+            Usage(
+                "Error: Invalid long option: '" +
+                std::string{argv[optind - 1]} + "'");
+          } else {
+            Usage("Error: Unknown command-line argument.");
+          }
           break;
       }
     }


### PR DESCRIPTION
Return any errors with the PA CLI after the CLI help menu. This makes it so that the error is immediately visible without scrolling up through all of the CLI args.

After changes, the error goes to the bottom.

Invalid short option:
![image](https://github.com/user-attachments/assets/5731ea12-6206-4f6f-801a-22de622d645e)

Invalid long option:
![image](https://github.com/user-attachments/assets/0ad3223e-9de8-45b2-b8fe-5b1c5b72b8ce)

Invalid general option:
![image](https://github.com/user-attachments/assets/5f85d93f-2f06-4343-8900-8497765720e6)
