### PR TITLE
Support hash ids, input_length, and output_length for the fixed schedule feature

### DIFF
--- a/genai-perf/genai_perf/inputs/converters/base_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/base_converter.py
@@ -80,15 +80,13 @@ class BaseConverter:
         """
         if "max_tokens" in optional_data:
             return optional_data["max_tokens"]
-        elif config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN:
-            return int(
-                sample_bounded_normal(
-                    mean=config.output_tokens_mean,
-                    stddev=config.output_tokens_stddev,
-                    lower=1,  # output token must be >= 1
-                )
+        return int(
+            sample_bounded_normal(
+                mean=config.output_tokens_mean,
+                stddev=config.output_tokens_stddev,
+                lower=1,  # output token must be >= 1
             )
-        return DEFAULT_OUTPUT_TOKENS_MEAN
+        )
 
     def _add_request_params(
         self,

--- a/genai-perf/genai_perf/inputs/converters/base_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/base_converter.py
@@ -80,13 +80,15 @@ class BaseConverter:
         """
         if "max_tokens" in optional_data:
             return optional_data["max_tokens"]
-        return int(
-            sample_bounded_normal(
-                mean=config.output_tokens_mean,
-                stddev=config.output_tokens_stddev,
-                lower=1,  # output token must be >= 1
+        elif config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN:
+            return int(
+                sample_bounded_normal(
+                    mean=config.output_tokens_mean,
+                    stddev=config.output_tokens_stddev,
+                    lower=1,  # output token must be >= 1
+                )
             )
-        )
+        return DEFAULT_OUTPUT_TOKENS_MEAN
 
     def _add_request_params(
         self,

--- a/genai-perf/genai_perf/inputs/converters/base_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/base_converter.py
@@ -72,11 +72,14 @@ class BaseConverter:
     def _get_max_tokens(
         self, config: InputsConfig, optional_data: Dict[str, Any]
     ) -> int:
-        if (
-            config.output_tokens_mean == DEFAULT_OUTPUT_TOKENS_MEAN
-            and "max_tokens" in optional_data
-        ):
-            return config.max_tokens_list.pop(0)
+        """
+        Return the `max_tokens` value to be added in the payload.
+        If `max_tokens` is present in `optional_data`, that value is used.
+        Otherwise, `max_tokens` is sampled from a bounded normal
+        distribution with a minimum value of 1.
+        """
+        if "max_tokens" in optional_data:
+            return optional_data["max_tokens"]
         elif config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN:
             return int(
                 sample_bounded_normal(

--- a/genai-perf/genai_perf/inputs/converters/base_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/base_converter.py
@@ -70,7 +70,7 @@ class BaseConverter:
             )
 
     def _get_max_tokens(
-        self, config: InputsConfig, optional_data: Dict[str, Any]
+        self, config: InputsConfig, optional_data: Dict[Any, Any]
     ) -> int:
         """
         Return the `max_tokens` value to be added in the payload.
@@ -94,7 +94,7 @@ class BaseConverter:
         self,
         payload: Dict[Any, Any],
         config: InputsConfig,
-        optional_data: Dict[str, Any],
+        optional_data: Dict[Any, Any],
     ) -> None:
         for key, value in config.extra_inputs.items():
             payload[key] = value
@@ -115,7 +115,7 @@ class BaseConverter:
         triton_format=False,
     ) -> Dict[str, Any]:
         self._add_request_params(payload, config, row.optional_data)
-        self._add_payload_params(payload, row.optional_data)
+        self._add_payload_optional_data(payload, row)
         record: Dict[str, Any] = {}
         if not triton_format:
             record["payload"] = [payload]

--- a/genai-perf/genai_perf/inputs/converters/dynamic_grpc_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/dynamic_grpc_converter.py
@@ -53,7 +53,7 @@ class DynamicGRPCConverter(BaseConverter):
         for file_data in generic_dataset.files_data.values():
             for index, row in enumerate(file_data.rows):
                 payload = {"message_generator": row.texts[0]}
-                self._add_request_params(payload, config)
+                self._add_request_params(payload, config, {})
                 request_body["data"].append(payload)
 
         return request_body

--- a/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
@@ -123,7 +123,12 @@ class OpenAIChatCompletionsConverter(BaseConverter):
     def _add_request_params(self, payload: Dict, config: InputsConfig) -> None:
         if config.add_stream:
             payload["stream"] = True
-        if config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN:
+        if (
+            config.output_tokens_mean == DEFAULT_OUTPUT_TOKENS_MEAN
+            and config.max_tokens_list
+        ):
+            payload["max_tokens"] = config.max_tokens_list.pop(0)
+        elif config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN:
             payload["max_tokens"] = int(
                 sample_bounded_normal(
                     mean=config.output_tokens_mean,

--- a/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
@@ -121,7 +121,7 @@ class OpenAIChatCompletionsConverter(BaseConverter):
         return content
 
     def _add_request_params(
-        self, payload: Dict, config: InputsConfig, optional_data: Dict[str, Any]
+        self, payload: Dict, config: InputsConfig, optional_data: Dict[Any, Any]
     ) -> None:
         if config.add_stream:
             payload["stream"] = True

--- a/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
@@ -120,21 +120,13 @@ class OpenAIChatCompletionsConverter(BaseConverter):
             )
         return content
 
-    def _add_request_params(self, payload: Dict, config: InputsConfig) -> None:
+    def _add_request_params(
+        self, payload: Dict, config: InputsConfig, optional_data: Dict[str, Any]
+    ) -> None:
         if config.add_stream:
             payload["stream"] = True
-        if (
-            config.output_tokens_mean == DEFAULT_OUTPUT_TOKENS_MEAN
-            and config.max_tokens_list
-        ):
-            payload["max_tokens"] = config.max_tokens_list.pop(0)
-        elif config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN:
-            payload["max_tokens"] = int(
-                sample_bounded_normal(
-                    mean=config.output_tokens_mean,
-                    stddev=config.output_tokens_stddev,
-                    lower=1,  # output token must be >= 1
-                )
-            )
+        max_tokens = self._get_max_tokens(config, optional_data)
+        if max_tokens != DEFAULT_OUTPUT_TOKENS_MEAN:
+            payload["max_tokens"] = max_tokens
         for key, value in config.extra_inputs.items():
             payload[key] = value

--- a/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
@@ -56,7 +56,7 @@ class OpenAICompletionsConverter(BaseConverter):
         return request_body
 
     def _add_request_params(
-        self, payload: Dict, config: InputsConfig, optional_data: Dict[str, Any]
+        self, payload: Dict, config: InputsConfig, optional_data: Dict[Any, Any]
     ) -> None:
         if config.add_stream:
             payload["stream"] = True

--- a/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
@@ -55,22 +55,13 @@ class OpenAICompletionsConverter(BaseConverter):
 
         return request_body
 
-    def _add_request_params(self, payload: Dict, config: InputsConfig) -> None:
+    def _add_request_params(
+        self, payload: Dict, config: InputsConfig, optional_data: Dict[str, Any]
+    ) -> None:
         if config.add_stream:
             payload["stream"] = True
-        # TODO Should we error out in parser if output token mean is set with the payload input file?
-        if (
-            config.output_tokens_mean == DEFAULT_OUTPUT_TOKENS_MEAN
-            and config.max_tokens_list
-        ):
-            payload["max_tokens"] = config.max_tokens_list.pop(0)
-        elif config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN:
-            payload["max_tokens"] = int(
-                sample_bounded_normal(
-                    mean=config.output_tokens_mean,
-                    stddev=config.output_tokens_stddev,
-                    lower=1,  # output token must be >= 1
-                )
-            )
+        max_tokens = self._get_max_tokens(config, optional_data)
+        if max_tokens != DEFAULT_OUTPUT_TOKENS_MEAN:
+            payload["max_tokens"] = max_tokens
         for key, value in config.extra_inputs.items():
             payload[key] = value

--- a/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py
@@ -58,7 +58,13 @@ class OpenAICompletionsConverter(BaseConverter):
     def _add_request_params(self, payload: Dict, config: InputsConfig) -> None:
         if config.add_stream:
             payload["stream"] = True
-        if config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN:
+        # TODO Should we error out in parser if output token mean is set with the payload input file?
+        if (
+            config.output_tokens_mean == DEFAULT_OUTPUT_TOKENS_MEAN
+            and config.max_tokens_list
+        ):
+            payload["max_tokens"] = config.max_tokens_list.pop(0)
+        elif config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN:
             payload["max_tokens"] = int(
                 sample_bounded_normal(
                     mean=config.output_tokens_mean,

--- a/genai-perf/genai_perf/inputs/converters/rankings_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/rankings_converter.py
@@ -94,7 +94,9 @@ class RankingsConverter(BaseConverter):
             return True
         return False
 
-    def _add_request_params(self, payload: Dict, config: InputsConfig) -> None:
+    def _add_request_params(
+        self, payload: Dict, config: InputsConfig, optional_data: Dict[str, Any]
+    ) -> None:
         for key, value in config.extra_inputs.items():
             if not (key == "rankings" and value == "tei"):
                 payload[key] = value

--- a/genai-perf/genai_perf/inputs/converters/rankings_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/rankings_converter.py
@@ -95,7 +95,7 @@ class RankingsConverter(BaseConverter):
         return False
 
     def _add_request_params(
-        self, payload: Dict, config: InputsConfig, optional_data: Dict[str, Any]
+        self, payload: Dict, config: InputsConfig, optional_data: Dict[Any, Any]
     ) -> None:
         for key, value in config.extra_inputs.items():
             if not (key == "rankings" and value == "tei"):

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
@@ -68,17 +68,13 @@ class TensorRTLLMConverter(BaseConverter):
 
         return request_body
 
-    def _add_request_params(self, payload: Dict, config: InputsConfig) -> None:
+    def _add_request_params(
+        self, payload: Dict, config: InputsConfig, optional_data: Dict[str, Any]
+    ) -> None:
         if config.add_stream:
             payload["stream"] = [True]
-        if config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN:
-            number_of_tokens = int(
-                sample_bounded_normal(
-                    mean=config.output_tokens_mean,
-                    stddev=config.output_tokens_stddev,
-                    lower=1,  # output token must be >= 1
-                )
-            )
+        number_of_tokens = self._get_max_tokens(config, optional_data)
+        if number_of_tokens != DEFAULT_OUTPUT_TOKENS_MEAN:
             if config.output_tokens_deterministic:
                 payload["min_length"] = [number_of_tokens]
             payload["max_tokens"] = [number_of_tokens]

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_converter.py
@@ -69,7 +69,7 @@ class TensorRTLLMConverter(BaseConverter):
         return request_body
 
     def _add_request_params(
-        self, payload: Dict, config: InputsConfig, optional_data: Dict[str, Any]
+        self, payload: Dict, config: InputsConfig, optional_data: Dict[Any, Any]
     ) -> None:
         if config.add_stream:
             payload["stream"] = [True]

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
@@ -68,7 +68,9 @@ class TensorRTLLMEngineConverter(BaseConverter):
 
         return request_body
 
-    def _add_request_params(self, payload: Dict, config: InputsConfig) -> None:
+    def _add_request_params(
+        self, payload: Dict, config: InputsConfig, optional_data: Dict[str, Any]
+    ) -> None:
         if config.add_stream:
             payload["streaming"] = [True]
         if config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN:

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
@@ -69,7 +69,7 @@ class TensorRTLLMEngineConverter(BaseConverter):
         return request_body
 
     def _add_request_params(
-        self, payload: Dict, config: InputsConfig, optional_data: Dict[str, Any]
+        self, payload: Dict, config: InputsConfig, optional_data: Dict[Any, Any]
     ) -> None:
         if config.add_stream:
             payload["streaming"] = [True]

--- a/genai-perf/genai_perf/inputs/converters/triton_generate_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/triton_generate_converter.py
@@ -65,16 +65,13 @@ class TritonGenerateConverter(BaseConverter):
 
         return request_body
 
-    def _add_request_params(self, payload: Dict, config: InputsConfig) -> None:
+    def _add_request_params(
+        self, payload: Dict, config: InputsConfig, optional_data: Dict[str, Any]
+    ) -> None:
         if config.add_stream:
             payload["stream"] = True
-        if config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN:
-            payload["max_tokens"] = int(
-                sample_bounded_normal(
-                    mean=config.output_tokens_mean,
-                    stddev=config.output_tokens_stddev,
-                    lower=1,  # output token must be >= 1
-                )
-            )
+        max_tokens = self._get_max_tokens(config, optional_data)
+        if max_tokens != DEFAULT_OUTPUT_TOKENS_MEAN:
+            payload["max_tokens"] = max_tokens
         for key, value in config.extra_inputs.items():
             payload[key] = value

--- a/genai-perf/genai_perf/inputs/converters/triton_generate_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/triton_generate_converter.py
@@ -66,7 +66,7 @@ class TritonGenerateConverter(BaseConverter):
         return request_body
 
     def _add_request_params(
-        self, payload: Dict, config: InputsConfig, optional_data: Dict[str, Any]
+        self, payload: Dict, config: InputsConfig, optional_data: Dict[Any, Any]
     ) -> None:
         if config.add_stream:
             payload["stream"] = True

--- a/genai-perf/genai_perf/inputs/converters/vllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/vllm_converter.py
@@ -68,7 +68,7 @@ class VLLMConverter(BaseConverter):
         return request_body
 
     def _add_request_params(
-        self, payload: Dict, config: InputsConfig, optional_data: Dict[str, Any]
+        self, payload: Dict, config: InputsConfig, optional_data: Dict[Any, Any]
     ) -> None:
         if config.add_stream:
             payload["stream"] = [True]

--- a/genai-perf/genai_perf/inputs/converters/vllm_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/vllm_converter.py
@@ -67,17 +67,13 @@ class VLLMConverter(BaseConverter):
 
         return request_body
 
-    def _add_request_params(self, payload: Dict, config: InputsConfig) -> None:
+    def _add_request_params(
+        self, payload: Dict, config: InputsConfig, optional_data: Dict[str, Any]
+    ) -> None:
         if config.add_stream:
             payload["stream"] = [True]
-        if config.output_tokens_mean != DEFAULT_OUTPUT_TOKENS_MEAN:
-            number_of_tokens = int(
-                sample_bounded_normal(
-                    mean=config.output_tokens_mean,
-                    stddev=config.output_tokens_stddev,
-                    lower=1,  # output token must be >= 1
-                )
-            )
+        number_of_tokens = self._get_max_tokens(config, optional_data)
+        if number_of_tokens != DEFAULT_OUTPUT_TOKENS_MEAN:
             sampling_parameters = {
                 "max_tokens": f"{number_of_tokens}",
             }

--- a/genai-perf/genai_perf/inputs/inputs_config.py
+++ b/genai-perf/genai_perf/inputs/inputs_config.py
@@ -106,7 +106,6 @@ class InputsConfig:
     # Number of entries to gather
     length: int = DEFAULT_LENGTH
 
-    max_tokens_list: List[int] = field(default_factory=list)
     # The model name
     model_name: List[str] = field(default_factory=list)
 

--- a/genai-perf/genai_perf/inputs/inputs_config.py
+++ b/genai-perf/genai_perf/inputs/inputs_config.py
@@ -106,6 +106,7 @@ class InputsConfig:
     # Number of entries to gather
     length: int = DEFAULT_LENGTH
 
+    max_tokens_list: List[int] = field(default_factory=list)
     # The model name
     model_name: List[str] = field(default_factory=list)
 

--- a/genai-perf/genai_perf/inputs/retrievers/base_file_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/base_file_input_retriever.py
@@ -26,7 +26,7 @@
 
 
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 from genai_perf.inputs.retrievers.base_input_retriever import BaseInputRetriever
 from genai_perf.inputs.retrievers.generic_dataset import (

--- a/genai-perf/genai_perf/inputs/retrievers/base_file_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/base_file_input_retriever.py
@@ -33,8 +33,6 @@ from genai_perf.inputs.retrievers.generic_dataset import (
     FileData,
     GenericDataset,
     ImageData,
-    OptionalData,
-    PayloadMetadata,
     TextData,
 )
 
@@ -61,14 +59,9 @@ class BaseFileInputRetriever(BaseInputRetriever):
         if not filename.exists():
             raise FileNotFoundError(f"The file '{filename}' does not exist.")
 
-    def _get_content_from_input_file(self, filename: Path) -> Union[
-        Tuple[TextData, ImageData],
-        Tuple[
-            TextData,
-            List[OptionalData],
-            List[PayloadMetadata],
-        ],
-    ]:
+    def _get_content_from_input_file(
+        self, filename: Path
+    ) -> Union[Tuple[TextData, ImageData], Dict[str, Any]]:
         """
         Reads the content from a JSONL file and returns lists of each content type.
 

--- a/genai-perf/genai_perf/inputs/retrievers/payload_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/payload_input_retriever.py
@@ -182,6 +182,9 @@ class PayloadInputRetriever(BaseFileInputRetriever):
         }
         excluded_keys.update(PAYLOAD_METADATA_FIELDS)
         optional_data = {k: v for k, v in data.items() if k not in excluded_keys}
+        max_tokens = data.get("output_length")
+        if max_tokens:
+            optional_data["max_tokens"] = max_tokens
 
         return optional_data
 

--- a/genai-perf/genai_perf/inputs/retrievers/payload_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/payload_input_retriever.py
@@ -182,8 +182,6 @@ class PayloadInputRetriever(BaseFileInputRetriever):
         }
         excluded_keys.update(PAYLOAD_METADATA_FIELDS)
         optional_data = {k: v for k, v in data.items() if k not in excluded_keys}
-        if max_tokens is not None:
-            optional_data["max_tokens"] = max_tokens
 
         return optional_data
 

--- a/genai-perf/genai_perf/inputs/retrievers/payload_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/payload_input_retriever.py
@@ -25,7 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.inputs.input_constants import (

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -426,6 +426,12 @@ def _print_warnings(args: argparse.Namespace) -> None:
             "Custom tokenizer code can be executed. "
             "This should only be used with repositories you trust."
         )
+    if args.prompt_source == ic.PromptSource.PAYLOAD and args.output_tokens_mean:
+        logger.warning(
+            "--output-tokens-mean is incompatible with output_length"
+            " in the payload input file. output-tokens-mean"
+            " will be ignored in favour of per payload settings"
+        )
 
 
 def _check_server_metrics_url(

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -426,11 +426,14 @@ def _print_warnings(args: argparse.Namespace) -> None:
             "Custom tokenizer code can be executed. "
             "This should only be used with repositories you trust."
         )
-    if args.prompt_source == ic.PromptSource.PAYLOAD and args.output_tokens_mean:
+    if (
+        args.prompt_source == ic.PromptSource.PAYLOAD
+        and args.output_tokens_mean != ic.DEFAULT_OUTPUT_TOKENS_MEAN
+    ):
         logger.warning(
             "--output-tokens-mean is incompatible with output_length"
             " in the payload input file. output-tokens-mean"
-            " will be ignored in favour of per payload settings"
+            " will be ignored in favour of per payload settings."
         )
 
 

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -1089,7 +1089,11 @@ class TestCLIArguments:
             pytest.fail("Unexpected error in test")
 
     def test_print_warnings_payload(self, monkeypatch, mocker):
-        expected_warning_message = "--output-tokens-mean is incompatible with output_length in the payload input file. output-tokens-mean will be ignored in favour of per payload settings"
+        expected_warning_message = (
+            "--output-tokens-mean is incompatible with output_length"
+            " in the payload input file. output-tokens-mean"
+            " will be ignored in favour of per payload settings."
+        )
 
         args = [
             "genai-perf",

--- a/genai-perf/tests/test_converters/test_triton_generate_converter.py
+++ b/genai-perf/tests/test_converters/test_triton_generate_converter.py
@@ -152,7 +152,7 @@ class TestTritonGenerateConverter:
             return 95
 
         monkeypatch.setattr(
-            "genai_perf.inputs.converters.triton_generate_converter.sample_bounded_normal",
+            "genai_perf.inputs.converters.base_converter.sample_bounded_normal",
             mock_sample_bounded_normal,
         )
 


### PR DESCRIPTION
In this PR,
1. Added support for caching tokens generated using SyntheticPromptGenerator based on hash_ids and input_length provided in the input file.
2. If output_length is also provided, it will be sent as max_tokens.
3. Unit tests updated accordingly.
4. Small cleanup in PayloadInputRetriever. 