### PR TITLE
Add process-export-files subcommand in GAP

### DIFF
--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -41,6 +41,7 @@ from genai_perf.inputs import input_constants as ic
 from genai_perf.inputs.retrievers.synthetic_image_generator import ImageFormat
 from genai_perf.subcommand.analyze import analyze_handler
 from genai_perf.subcommand.compare import compare_handler
+from genai_perf.subcommand.process_export_files import process_export_files_handler
 from genai_perf.subcommand.profile import profile_handler
 from genai_perf.tokenizer import DEFAULT_TOKENIZER, DEFAULT_TOKENIZER_REVISION
 
@@ -59,9 +60,13 @@ class Subcommand(Enum):
     PROFILE = auto()
     COMPARE = auto()
     ANALYZE = auto()
+    PROCESS_EXPORT_FILES = auto()
 
     def to_lowercase(self):
         return self.name.lower()
+
+    def to_cli_format(self):
+        return self.to_lowercase().replace("_", "-")
 
 
 logger = logging.getLogger(__name__)
@@ -1192,6 +1197,15 @@ def _parse_analyze_args(subparsers) -> argparse.ArgumentParser:
     return analyze
 
 
+def _parse_process_export_files_args(subparsers) -> argparse.ArgumentParser:
+    process_export_files = subparsers.add_parser(
+        Subcommand.PROCESS_EXPORT_FILES.to_cli_format(),
+        description="Subcommand to process export files and aggregate the results.",
+    )
+    process_export_files.set_defaults(func=process_export_files_handler)
+    return process_export_files
+
+
 ### Parser Initialization ###
 
 
@@ -1215,6 +1229,7 @@ def init_parsers():
     _ = _parse_compare_args(subparsers)
     _ = _parse_profile_args(subparsers)
     _ = _parse_analyze_args(subparsers)
+    _ = _parse_process_export_files_args(subparsers)
     subparsers.required = True
 
     return parser
@@ -1257,6 +1272,8 @@ def refine_args(
         _print_warnings(args)
     elif args.subcommand == Subcommand.COMPARE.to_lowercase():
         args = _check_compare_args(parser, args)
+    elif args.subcommand == Subcommand.PROCESS_EXPORT_FILES.to_cli_format():
+        pass
     else:
         raise ValueError(f"Unknown subcommand: {args.subcommand}")
 

--- a/genai-perf/genai_perf/subcommand/process_export_files.py
+++ b/genai-perf/genai_perf/subcommand/process_export_files.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -25,39 +24,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
-import sys
-import traceback
+from argparse import Namespace
 
-import genai_perf.logging as logging
-from genai_perf import parser
+from genai_perf.exceptions import GenAIPerfException
 
 
-# Separate function that can raise exceptions used for testing
-# to assert correct errors and messages.
-def run():
-    # TMA-1900: refactor CLI handler
-    logging.init_logging()
-    args, extra_args = parser.parse_args()
-    if args.subcommand in ["compare", "analyze", "process-export-files"]:
-        args.func(args)
-    else:  # profile
-        args.func(args, extra_args)
-
-
-def main():
-    # Interactive use will catch exceptions and log formatted errors rather than
-    # tracebacks.
-    try:
-        run()
-    except Exception as e:
-        traceback.print_exc()
-        logger = logging.getLogger(__name__)
-        logger.error(e)
-        return 1
-
-    return 0
-
-
-if __name__ == "__main__":
-    sys.exit(main())
+def process_export_files_handler(args: Namespace) -> None:
+    """
+    Handles `process-export-files` subcommand workflow
+    """
+    raise GenAIPerfException("Not implemented yet")


### PR DESCRIPTION
- Adds a new subcommand `process-export-files`
- Raises a "Not implemented yet" exception.

![image](https://github.com/user-attachments/assets/14cc44e6-d1ba-4af6-9796-7b0c31788444)
