### PR TITLE
Add per-session metrics to the resulting JSON file

### DIFF
--- a/genai-perf/genai_perf/export_data/exporter_config.py
+++ b/genai-perf/genai_perf/export_data/exporter_config.py
@@ -41,3 +41,4 @@ class ExporterConfig:
     extra_inputs: Dict[str, Any]
     artifact_dir: Path
     telemetry_stats: Dict[str, Any] = field(default_factory=dict)
+    session_stats: Dict[str, Any] = field(default_factory=dict)

--- a/genai-perf/genai_perf/metrics/llm_metrics.py
+++ b/genai-perf/genai_perf/metrics/llm_metrics.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import List, Union
+from typing import Dict, List, Union
 
 from genai_perf.metrics.metrics import MetricMetadata, Metrics
 
@@ -99,6 +99,25 @@ class LLMMetrics(Metrics):
         )
         self._base_names["output_sequence_lengths"] = "output_sequence_length"
         self._base_names["input_sequence_lengths"] = "input_sequence_length"
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, List[float | int]]) -> "LLMMetrics":
+        """Create LLMMetrics from a dictionary, converting types as needed."""
+        return cls(
+            request_throughputs=[float(x) for x in data["request_throughputs"]],
+            request_latencies=[int(x) for x in data["request_latencies"]],
+            time_to_first_tokens=[int(x) for x in data["time_to_first_tokens"]],
+            time_to_second_tokens=[int(x) for x in data["time_to_second_tokens"]],
+            inter_token_latencies=[int(x) for x in data["inter_token_latencies"]],
+            output_token_throughputs=[
+                float(x) for x in data["output_token_throughputs"]
+            ],
+            output_token_throughputs_per_request=[
+                float(x) for x in data["output_token_throughputs_per_request"]
+            ],
+            output_sequence_lengths=[int(x) for x in data["output_sequence_lengths"]],
+            input_sequence_lengths=[int(x) for x in data["input_sequence_lengths"]],
+        )
 
     @property
     def request_metrics(self) -> List[MetricMetadata]:

--- a/genai-perf/genai_perf/metrics/statistics.py
+++ b/genai-perf/genai_perf/metrics/statistics.py
@@ -27,11 +27,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from collections import defaultdict
-from pathlib import Path
 from typing import Dict, List, Tuple, Union
 
 import numpy as np
-import pandas as pd
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.metrics.metrics import Metrics
 from genai_perf.metrics.telemetry_metrics import TelemetryMetrics

--- a/genai-perf/genai_perf/metrics/statistics.py
+++ b/genai-perf/genai_perf/metrics/statistics.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -65,6 +65,7 @@ class Statistics:
             if self._should_skip(data, attr):
                 continue
 
+            # TelemetryMetrics does not have get_base_name method
             if hasattr(metrics, "get_base_name"):
                 attr = metrics.get_base_name(attr)
                 self._add_units(attr)
@@ -110,17 +111,12 @@ class Statistics:
         return float(std)
 
     def scale_data(self, factor: float = 1 / 1e6) -> None:
+        """Scale the time-based metrics by the factor."""
         for k1, v1 in self.stats_dict.items():
             if self._is_time_metric(k1):
                 for k2, v2 in v1.items():
                     if k2 != "unit":
-                        self.stats_dict[k1][k2] = self._scale(v2, factor)
-
-    def _scale(self, metric: float, factor: float) -> float:
-        """
-        Scale metrics by the factor
-        """
-        return metric * factor
+                        self.stats_dict[k1][k2] = v2 * factor
 
     def _add_units(self, key) -> None:
         if self._is_time_metric(key):
@@ -174,30 +170,6 @@ class Statistics:
             "image_latency",
         ]
         return field in time_metrics
-
-    def export_parquet(self, artifact_dir: Path, filename: str) -> None:
-        max_length = -1
-        col_index = 0
-        filler_list = []
-        df = pd.DataFrame()
-
-        # Data frames require all columns of the same length
-        # find the max length column
-        for key, value in self._metrics.data.items():
-            max_length = max(max_length, len(value))
-
-        # Insert None for shorter columns to match longest column
-        for key, value in self._metrics.data.items():
-            if len(value) < max_length:
-                diff = max_length - len(value)
-                filler_list = [None] * diff
-            df.insert(col_index, key, value + filler_list)
-            diff = 0
-            filler_list = []
-            col_index = col_index + 1
-
-        filepath = artifact_dir / f"{filename}.gzip"
-        df.to_parquet(filepath, compression="gzip")
 
     def create_records(self) -> PerfRecords:
         """

--- a/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
+++ b/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
@@ -333,7 +333,7 @@ class LLMProfileDataParser(ProfileDataParser):
         elif self._response_format == ResponseFormat.OPENAI_CHAT_COMPLETIONS:
             input_text = payload["messages"][0]["content"]
         elif self._response_format == ResponseFormat.OPENAI_COMPLETIONS:
-            input_text = payload["prompt"]
+            input_text = " ".join(payload["prompt"])
         elif self._response_format == ResponseFormat.OPENAI_VISION:
             content = payload["messages"][0]["content"]
             input_text = " ".join(c["text"] for c in content if c["type"] == "text")

--- a/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
+++ b/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
@@ -27,13 +27,14 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
+from collections import defaultdict
 from itertools import tee
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, TypeAlias
 
 from genai_perf.constants import EMPTY_RESPONSE_TOKEN
 from genai_perf.logging import logging
-from genai_perf.metrics import LLMMetrics, Metrics
+from genai_perf.metrics import LLMMetrics, Statistics
 from genai_perf.profile_data_parser.profile_data_parser import (
     ProfileDataParser,
     ResponseFormat,
@@ -43,6 +44,8 @@ from genai_perf.utils import load_json_str, remove_sse_prefix
 from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
+
+SessionMetrics: TypeAlias = Dict[str, Dict[str, List[float | int]]]
 
 
 class LLMProfileDataParser(ProfileDataParser):
@@ -77,9 +80,29 @@ class LLMProfileDataParser(ProfileDataParser):
         goodput_constraints: Dict[str, float] = {},
     ) -> None:
         self._tokenizer = tokenizer
+        self._session_metrics: SessionMetrics = defaultdict(lambda: defaultdict(list))
         super().__init__(filename, goodput_constraints)
 
-    def _parse_requests(self, requests: dict) -> Metrics:
+    def _parse_profile_data(self, data: dict) -> None:
+        """Parse through the entire profile data to collect statistics."""
+        self._profile_results = {}
+        for experiment in data["experiments"]:
+            infer_mode = experiment["experiment"]["mode"]
+            load_level = experiment["experiment"]["value"]
+            requests = experiment["requests"]
+
+            llm_metrics = self._parse_requests(requests)
+
+            # aggregate and calculate statistics
+            statistics = Statistics(llm_metrics)
+            self._profile_results[(infer_mode, str(load_level))] = statistics
+
+            # calculate per-session statistics
+            for session_id, session_metric in self._session_metrics.items():
+                metrics = LLMMetrics.from_dict(session_metric)
+                self._session_statistics[session_id] = Statistics(metrics)
+
+    def _parse_requests(self, requests: dict) -> LLMMetrics:
         """Parse each requests in profile export data to extract key metrics."""
         min_req_timestamp, max_res_timestamp = float("inf"), 0
         request_latencies = []
@@ -126,7 +149,7 @@ class LLMProfileDataParser(ProfileDataParser):
                     time_to_second_tokens.append(ttst)
 
                 # number of input tokens
-                input_seq_len = self._get_input_token_count(req_inputs)
+                input_seq_len, session_id = self._get_input_token_count(req_inputs)
                 input_sequence_lengths.append(input_seq_len)
 
                 # output token throughput per request
@@ -161,6 +184,26 @@ class LLMProfileDataParser(ProfileDataParser):
                     chunked_inter_token_latency.append(round((t2 - t1) / num_token))
                 chunked_inter_token_latencies.append(chunked_inter_token_latency)
 
+                # (per-session) calculate llm metrics
+                if session_id:
+                    session_metric = self._session_metrics[session_id]
+                    session_metric["request_latencies"].append(req_latency_ns)
+                    session_metric["time_to_first_tokens"].append(ttft)
+                    if len(res_timestamps) > 1:
+                        session_metric["time_to_second_tokens"].append(ttst)
+                    if total_output_token > 1:
+                        session_metric["inter_token_latencies"].append(
+                            inter_token_latency
+                        )
+                    session_metric["output_token_throughputs_per_request"].append(
+                        total_output_token / req_latency_s
+                    )
+                    session_metric["input_sequence_lengths"].append(input_seq_len)
+                    session_metric["output_sequence_lengths"].append(total_output_token)
+                    # collect request and last response timestamps each session
+                    session_metric["req_timestamps"].append(req_timestamp)
+                    session_metric["last_res_timestamps"].append(res_timestamps[-1])
+
                 pbar.update(1)
 
         # request & output token throughput
@@ -168,7 +211,20 @@ class LLMProfileDataParser(ProfileDataParser):
         request_throughputs = [len(requests) / benchmark_duration]
         output_token_throughputs = [sum(output_sequence_lengths) / benchmark_duration]
 
-        llm_metric = LLMMetrics(
+        # (per-session) request & output token throughput
+        for metric in self._session_metrics.values():
+            init_t = min(metric["req_timestamps"])
+            last_t = max(metric["last_res_timestamps"])
+            session_latency = (last_t - init_t) / 1e9  # to seconds
+            num_requests = len(metric["req_timestamps"])
+            num_tokens = sum(metric["output_sequence_lengths"])
+            metric["request_throughputs"].append(num_requests / session_latency)
+            metric["output_token_throughputs"].append(num_tokens / session_latency)
+            # clean up
+            del metric["req_timestamps"]
+            del metric["last_res_timestamps"]
+
+        llm_metrics = LLMMetrics(
             request_throughputs,
             request_latencies,
             time_to_first_tokens,
@@ -182,10 +238,10 @@ class LLMProfileDataParser(ProfileDataParser):
         )
 
         if self._goodput_constraints:
-            goodput_val = self._calculate_goodput(benchmark_duration, llm_metric)
-            llm_metric.request_goodputs = goodput_val
+            goodput_val = self._calculate_goodput(benchmark_duration, llm_metrics)
+            llm_metrics.request_goodputs = goodput_val
 
-        return llm_metric
+        return llm_metrics
 
     def _pairwise(self, iterable):
         """Generate pairs of consecutive elements from the given iterable."""
@@ -252,33 +308,38 @@ class LLMProfileDataParser(ProfileDataParser):
                 res_timestamps.pop(index)
                 res_outputs.pop(index)
 
-    def _get_input_token_count(self, req_inputs: dict) -> int:
+    def _get_input_token_count(self, req_inputs: dict) -> Tuple[int, str]:
         """Deserialize the request input and return tokenized inputs."""
         if self._service_kind == "triton":
             input_text = req_inputs["text_input"]
+            session_id = req_inputs.get("session_id", "")
         elif self._service_kind == "triton_c_api":
-            return len(req_inputs["input_ids"])  # no tokenizer required
+            session_id = req_inputs.get("session_id", "")
+            return len(req_inputs["input_ids"]), session_id  # no tokenizer required
         elif self._service_kind == "openai":
-            input_text = self._get_input_text(req_inputs)
+            input_text, session_id = self._get_input_payload(req_inputs)
         else:
             raise ValueError(f"Unknown service kind: '{self._service_kind}'.")
 
-        return len(self._tokenizer.encode(input_text))
+        token_count = len(self._tokenizer.encode(input_text))
+        return token_count, session_id
 
-    def _get_input_text(self, req_inputs: dict) -> str:
-        """Tokenize the request input texts."""
+    def _get_input_payload(self, req_inputs: dict) -> Tuple[str, str]:
+        """Deserialize the request input payload."""
         payload = load_json_str(req_inputs["payload"])
+        session_id = payload.get("session_id", "")
         if self._response_format == ResponseFormat.TRITON_GENERATE:
-            return " ".join(payload["text_input"])
+            input_text = " ".join(payload["text_input"])
         elif self._response_format == ResponseFormat.OPENAI_CHAT_COMPLETIONS:
-            return payload["messages"][0]["content"]
+            input_text = payload["messages"][0]["content"]
         elif self._response_format == ResponseFormat.OPENAI_COMPLETIONS:
-            return " ".join(payload["prompt"])
+            input_text = payload["prompt"]
         elif self._response_format == ResponseFormat.OPENAI_VISION:
             content = payload["messages"][0]["content"]
-            return " ".join(c["text"] for c in content if c["type"] == "text")
+            input_text = " ".join(c["text"] for c in content if c["type"] == "text")
         else:
             raise ValueError("Failed to parse request input in profile export file.")
+        return input_text, session_id
 
     def _get_output_token_counts(
         self, res_outputs: List[Dict]

--- a/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
+++ b/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
@@ -163,10 +163,10 @@ class LLMProfileDataParser(ProfileDataParser):
 
                 # inter token latencies
                 if total_output_token > 1:
-                    inter_token_latency = (req_latency_ns - ttft) / (
-                        total_output_token - 1
+                    inter_token_latency = round(
+                        (req_latency_ns - ttft) / (total_output_token - 1)
                     )
-                    inter_token_latencies.append(round(inter_token_latency))
+                    inter_token_latencies.append(inter_token_latency)
 
                 # The new ITL calculation above loses all token-level ITL information
                 # and as a result breaks ITL vs token position visualization. Keep

--- a/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
+++ b/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
@@ -61,6 +61,7 @@ class ProfileDataParser:
         goodput_constraints: Dict[str, float] = {},
     ) -> None:
         self._goodput_constraints = goodput_constraints
+        self._session_statistics: Dict[str, Statistics] = {}
         logger.info("Loading response data from '%s'", str(filename))
         data = load_json(filename)
         self._get_profile_metadata(data)
@@ -186,6 +187,10 @@ class ProfileDataParser:
         if (infer_mode, load_level) not in self._profile_results:
             raise KeyError(f"Profile with {infer_mode}={load_level} does not exist.")
         return self._profile_results[(infer_mode, load_level)]
+
+    def get_session_statistics(self) -> Dict[str, Statistics]:
+        """Return session statistics."""
+        return self._session_statistics
 
     def get_profile_load_info(self) -> List[Tuple[str, str]]:
         """Return available (infer_mode, load_level) tuple keys."""

--- a/genai-perf/genai_perf/subcommand/analyze.py
+++ b/genai-perf/genai_perf/subcommand/analyze.py
@@ -231,6 +231,7 @@ class Analyze:
                 )
                 data_parser = calculate_metrics(obj_args, tokenizer)
                 perf_stats = data_parser.get_statistics(infer_mode, load_level)
+                session_stats = data_parser.get_session_statistics()
                 perf_metrics = perf_stats.create_records()
 
                 #
@@ -249,7 +250,7 @@ class Analyze:
                 #
                 # Create output CSV in artifact directory
                 OutputReporter(
-                    perf_stats, merged_telemetry_stats, obj_args
+                    perf_stats, merged_telemetry_stats, obj_args, session_stats
                 ).report_output()
 
                 #

--- a/genai-perf/genai_perf/subcommand/profile.py
+++ b/genai-perf/genai_perf/subcommand/profile.py
@@ -91,17 +91,15 @@ def _report_output(
         raise GenAIPerfException("No valid infer mode specified")
 
     stats = data_parser.get_statistics(infer_mode, load_level)
-    telemetry_metrics_list = [
-        collector.get_metrics() for collector in telemetry_data_collectors
-    ]
+    session_stats = data_parser.get_session_statistics()
 
-    merged_telemetry_metrics = merge_telemetry_metrics(telemetry_metrics_list)
+    telemetry_metrics = [c.get_metrics() for c in telemetry_data_collectors]
+    merged_telemetry_metrics = merge_telemetry_metrics(telemetry_metrics)
+    telemetry_stats = TelemetryStatistics(merged_telemetry_metrics)
 
-    reporter = OutputReporter(
-        stats, TelemetryStatistics(merged_telemetry_metrics), args
-    )
-
+    reporter = OutputReporter(stats, telemetry_stats, args, session_stats)
     reporter.report_output()
+
     if args.generate_plots:
         _create_plots(args)
 

--- a/genai-perf/tests/test_data_parser/test_llm_profile_data_parser.py
+++ b/genai-perf/tests/test_data_parser/test_llm_profile_data_parser.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -974,3 +974,190 @@ class TestLLMProfileDataParser:
 
         pd._preprocess_response(res_timestamps, res_outputs)
         assert res_outputs[0]["response"] == expected_response
+
+    ###############################
+    # SESSION METRICS
+    ###############################
+    session_profile_data = {
+        "service_kind": "openai",
+        "endpoint": "v1/chat/completions",
+        "experiments": [
+            {
+                "experiment": {
+                    "mode": "concurrency",
+                    "value": 10,
+                },
+                "requests": [
+                    # ---------------- session 1 ----------------
+                    {
+                        "timestamp": 1,
+                        "request_inputs": {
+                            "payload": '{"model":"test_model","messages":[{"role":"user","content":"I like dogs"}],"session_id":"session-id-123"}',
+                        },
+                        "response_timestamps": [3, 5, 8],
+                        "response_outputs": [
+                            {
+                                "response": 'data: {"object":"chat.completion.chunk","model":"test_model","choices":[{"index":0,"delta":{"content":"I"}}]}\n\n'
+                            },
+                            {
+                                "response": 'data: {"object":"chat.completion.chunk","model":"test_model","choices":[{"index":0,"delta":{"content":" like"}}]}\n\n'
+                            },
+                            {
+                                "response": 'data: {"object":"chat.completion.chunk","model":"test_model","choices":[{"index":0,"delta":{"content":" dogs"}}]}\n\n'
+                            },
+                        ],
+                    },
+                    {
+                        "timestamp": 14,
+                        "request_inputs": {
+                            "payload": '{"model":"test_model","messages":[{"role":"user","content":"I like dogs"}],"session_id":"session-id-123"}',
+                        },
+                        "response_timestamps": [16, 18],
+                        "response_outputs": [
+                            {
+                                "response": 'data: {"object":"chat.completion.chunk","model":"test_model","choices":[{"index":0,"delta":{"content":"Hello"}}]}\n\n'
+                            },
+                            {
+                                "response": 'data: {"object":"chat.completion.chunk","model":"test_model","choices":[{"index":0,"delta":{"content":" world"}}]}\n\n'
+                            },
+                        ],
+                    },
+                    # -------------------------------------------
+                    # ---------------- session 2 ----------------
+                    {
+                        "timestamp": 2,
+                        "request_inputs": {
+                            "payload": '{"model":"test_model","messages":[{"role":"user","content":"I like dogs too"}],"session_id":"session-id-456"}',
+                        },
+                        "response_timestamps": [4, 7, 10],
+                        "response_outputs": [
+                            {
+                                "response": 'data: {"object":"chat.completion.chunk","model":"test_model","choices":[{"index":0,"delta":{"content":"I"}}]}\n\n'
+                            },
+                            {
+                                "response": 'data: {"object":"chat.completion.chunk","model":"test_model","choices":[{"index":0,"delta":{"content":" like"}}]}\n\n'
+                            },
+                            {
+                                "response": 'data: {"object":"chat.completion.chunk","model":"test_model","choices":[{"index":0,"delta":{"content":" dogs"}}]}\n\n'
+                            },
+                        ],
+                    },
+                    {
+                        "timestamp": 13,
+                        "request_inputs": {
+                            "payload": '{"model":"test_model","messages":[{"role":"user","content":"I like dogs too"}],"session_id":"session-id-456"}',
+                        },
+                        "response_timestamps": [15, 16, 17],
+                        "response_outputs": [
+                            {
+                                "response": 'data: {"object":"chat.completion.chunk","model":"test_model","choices":[{"index":0,"delta":{"content":"I"}}]}\n\n'
+                            },
+                            {
+                                "response": 'data: {"object":"chat.completion.chunk","model":"test_model","choices":[{"index":0,"delta":{"content":" like"}}]}\n\n'
+                            },
+                            {
+                                "response": 'data: {"object":"chat.completion.chunk","model":"test_model","choices":[{"index":0,"delta":{"content":" dogs"}}]}\n\n'
+                            },
+                        ],
+                    },
+                    # -------------------------------------------
+                ],
+            },
+        ],
+    }
+
+    @patch(
+        "genai_perf.profile_data_parser.profile_data_parser.load_json",
+        return_value=session_profile_data,
+    )
+    @pytest.mark.parametrize(
+        "infer_mode, load_level, expected_session1_metrics, expected_session2_metrics",
+        [
+            (
+                "concurrency",
+                "10",
+                {
+                    "request_latencies": [7, 4],
+                    "request_throughputs": [2 / ns_to_sec(17)],
+                    "time_to_first_tokens": [2, 2],
+                    "time_to_second_tokens": [2, 2],
+                    "inter_token_latencies": [2, 2],
+                    "output_token_throughputs_per_request": [
+                        3 / ns_to_sec(7),
+                        1 / ns_to_sec(2),
+                    ],
+                    "output_token_throughputs": [5 / ns_to_sec(17)],
+                    "output_sequence_lengths": [3, 2],
+                    "input_sequence_lengths": [3, 3],
+                },
+                {
+                    "request_latencies": [8, 4],
+                    "request_throughputs": [2 / ns_to_sec(15)],
+                    "time_to_first_tokens": [2, 2],
+                    "time_to_second_tokens": [3, 1],
+                    "inter_token_latencies": [3, 1],
+                    "output_token_throughputs_per_request": [
+                        3 / ns_to_sec(8),
+                        3 / ns_to_sec(4),
+                    ],
+                    "output_token_throughputs": [6 / ns_to_sec(15)],
+                    "output_sequence_lengths": [3, 3],
+                    "input_sequence_lengths": [4, 4],
+                },
+            ),
+        ],
+    )
+    def test_session_metrics(
+        self,
+        mock_json,
+        infer_mode,
+        load_level,
+        expected_session1_metrics,
+        expected_session2_metrics,
+    ) -> None:
+        """Check if it handles session metrics.
+
+        Metrics
+        * request_latencies
+            - session 1: [8 - 1, 18 - 14] = [7, 4]
+            - session 2: [10 - 2, 17 - 13] = [8, 4]
+        * request_throughputs
+            - session 1: [2/(18 - 1)] = [2/17]
+            - session 2: [2/(17 - 2)] = [2/15]
+        * time to first tokens
+            - session 1: [3 - 1, 16 - 14] = [2, 2]
+            - session 2: [4 - 2, 15 - 13] = [2, 2]
+        * time to second tokens
+            - session 1: [5 - 3, 18 - 16] = [2, 2]
+            - session 2: [7 - 4, 16 - 15] = [3, 1]
+        * inter token latencies
+            - session 1: [((8 - 1) - 2)/(3 - 1), ((18 - 14) - 2)/(2 - 1)]
+                          : [2.5, 2]
+                          : [2, 2]  # rounded
+            - session 2: [((10 - 2) - 2)/(3 - 1), ((17 - 13) - 2)/(3 - 1)]
+                          : [3, 1]
+        * output token throughputs per request
+            - session 1: [3/(8 - 1), 2/(18 - 14)] = [3/7, 1/2]
+            - session 2: [3/(10 - 2), 3/(17 - 13)] = [3/8, 3/4]
+        * output token throughputs
+            - session 1: [(3 + 2)/(18 - 1)] = [5/17]
+            - session 2: [(3 + 3)/(17 - 2)] = [6/15]
+        * output sequence lengths
+            - session 1: [3, 2]
+            - session 2: [3, 3]
+        * input sequence lengths
+            - session 1: [3, 3]
+            - session 2: [4, 4]
+        """
+
+        tokenizer = get_tokenizer(DEFAULT_TOKENIZER)
+        pd = LLMProfileDataParser(
+            filename=Path("session_profile_export.json"),
+            tokenizer=tokenizer,
+        )
+
+        session_metrics = pd._session_metrics
+        assert "session-id-123" in session_metrics
+        assert "session-id-456" in session_metrics
+        assert session_metrics["session-id-123"] == expected_session1_metrics
+        assert session_metrics["session-id-456"] == expected_session2_metrics

--- a/genai-perf/tests/test_exporters/test_json_exporter.py
+++ b/genai-perf/tests/test_exporters/test_json_exporter.py
@@ -312,7 +312,7 @@ class TestJsonExporter:
             artifact_dir=args.artifact_dir,
         )
         json_exporter = JsonExporter(config)
-        assert json_exporter._stats_and_args == json.loads(self.expected_json_output)
+        assert json_exporter._export_data == json.loads(self.expected_json_output)
         json_exporter.export()
         expected_filename = "profile_export_genai_perf.json"
         written_data = [
@@ -501,10 +501,10 @@ class TestJsonExporter:
             artifact_dir=args.artifact_dir,
         )
         json_exporter = JsonExporter(config)
-        assert json_exporter._stats_and_args["request_goodput"] == json.loads(
+        assert json_exporter._export_data["request_goodput"] == json.loads(
             expected_valid_goodput_json_output
         )
-        assert json_exporter._stats_and_args["input_config"]["goodput"] == json.loads(
+        assert json_exporter._export_data["input_config"]["goodput"] == json.loads(
             expected_valid_goodput_json_config
         )
 
@@ -659,11 +659,11 @@ class TestJsonExporter:
             artifact_dir=args.artifact_dir,
         )
         json_exporter = JsonExporter(config)
-        assert json_exporter._stats_and_args["request_goodput"] == json.loads(
+        assert json_exporter._export_data["request_goodput"] == json.loads(
             expected_invalid_goodput_json_output
         )
-        print(json_exporter._stats_and_args["input_config"]["goodput"])
-        assert json_exporter._stats_and_args["input_config"]["goodput"] == json.loads(
+        print(json_exporter._export_data["input_config"]["goodput"])
+        assert json_exporter._export_data["input_config"]["goodput"] == json.loads(
             expected_invalid_goodput_json_config
         )
         json_exporter.export()
@@ -846,7 +846,7 @@ class TestJsonExporter:
             artifact_dir=args.artifact_dir,
         )
         json_exporter = JsonExporter(config)
-        assert json_exporter._stats_and_args["telemetry_stats"] == json.loads(
+        assert json_exporter._export_data["telemetry_stats"] == json.loads(
             expected_telemetry_json_output
         )
 

--- a/genai-perf/tests/test_utils.py
+++ b/genai-perf/tests/test_utils.py
@@ -74,6 +74,7 @@ def create_default_exporter_config(
     extra_inputs: Optional[Dict[str, Any]] = None,
     artifact_dir: Optional[Path] = None,
     telemetry_stats: Dict[str, Any] = {},
+    session_stats: Dict[str, Any] = {},
 ) -> ExporterConfig:
     return ExporterConfig(
         stats=stats or {},
@@ -82,6 +83,7 @@ def create_default_exporter_config(
         extra_inputs=extra_inputs or {},
         artifact_dir=artifact_dir or Path("."),
         telemetry_stats=telemetry_stats,
+        session_stats=session_stats,
     )
 
 


### PR DESCRIPTION
Example exported JSON file with session statistics:
```
{
  "request_throughput": {
    "unit": "requests/sec",
    "avg": 2.2453037464000505
  },
  "request_latency": {
    "unit": "ms",
    "avg": 144.78743075,
    ...
  },
  ...,
  "input_config": {
    ...
  },
  "sessions": {
    "181df3d3-d00d-465f-bdb3-6363547563ea": {
      "request_throughput": {
        "unit": "requests/sec",
        "avg": 1.1226518732000252
      },
      "request_latency": {
        "unit": "ms",
        "avg": 140.6232415,
        ...
      },
      ...
    },
    "c8af0fc8-c266-4052-b8d8-7e7031f65e2d": {
      "request_throughput": {
        "unit": "requests/sec",
        "avg": 1.5406063077538594
      },
      "request_latency": {
        "unit": "ms",
        "avg": 148.95162,
        ...
      },
      ...
    }
  }
}
```