### PR TITLE
Improve input sequence length accuracy for hash ID blocks

### DIFF
--- a/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
+++ b/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
@@ -188,9 +188,7 @@ class SyntheticPromptGenerator:
                 prompt_tokens.insert(0, tokenizer.bos_token_id())
                 cls._cache[hash_index] = prompt_tokens
             final_prompt.extend(cls._cache[hash_index])
-        prompt = tokenizer.decode(
-            final_prompt, skip_special_tokens=False, clean_up_tokenization_spaces=False
-        )
+        prompt = tokenizer.decode(final_prompt, skip_special_tokens=False)
 
         return prompt
 

--- a/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
+++ b/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
@@ -180,15 +180,9 @@ class SyntheticPromptGenerator:
             if index == len(prompt_hash_list) - 1:
                 size_to_use = num_tokens - (index * block_size)
             if hash_index not in cls._cache:
-                # To ensure that the prompt doesn't merge chunks, we pop the last token
-                # and insert the bos token at the beginning. Length is maintained and
-                # the prompt generates the expected number of tokens.
-                prompt_tokens = cls._generate_prompt_tokens(size_to_use)
-                prompt_tokens.pop(-1)
-                prompt_tokens.insert(0, tokenizer.bos_token_id())
-                cls._cache[hash_index] = prompt_tokens
+                cls._cache[hash_index] = cls._generate_prompt_tokens(size_to_use)
             final_prompt.extend(cls._cache[hash_index])
-        prompt = tokenizer.decode(final_prompt, skip_special_tokens=False)
+        prompt = tokenizer.decode(final_prompt, clean_up_tokenization_spaces=False)
 
         return prompt
 

--- a/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
+++ b/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
@@ -180,7 +180,13 @@ class SyntheticPromptGenerator:
             if index == len(prompt_hash_list) - 1:
                 size_to_use = num_tokens - (index * block_size)
             if hash_index not in cls._cache:
-                cls._cache[hash_index] = cls._generate_prompt_tokens(size_to_use)
+                # To ensure that the prompt doesn't merge chunks, we pop the last token
+                # and insert the bos token at the beginning. Length is maintained and
+                # the prompt generates the expected number of tokens.
+                prompt_tokens = cls._generate_prompt_tokens(size_to_use)
+                prompt_tokens.pop(0)
+                prompt_tokens.insert(0, tokenizer.bos_token_id())
+                cls._cache[hash_index] = prompt_tokens
             final_prompt.extend(cls._cache[hash_index])
         prompt = tokenizer.decode(final_prompt, clean_up_tokenization_spaces=False)
 

--- a/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
+++ b/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
@@ -188,7 +188,9 @@ class SyntheticPromptGenerator:
                 prompt_tokens.insert(0, tokenizer.bos_token_id())
                 cls._cache[hash_index] = prompt_tokens
             final_prompt.extend(cls._cache[hash_index])
-        prompt = tokenizer.decode(final_prompt, clean_up_tokenization_spaces=False)
+        prompt = tokenizer.decode(
+            final_prompt, skip_special_tokens=False, clean_up_tokenization_spaces=False
+        )
 
         return prompt
 


### PR DESCRIPTION
Filter corpus to include only alphanumeric characters with one space between words. In testing against a large dataset, this proved to work for combining hash ID blocks in the synthetic prompt retriever.

This keeps our corpus as representative as possible without resulting in unexpected token counts when concatenating texts (allowing punctuation or other characters still results in token counts being off).