### PR TITLE
Remove frequency of whitespace in corpus

### DIFF
--- a/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
+++ b/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
@@ -82,7 +82,9 @@ class SyntheticPromptGenerator:
             lines = f.readlines()
 
         def tokenize_chunk(chunk):
-            return tokenizer.encode(" ".join(chunk))
+            cleaned_text = " ".join(line.strip() for line in chunk if line.strip())
+            tokens = tokenizer.encode(cleaned_text)
+            return tokens
 
         num_threads = os.cpu_count()
         if num_threads is None:


### PR DESCRIPTION
Remove the frequency of whitespace in corpus to be more representative of real text, since the corpus has a lot of empty space in the source material.

_5% reduction in corpus size_
Corpus size before change: 1471586 tokens
Corpus size after change:    1401275 tokens

_No change in runtime_
Runtime before change:
```
real    0m3.353s
user    0m12.496s
sys     0m3.665s
```
Runtime after change:
```
real    0m3.479s
user    0m10.487s
sys     0m3.668s
```
