### PR TITLE
Compare subcommand changes to work with config file

### DIFF
--- a/genai-perf/genai_perf/config/input/config_analyze.py
+++ b/genai-perf/genai_perf/config/input/config_analyze.py
@@ -34,10 +34,10 @@ class ConfigAnalyze(BaseConfig):
         # yapf: disable
         sweep_parameter_template_comment = \
         (f"Uncomment the lines below to enable the analyze subcommand\n"
-         f"For further details see analyze.md sweep_parameters:\n"
-         f"  concurrency:\n"
-         f"    start: {AnalyzeDefaults.MIN_CONCURRENCY}\n"
-         f"    stop: {AnalyzeDefaults.MAX_CONCURRENCY}")
+         f"#  For further details see analyze.md sweep_parameters:\n"
+         f"concurrency:\n"
+         f"  start: {AnalyzeDefaults.MIN_CONCURRENCY}\n"
+         f"  stop: {AnalyzeDefaults.MAX_CONCURRENCY}")
         # yapf: enable
 
         self.sweep_parameters: Any = ConfigField(

--- a/genai-perf/genai_perf/config/input/config_command.py
+++ b/genai-perf/genai_perf/config/input/config_command.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, List, Optional, Tuple, TypeAlias, Union
 import genai_perf.logging as logging
 from genai_perf.config.input.base_config import BaseConfig
 from genai_perf.config.input.config_analyze import ConfigAnalyze
+from genai_perf.config.input.config_compare import ConfigCompare
 from genai_perf.config.input.config_defaults import (
     AnalyzeDefaults,
     Range,
@@ -67,6 +68,7 @@ class ConfigCommand(BaseConfig):
         self.input = ConfigInput()
         self.output = ConfigOutput()
         self.tokenizer = ConfigTokenizer()
+        self.compare = ConfigCompare()
 
         self._parse_yaml(user_config)
 
@@ -92,6 +94,8 @@ class ConfigCommand(BaseConfig):
                 self.output.parse(value)
             elif key == "tokenizer":
                 self.tokenizer.parse(value)
+            elif key == "compare":
+                self.compare.parse(value)
             else:
                 raise ValueError(
                     f"User Config: {key} is not a valid top-level parameter"
@@ -124,6 +128,7 @@ class ConfigCommand(BaseConfig):
         self._check_output_format_and_generate_plots()
 
         self.endpoint.check_for_illegal_combinations()
+        self.compare.check_for_illegal_combinations()
 
     def _check_output_tokens_and_service_kind(self) -> None:
         if self.endpoint.service_kind not in ["triton", "tensorrtllm_engine"]:

--- a/genai-perf/genai_perf/config/input/config_compare.py
+++ b/genai-perf/genai_perf/config/input/config_compare.py
@@ -1,0 +1,75 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Any, Dict
+
+from genai_perf.config.input.base_config import BaseConfig
+from genai_perf.config.input.config_defaults import CompareDefaults
+from genai_perf.config.input.config_field import ConfigField
+
+
+class ConfigCompare(BaseConfig):
+    """
+    Describes the configuration compare options
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # yapf: disable
+        compare_template_comment = \
+            (f"Uncomment the lines below to enable the compare subcommand\n"
+             f"plot_config:\n"
+             f"files:")
+
+        verbose_compare_template_comment = \
+            (f"Uncomment the lines below to enable the compare subcommand\n"
+             f"#  The path to the YAML file that specifies plot configurations\n"
+             f"#  for comparing multiple runs.\n"
+             f"plot_config:\n"
+             f"#\n"
+             f"#  List of paths to the profile export JSON files.\n"
+             f"#  Users can specify this option instead of `plot_config` if they would like\n"
+             f"#  GenAI-Perf to generate default plots as well as initial YAML config file.\n"
+             f"files:")
+        # yapf: enable
+
+        self.plot_config: Any = ConfigField(
+            default=CompareDefaults.PLOT_CONFIG,
+            add_to_template=False,
+            template_comment=compare_template_comment,
+            verbose_template_comment=verbose_compare_template_comment,
+        )
+        self.files: Any = ConfigField(
+            default=CompareDefaults.FILES,
+            add_to_template=False,
+        )
+
+    def parse(self, output: Dict[str, Any]) -> None:
+        for key, value in output.items():
+            if key == "plot_config":
+                self.plot_config = Path(value)
+            elif key == "files":
+                self.files = value
+            else:
+                raise ValueError(f"User Config: {key} is not a valid compare parameter")
+
+    ###########################################################################
+    # Illegal Combination Methods
+    ###########################################################################
+    def check_for_illegal_combinations(self) -> None:
+        if self.plot_config and self.files:
+            raise ValueError(
+                "User Config: `plot_config` and `files` cannot be set at the same time"
+            )

--- a/genai-perf/genai_perf/config/input/config_defaults.py
+++ b/genai-perf/genai_perf/config/input/config_defaults.py
@@ -140,3 +140,9 @@ class TokenizerDefaults:
 @dataclass(frozen=True)
 class TemplateDefaults:
     FILENAME = "genai_perf_config.yaml"
+
+
+@dataclass(frozen=True)
+class CompareDefaults:
+    PLOT_CONFIG = ""
+    FILES = None

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -1149,6 +1149,11 @@ def add_cli_options_to_config(
     config.tokenizer.revision = args.tokenizer_revision
     config.tokenizer.trust_remote_code = args.tokenizer_trust_remote_code
 
+    # Compare
+    if args.subcommand == "compare":
+        config.compare.plot_config = args.config
+        config.compare.files = args.files
+
     return config
 
 
@@ -1199,6 +1204,11 @@ def parse_args():
         # Set subcommand
         if config.analyze.get_field("sweep_parameters").is_set_by_user:
             config_args = ["analyze"]
+        elif (
+            config.compare.get_field("plot_config").is_set_by_user
+            or config.compare.get_field("files").is_set_by_user
+        ):
+            config_args = ["compare"]
         else:
             config_args = ["profile"]
 

--- a/genai-perf/genai_perf/subcommand/compare.py
+++ b/genai-perf/genai_perf/subcommand/compare.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,23 +27,24 @@ import os
 from argparse import Namespace
 from pathlib import Path
 
+from genai_perf.config.input.config_command import ConfigCommand
 from genai_perf.constants import DEFAULT_COMPARE_DIR
 from genai_perf.plots.plot_config_parser import PlotConfigParser
 from genai_perf.plots.plot_manager import PlotManager
 
 
-def compare_handler(args: Namespace) -> None:
+def compare_handler(config: ConfigCommand) -> None:
     """
     Handles `compare` subcommand workflow
     """
-    if args.files:
+    if config.compare.files:
         _create_compare_dir()
         output_dir = Path(f"{DEFAULT_COMPARE_DIR}")
-        PlotConfigParser.create_init_yaml_config(args.files, output_dir)
-        args.config = output_dir / "config.yaml"
+        PlotConfigParser.create_init_yaml_config(config.compare.files, output_dir)
+        config.compare.plot_config = output_dir / "config.yaml"
 
-    config_parser = PlotConfigParser(args.config)
-    plot_configs = config_parser.generate_configs(args.tokenizer)
+    config_parser = PlotConfigParser(config.compare.plot_config)
+    plot_configs = config_parser.generate_configs(config)
     plot_manager = PlotManager(plot_configs)
     plot_manager.generate_plots()
 

--- a/genai-perf/tests/test_config_command.py
+++ b/genai-perf/tests/test_config_command.py
@@ -535,7 +535,7 @@ class TestConfigCommand(unittest.TestCase):
 
         user_config = yaml.safe_load(yaml_str)
         with self.assertRaises(ValueError):
-            config = ConfigCommand(user_config)
+            ConfigCommand(user_config)
 
 
 if __name__ == "__main__":

--- a/genai-perf/tests/test_config_command.py
+++ b/genai-perf/tests/test_config_command.py
@@ -516,6 +516,27 @@ class TestConfigCommand(unittest.TestCase):
 
         self.assertEqual(config.endpoint.custom, "v1/embeddings")
 
+    ###########################################################################
+    # Test Compare Illegal Combination Methods
+    ###########################################################################
+    def test_compare_illegal_both(self):
+        """
+        Test that the compare raises an error when both plot_config and files are set
+        """
+        # yapf: disable
+        yaml_str = ("""
+            model_name: gpt2
+
+            compare:
+                plot_config: "test_plot_config"
+                files: "test_files"
+            """)
+        # yapf: enable
+
+        user_config = yaml.safe_load(yaml_str)
+        with self.assertRaises(ValueError):
+            config = ConfigCommand(user_config)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/genai-perf/tests/test_exporters/test_json_exporter.py
+++ b/genai-perf/tests/test_exporters/test_json_exporter.py
@@ -134,6 +134,7 @@ class TestJsonExporter:
         "tokenizer",
         "subcommand",
         "verbose",
+        "compare",
     ]
     expected_json_stats = """
       {


### PR DESCRIPTION
Add `compare` to the config file and convert the subcommand's logic to use config instead of argparse.