### PR TITLE
Fix hash blocks generation for the payload retriever

### DIFF
--- a/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
+++ b/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
@@ -183,9 +183,9 @@ class SyntheticPromptGenerator:
                 prompt_tokens.pop(-1)
                 prompt_tokens.insert(0, tokenizer.bos_token_id())
                 cls._cache[hash_index] = prompt_tokens
-            if num_tokens < 0:
+            if num_tokens <= 0:
                 raise ValueError(
-                    "Internal error: number of tokens cannot be " "negative."
+                    "Internal error: number of tokens should never be negative."
                 )
 
             if num_tokens > 0:

--- a/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
+++ b/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
@@ -183,7 +183,7 @@ class SyntheticPromptGenerator:
                 prompt_tokens.pop(-1)
                 prompt_tokens.insert(0, tokenizer.bos_token_id())
                 cls._cache[hash_index] = prompt_tokens
-            if num_tokens <= 0:
+            if num_tokens < 0:
                 raise ValueError(
                     "Internal error: number of tokens should never be negative."
                 )


### PR DESCRIPTION
Previously, when using the payload retriever, the hash blocks would generate full blocks for every hash ID. On the last one, it would check the number of tokens left. This could lead to some hash blocks being less than the block size. It could lead to issues like this:

![image](https://github.com/user-attachments/assets/d88943e8-734e-4ffb-be7b-e92e282c2875)

This PR changes the code to generate a full hash block for every hash ID. If there are still more tokens to get, then get that number of tokens from the hash block.

After changes:
![image](https://github.com/user-attachments/assets/621acd48-7f02-4f50-906f-ef0b4b202256)
