### PR TITLE
Support multi-turn benchmarking

### DIFF
--- a/genai-perf/genai_perf/inputs/converters/base_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/base_converter.py
@@ -71,9 +71,13 @@ class BaseConverter:
         for key, value in config.extra_inputs.items():
             payload[key] = value
 
-    def _add_payload_params(self, payload: Dict[Any, Any], optional_data) -> None:
-        for key, value in optional_data.items():
+    def _add_payload_optional_data(self, payload: Dict[Any, Any], row: DataRow) -> None:
+        for key, value in row.optional_data.items():
             payload[key] = value
+
+    def _add_payload_metadata(self, record: Dict[str, Any], row: DataRow) -> None:
+        for key, value in row.payload_metadata.items():
+            record[key] = [value]
 
     def _finalize_payload(
         self,
@@ -83,13 +87,12 @@ class BaseConverter:
         triton_format=False,
     ) -> Dict[str, Any]:
         self._add_request_params(payload, config)
-        self._add_payload_params(payload, row.optional_data)
+        self._add_payload_optional_data(payload, row)
         record: Dict[str, Any] = {}
         if not triton_format:
             record["payload"] = [payload]
         else:
             record.update(payload)
-        if row.timestamp is not None:
-            record["timestamp"] = [row.timestamp]
+        self._add_payload_metadata(record, row)
 
         return record

--- a/genai-perf/genai_perf/inputs/input_constants.py
+++ b/genai-perf/genai_perf/inputs/input_constants.py
@@ -72,6 +72,8 @@ DEFAULT_REQUEST_COUNT = 0
 DEFAULT_SYNTHETIC_FILENAME = "synthetic_data.json"
 DEFAULT_WARMUP_REQUEST_COUNT = 0
 DEFAULT_BACKEND = "tensorrtllm"
+PAYLOAD_METADATA_FIELDS = ["timestamp", "delay"]
+PAYLOAD_METADATA_INT_FIELDS = ["timestamp", "delay"]
 
 ###########################
 # Default Prompt Parameters

--- a/genai-perf/genai_perf/inputs/retrievers/base_file_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/base_file_input_retriever.py
@@ -34,8 +34,8 @@ from genai_perf.inputs.retrievers.generic_dataset import (
     GenericDataset,
     ImageData,
     OptionalData,
+    PayloadMetadata,
     TextData,
-    Timestamp,
 )
 
 
@@ -63,7 +63,11 @@ class BaseFileInputRetriever(BaseInputRetriever):
 
     def _get_content_from_input_file(self, filename: Path) -> Union[
         Tuple[TextData, ImageData],
-        Tuple[TextData, List[Timestamp], List[OptionalData]],
+        Tuple[
+            TextData,
+            List[OptionalData],
+            List[PayloadMetadata],
+        ],
     ]:
         """
         Reads the content from a JSONL file and returns lists of each content type.

--- a/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
+++ b/genai-perf/genai_perf/inputs/retrievers/generic_dataset.py
@@ -32,17 +32,18 @@ TextData: TypeAlias = List[str]
 ImageData: TypeAlias = List[str]
 InputData: TypeAlias = Union[TextData, ImageData]
 OptionalData: TypeAlias = Dict[str, Any]
-Timestamp: TypeAlias = int
-DataRowDict: TypeAlias = Dict[str, Union[InputData, Timestamp, OptionalData]]
+PayloadMetadata: TypeAlias = Dict[str, Any]
+DataRowField: TypeAlias = Union[InputData, OptionalData, PayloadMetadata]
+DataRowDict: TypeAlias = Dict[str, DataRowField]
 GenericDatasetDict: TypeAlias = Dict[Filename, List[DataRowDict]]
 
 
 @dataclass
 class DataRow:
-    texts: List[str] = field(default_factory=list)
-    images: List[str] = field(default_factory=list)
-    timestamp: Optional[int] = None
+    texts: TextData = field(default_factory=list)
+    images: ImageData = field(default_factory=list)
     optional_data: Dict[str, Any] = field(default_factory=dict)
+    payload_metadata: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> DataRowDict:
         """
@@ -54,10 +55,10 @@ class DataRow:
             datarow_dict["texts"] = self.texts
         if self.images:
             datarow_dict["images"] = self.images
-        if self.timestamp:
-            datarow_dict["timestamp"] = self.timestamp
         if self.optional_data:
             datarow_dict["optional_data"] = self.optional_data
+        if self.payload_metadata:
+            datarow_dict["payload_metadata"] = self.payload_metadata
         return datarow_dict
 
 
@@ -70,8 +71,8 @@ class FileData:
         Converts the FileData object to a list.
         Output format example for two payloads from a file:
         [
-            {'texts': ['text1', 'text2'], 'images': ['image1', 'image2'], 'timestamp': 'timestamp1', 'optional_data': {}},
-            {'texts': ['text3', 'text4'], 'images': ['image3', 'image4'], 'timestamp': 'timestamp2', 'optional_data': {}},
+            {'texts': ['text1', 'text2'], 'images': ['image1', 'image2'], 'optional_data': {}, 'payload_metadata': {}},
+            {'texts': ['text3', 'text4'], 'images': ['image3', 'image4'], 'optional_data': {}, 'payload_metadata': {}},
         ]
         """
         return [row.to_dict() for row in self.rows]
@@ -86,8 +87,8 @@ class GenericDataset:
         Converts the entire DataStructure object to a dictionary.
         Output format example for one payload from two files:
         {
-            'file_0': [{'texts': ['text1', 'text2'], 'images': ['image1', 'image2'],  'timestamp': 'timestamp1', 'optional_data': {}}],
-            'file_1': [{'texts': ['text1', 'text2'], 'images': ['image1', 'image2'],  'timestamp': 'timestamp2', 'optional_data': {}}],
+            'file_0': [{'texts': ['text1', 'text2'], 'images': ['image1', 'image2'], 'optional_data': {}, 'payload_metadata': {}],
+            'file_1': [{'texts': ['text1', 'text2'], 'images': ['image1', 'image2'], 'optional_data': {}, 'payload_metadata': {}],
         }
         """
         return {

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -1044,6 +1044,17 @@ def _add_profile_args(parser):
     )
 
 
+def _add_session_args(parser):
+    session_group = parser.add_argument_group("Session")
+
+    session_group.add_argument(
+        "--session-concurrency",
+        type=int,
+        required=False,
+        help="The number of concurrenct sessions to benchmark.",
+    )
+
+
 def _add_tokenizer_args(parser):
     tokenizer_group = parser.add_argument_group("Tokenizer")
 
@@ -1097,6 +1108,7 @@ def _parse_profile_args(subparsers) -> argparse.ArgumentParser:
     _add_other_args(profile)
     _add_output_args(profile)
     _add_profile_args(profile)
+    _add_session_args(profile)
     _add_tokenizer_args(profile)
     profile.set_defaults(func=profile_handler)
     return profile

--- a/genai-perf/genai_perf/subcommand/analyze.py
+++ b/genai-perf/genai_perf/subcommand/analyze.py
@@ -386,7 +386,11 @@ class Analyze:
             or args.sweep_type == "num_dataset_entries"
             or args.sweep_type == "batch_size"
         ):
-            if args.concurrency:
+            if args.session_concurrency:
+                # [TPA-985] Profile export file should have a session concurrency mode
+                infer_mode = "request_rate"
+                load_level = "0.0"
+            elif args.concurrency:
                 infer_mode = "concurrency"
                 load_level = f"{args.concurrency}"
             elif args.request_rate:

--- a/genai-perf/genai_perf/subcommand/profile.py
+++ b/genai-perf/genai_perf/subcommand/profile.py
@@ -76,7 +76,11 @@ def _report_output(
     telemetry_data_collectors: List[TelemetryDataCollector],
     args: Namespace,
 ) -> None:
-    if args.concurrency:
+    if args.session_concurrency:
+        # [TPA-985] Profile export file should have a session concurrency mode
+        infer_mode = "request_rate"
+        load_level = "0.0"
+    elif args.concurrency:
         infer_mode = "concurrency"
         load_level = f"{args.concurrency}"
     elif args.request_rate:

--- a/genai-perf/genai_perf/wrapper.py
+++ b/genai-perf/genai_perf/wrapper.py
@@ -67,7 +67,10 @@ class Profiler:
     @staticmethod
     def add_payload_args(args: Namespace) -> List[str]:
         cmd = []
-        if args.prompt_source == PromptSource.PAYLOAD:
+        if (
+            args.prompt_source == PromptSource.PAYLOAD
+            and args.session_concurrency is None
+        ):
             cmd += ["--fixed-schedule"]
         return cmd
 

--- a/genai-perf/tests/test_converters/test_embeddings_converter.py
+++ b/genai-perf/tests/test_converters/test_embeddings_converter.py
@@ -229,13 +229,13 @@ class TestOpenAIEmbeddingsConverter:
                     rows=[
                         DataRow(
                             texts=["text_1"],
-                            timestamp=0,
                             optional_data=optional_data_1,
+                            payload_metadata={"timestamp": 0},
                         ),
                         DataRow(
                             texts=["text_2"],
-                            timestamp=3047,
                             optional_data=optional_data_2,
+                            payload_metadata={"timestamp": 3047},
                         ),
                     ],
                 )

--- a/genai-perf/tests/test_converters/test_image_retrieval_converter.py
+++ b/genai-perf/tests/test_converters/test_image_retrieval_converter.py
@@ -58,8 +58,8 @@ class TestImageRetrievalConverter:
                     rows=[
                         DataRow(
                             images=["test_image_1", "test_image_2"],
-                            timestamp=0,
                             optional_data=optional_data,
+                            payload_metadata={"timestamp": 0},
                         )
                     ]
                 )

--- a/genai-perf/tests/test_converters/test_nvclip_converter.py
+++ b/genai-perf/tests/test_converters/test_nvclip_converter.py
@@ -169,8 +169,8 @@ class TestNVClipConverter:
                 DataRow(
                     texts=["text1"],
                     images=["image1"],
-                    timestamp=0,
                     optional_data=optional_data,
+                    payload_metadata={"timestamp": 0},
                 ),
             ]
         )

--- a/genai-perf/tests/test_converters/test_openai_chat_converter.py
+++ b/genai-perf/tests/test_converters/test_openai_chat_converter.py
@@ -64,9 +64,11 @@ class TestOpenAIChatCompletionsConverter:
                 return optional_data
             return {}
 
-        def clean_timestamp(row):
-            timestamp = row.get("timestamp")
-            return timestamp
+        def clean_payload_metadata(row):
+            payload_metadata = row.get("payload_metadata")
+            if isinstance(payload_metadata, Dict):
+                return payload_metadata
+            return {}
 
         return GenericDataset(
             files_data={
@@ -75,8 +77,8 @@ class TestOpenAIChatCompletionsConverter:
                         DataRow(
                             texts=clean_text(row),
                             images=clean_image(row),
-                            timestamp=clean_timestamp(row),
                             optional_data=clean_optional_data(row),
+                            payload_metadata=clean_payload_metadata(row),
                         )
                         for row in rows
                     ],
@@ -327,6 +329,7 @@ class TestOpenAIChatCompletionsConverter:
                     "text": "text input one",
                     "timestamp": 0,
                     "optional_data": optional_data,
+                    "payload_metadata": {"timestamp": 0},
                 }
             ]
         )

--- a/genai-perf/tests/test_converters/test_openai_completions_converter.py
+++ b/genai-perf/tests/test_converters/test_openai_completions_converter.py
@@ -69,13 +69,13 @@ class TestOpenAICompletionsConverter:
                     rows=[
                         DataRow(
                             texts=["text input one"],
-                            timestamp=0,
                             optional_data=optional_data_1,
+                            payload_metadata={"timestamp": 0},
                         ),
                         DataRow(
                             texts=["text input two"],
-                            timestamp=2345,
                             optional_data=optional_data_2,
+                            payload_metadata={"timestamp": 2345},
                         ),
                     ],
                 )

--- a/genai-perf/tests/test_converters/test_rankings_converter.py
+++ b/genai-perf/tests/test_converters/test_rankings_converter.py
@@ -63,8 +63,8 @@ class TestRankingsConverter:
     def create_generic_dataset_payload_parameters(
         queries_data: Optional[List[List[str]]] = None,
         passages_data: Optional[List[List[str]]] = None,
-        timestamps: Optional[List[int]] = None,
         optional_data: Optional[List[Dict[Any, Any]]] = None,
+        payload_metadata: Optional[List[Dict[Any, Any]]] = None,
     ) -> GenericDataset:
         files_data = {}
 
@@ -78,10 +78,14 @@ class TestRankingsConverter:
                 rows=[
                     DataRow(
                         texts=passage,
-                        timestamp=timestamps[index] if timestamps else None,
                         optional_data=(
                             optional_data[index]
                             if optional_data and index < len(optional_data)
+                            else {}
+                        ),
+                        payload_metadata=(
+                            payload_metadata[index]
+                            if payload_metadata and index < len(payload_metadata)
                             else {}
                         ),
                     )
@@ -367,8 +371,8 @@ class TestRankingsConverter:
         generic_dataset = self.create_generic_dataset_payload_parameters(
             queries_data=[["query 1"], ["query 2"]],
             passages_data=[["passage 1", "passage 2"], ["passage 3", "passage 4"]],
-            timestamps=[0, 2345],
             optional_data=[optional_data_1, optional_data_2],
+            payload_metadata=[{"timestamp": 0}, {"timestamp": 2345}],
         )
 
         config = InputsConfig(

--- a/genai-perf/tests/test_converters/test_tensorrtllm_engine_converter.py
+++ b/genai-perf/tests/test_converters/test_tensorrtllm_engine_converter.py
@@ -71,13 +71,13 @@ class TestTensorRTLLMEngineConverter:
                     rows=[
                         DataRow(
                             texts=["text input one"],
-                            timestamp=0,
                             optional_data=optional_data_1,
+                            payload_metadata={"timestamp": 0},
                         ),
                         DataRow(
                             texts=["text input two"],
-                            timestamp=2345,
                             optional_data=optional_data_2,
+                            payload_metadata={"timestamp": 2345},
                         ),
                     ],
                 )

--- a/genai-perf/tests/test_converters/test_triton_generate_converter.py
+++ b/genai-perf/tests/test_converters/test_triton_generate_converter.py
@@ -180,8 +180,8 @@ class TestTritonGenerateConverter:
             [
                 DataRow(
                     texts=["extra_input_prompt"],
-                    timestamp=0,
                     optional_data=optional_data,
+                    payload_metadata={"timestamp": 0},
                 )
             ]
         )

--- a/genai-perf/tests/test_converters/test_triton_tensorrtllm_converter.py
+++ b/genai-perf/tests/test_converters/test_triton_tensorrtllm_converter.py
@@ -72,13 +72,13 @@ class TestTensorRTLLMConverter:
                     rows=[
                         DataRow(
                             texts=["text input one"],
-                            timestamp=0,
                             optional_data=optional_data_1,
+                            payload_metadata={"timestamp": 0},
                         ),
                         DataRow(
                             texts=["text input two"],
-                            timestamp=2345,
                             optional_data=optional_data_2,
+                            payload_metadata={"timestamp": 2345},
                         ),
                     ],
                 )

--- a/genai-perf/tests/test_converters/test_triton_vllm_converter.py
+++ b/genai-perf/tests/test_converters/test_triton_vllm_converter.py
@@ -67,13 +67,13 @@ class TestVLLMConverter:
                     rows=[
                         DataRow(
                             texts=["text input one"],
-                            timestamp=0,
                             optional_data=optional_data_1,
+                            payload_metadata={"timestamp": 0},
                         ),
                         DataRow(
                             texts=["text input two"],
-                            timestamp=2345,
                             optional_data=optional_data_2,
+                            payload_metadata={"timestamp": 2345},
                         ),
                     ],
                 )

--- a/genai-perf/tests/test_exporters/test_json_exporter.py
+++ b/genai-perf/tests/test_exporters/test_json_exporter.py
@@ -223,6 +223,7 @@ class TestJsonExporter:
           "endpoint_type": "kserve",
           "service_kind": "triton",
           "server_metrics_url": [],
+          "session_concurrency": null,
           "streaming": true,
           "u": null,
           "num_dataset_entries": 100,


### PR DESCRIPTION
Add support for `session ID` and `delay` in the payload file retriever. Update tests, as needed.

The design is intended to be extensible, to make it easier to add support for other payload metadata in the future, plus add support via other retrievers (e.g. synthetic).

![image](https://github.com/user-attachments/assets/c22e6548-ac81-42b3-9445-8f45a9f34ec5)
