### PR TITLE
Enable generating empty prompts

### DIFF
--- a/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
+++ b/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
@@ -61,7 +61,7 @@ class SyntheticPromptGenerator:
             )
 
         num_prompt_tokens = max(
-            1, int(random.gauss(prompt_tokens_mean, prompt_tokens_stddev))
+            0, int(random.gauss(prompt_tokens_mean, prompt_tokens_stddev))
         )
 
         return cls._generate_prompt(tokenizer, num_prompt_tokens)


### PR DESCRIPTION
When the genai-perf is called with such arguments:
```bash
genai-perf profile \
    --endpoint-type vision \
    --synthetic-input-tokens-mean 0 \
    --synthetic-input-tokens-stddev 0 \
    --image-width-mean 2048 \
    --image-width-stddev 0 \
    --image-height-mean 1648 \
    --image-height-stddev 0 \
    --image-format png \
    ...
```
The genai-perf still produces 1-token prompts.
This MR fixes this issue.