### PR TITLE
Fix session ID missing from profile export JSON

### DIFF
--- a/src/session_concurrency/payload_dataset_manager.h
+++ b/src/session_concurrency/payload_dataset_manager.h
@@ -28,8 +28,8 @@
 #include <stddef.h>
 
 #include <chrono>
-#include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -47,7 +47,9 @@ class PayloadDatasetManager {
 
   std::vector<std::vector<size_t>> GroupPayloadsBySession() const;
 
-  std::chrono::milliseconds GetDelayForPayload(size_t dataset_index) const;
+  std::string GetSessionID(size_t dataset_index) const;
+
+  std::optional<std::chrono::milliseconds> GetDelay(size_t dataset_index) const;
 
   std::string GetPayload(size_t dataset_index) const;
 
@@ -55,8 +57,6 @@ class PayloadDatasetManager {
   using PayloadsMapType = std::unordered_map<std::string, std::vector<size_t>>;
 
   PayloadsMapType CreateSessionIdToPayloadsMap() const;
-
-  std::string GetSessionID(size_t dataset_index) const;
 
   std::shared_ptr<const DataLoader> data_loader_{};
   const std::shared_ptr<ModelParser> parser_{};

--- a/src/session_concurrency/request_handler.cc
+++ b/src/session_concurrency/request_handler.cc
@@ -28,11 +28,11 @@
 
 #include <rapidjson/allocators.h>
 #include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 #include <stddef.h>
 
+#include <chrono>
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <future>
 #include <memory>
@@ -73,6 +73,10 @@ RequestHandler::SendRequestAndWaitForResponse(
 
   PayloadJsonUtils::UpdateHistoryAndAddToPayload(payload, chat_history);
 
+  auto& request_inputs{request_record.request_inputs_.emplace_back()};
+
+  RecordRequestInputs(payload, dataset_index, request_inputs);
+
   auto response_promise{std::make_shared<std::promise<void>>()};
   std::future<void> response_future{response_promise->get_future()};
 
@@ -80,6 +84,52 @@ RequestHandler::SendRequestAndWaitForResponse(
       payload, std::move(response_promise), chat_history, request_record);
 
   WaitForResponse(std::move(response_future));
+}
+
+void
+RequestHandler::RecordRequestInputs(
+    const std::string& payload, size_t dataset_index,
+    RequestRecord::RequestInput& request_inputs) const
+{
+  RecordPayloadInput(payload, request_inputs);
+
+  const auto session_id{payload_dataset_manager_->GetSessionID(dataset_index)};
+  RecordSessionIDInput(session_id, request_inputs);
+
+  const auto delay{payload_dataset_manager_->GetDelay(dataset_index)};
+  if (delay) {
+    RecordDelayInput(*delay, request_inputs);
+  }
+}
+
+void
+RequestHandler::RecordPayloadInput(
+    const std::string& payload,
+    RequestRecord::RequestInput& request_inputs) const
+{
+  std::vector<uint8_t> payload_buf(payload.begin(), payload.end());
+  request_inputs.emplace("payload", RecordData(std::move(payload_buf), "JSON"));
+}
+
+void
+RequestHandler::RecordSessionIDInput(
+    const std::string& session_id,
+    RequestRecord::RequestInput& request_inputs) const
+{
+  std::vector<uint8_t> session_id_buf(session_id.begin(), session_id.end());
+  request_inputs.emplace(
+      "session_id", RecordData(std::move(session_id_buf), "BYTES"));
+}
+
+void
+RequestHandler::RecordDelayInput(
+    const std::chrono::milliseconds delay,
+    RequestRecord::RequestInput& request_inputs) const
+{
+  const uint64_t delay_ms{static_cast<uint64_t>(delay.count())};
+  std::vector<uint8_t> delay_buf(sizeof(uint64_t));
+  std::memcpy(delay_buf.data(), &delay_ms, sizeof(uint64_t));
+  request_inputs.emplace("delay", RecordData(std::move(delay_buf), "UINT64"));
 }
 
 void
@@ -98,7 +148,7 @@ RequestHandler::SendRequest(
 
   const auto inputs{PrepareInputs(payload)};
 
-  RecordRequest(inputs, request_record);
+  request_record.start_time_ = std::chrono::system_clock::now();
 
   const auto error{client_backend_->AsyncInfer(
       callback, options, inputs, requested_outputs)};
@@ -170,9 +220,7 @@ RequestHandler::RecordResponse(
 
   request_record.response_timestamps_.push_back(end_time);
 
-  request_record.response_outputs_.emplace_back();
-
-  auto& response_outputs{request_record.response_outputs_.back()};
+  auto& response_outputs{request_record.response_outputs_.emplace_back()};
 
   RecordResponseOutputs(infer_result, requested_outputs, response_outputs);
 }
@@ -237,38 +285,6 @@ RequestHandler::PrepareInputs(const std::string& payload) const
   }
 
   return {infer_input};
-}
-
-void
-RequestHandler::RecordRequest(
-    const std::vector<cb::InferInput*> inputs,
-    RequestRecord& request_record) const
-{
-  request_record.request_inputs_.emplace_back();
-
-  auto& request_inputs{request_record.request_inputs_.back()};
-
-  RecordRequestInputs(inputs, request_inputs);
-
-  request_record.start_time_ = std::chrono::system_clock::now();
-}
-
-void
-RequestHandler::RecordRequestInputs(
-    const std::vector<cb::InferInput*> inputs,
-    RequestRecord::RequestInput& request_inputs) const
-{
-  for (const auto& input : inputs) {
-    std::string data_type{input->Datatype()};
-    const uint8_t* buf{nullptr};
-    size_t byte_size{0};
-    input->RawData(&buf, &byte_size);
-
-    std::vector<uint8_t> buf_vec(buf, buf + byte_size);
-
-    request_inputs.emplace(
-        input->Name(), RecordData(std::move(buf_vec), data_type));
-  }
 }
 
 void

--- a/src/session_concurrency/request_handler.h
+++ b/src/session_concurrency/request_handler.h
@@ -28,6 +28,7 @@
 #include <rapidjson/document.h>
 #include <stddef.h>
 
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <future>
@@ -54,6 +55,22 @@ class RequestHandler {
       RequestRecord& request_record);
 
  private:
+  void RecordRequestInputs(
+      const std::string& payload, size_t dataset_index,
+      RequestRecord::RequestInput& request_inputs) const;
+
+  void RecordPayloadInput(
+      const std::string& payload,
+      RequestRecord::RequestInput& request_inputs) const;
+
+  void RecordSessionIDInput(
+      const std::string& session_id,
+      RequestRecord::RequestInput& request_inputs) const;
+
+  void RecordDelayInput(
+      const std::chrono::milliseconds delay,
+      RequestRecord::RequestInput& request_inputs) const;
+
   void SendRequest(
       const std::string& payload,
       std::shared_ptr<std::promise<void>>&& response_promise,
@@ -82,14 +99,6 @@ class RequestHandler {
 
   const std::vector<cb::InferInput*> PrepareInputs(
       const std::string& payload) const;
-
-  void RecordRequest(
-      const std::vector<cb::InferInput*> inputs,
-      RequestRecord& request_record) const;
-
-  void RecordRequestInputs(
-      const std::vector<cb::InferInput*> inputs,
-      RequestRecord::RequestInput& request_inputs) const;
 
   void WaitForResponse(std::future<void>&& response_future) const;
 

--- a/src/session_concurrency/session_concurrency_manager.h
+++ b/src/session_concurrency/session_concurrency_manager.h
@@ -69,7 +69,7 @@ class SessionConcurrencyManager : public LoadManager {
       const std::vector<size_t>& session_payloads,
       std::vector<RequestRecord>& request_records);
 
-  void GetAndWaitForDelayMs(size_t dataset_index) const;
+  void GetAndWaitForDelay(size_t dataset_index) const;
 
   std::vector<RequestRecord> GetRequestRecords() const;
 


### PR DESCRIPTION
This is to enable a new PR that will restore the intended functionality of [Add per-session metrics to the resulting JSON file #289](https://github.com/triton-inference-server/perf_analyzer/pull/289).

Before this PR, session ID was missing from the profile export JSON:

```json
{
  "experiments": [
    {
      "experiment": {
        "mode": "request_rate",
        "value": 0.0
      },
      "requests": [
        {
          "timestamp": 0,
          "request_inputs": {
            "payload": "my_request_body_1"
          },
          "response_timestamps": [
            1
          ],
          "response_outputs": [
            {
              "response": "my_response_body_1"
            }
          ]
        },
        {
          "timestamp": 2,
          "request_inputs": {
            "payload": "my_request_body_2"
          },
          "response_timestamps": [
            3
          ],
          "response_outputs": [
            {
              "response": "my_response_body_2"
            }
          ]
        }
      ],
      "window_boundaries": [
        0,
        18446744073709551615
      ]
    }
  ],
  "version": "0.0.0",
  "service_kind": "openai",
  "endpoint": "v1/chat/completions"
}
```

After this PR, session ID is included as an input next to the `payload` input in the profile export JSON:

```json
{
  "experiments": [
    {
      "experiment": {
        "mode": "request_rate",
        "value": 0.0
      },
      "requests": [
        {
          "timestamp": 0,
          "request_inputs": {
            "delay": 1,
            "session_id": "my_session_id",
            "payload": "my_request_body_1"
          },
          "response_timestamps": [
            1
          ],
          "response_outputs": [
            {
              "response": "my_response_body_1"
            }
          ]
        },
        {
          "timestamp": 2,
          "request_inputs": {
            "session_id": "my_session_id",
            "payload": "my_request_body_2"
          },
          "response_timestamps": [
            3
          ],
          "response_outputs": [
            {
              "response": "my_response_body_2"
            }
          ]
        }
      ],
      "window_boundaries": [
        0,
        18446744073709551615
      ]
    }
  ],
  "version": "0.0.0",
  "service_kind": "openai",
  "endpoint": "v1/chat/completions"
}
```