### PR TITLE
Initiate logger in TestConsoleExporter::test_missing_data

### DIFF
--- a/genai-perf/tests/test_exporters/test_console_exporter.py
+++ b/genai-perf/tests/test_exporters/test_console_exporter.py
@@ -27,7 +27,7 @@
 from unittest.mock import patch
 
 import pytest
-from genai_perf import parser
+from genai_perf import logging, parser
 from genai_perf.config.input.config_command import ConfigCommand
 from genai_perf.export_data.console_exporter import ConsoleExporter
 from genai_perf.metrics import (
@@ -525,6 +525,7 @@ class TestConsoleExporter:
         assert expected_content in returned_data
 
     def test_missing_data(self, monkeypatch, capsys) -> None:
+        logging.init_logging()
         argv = [
             "genai-perf",
             "profile",


### PR DESCRIPTION
Since the logger isn't initialized in the below sub-test, the errors are not logged correctly for the unit test to pick them up unless the test is run after other test, breaking independence of tests. Add logger initialization so that the test passes.

Before (failure):
![image](https://github.com/user-attachments/assets/dec37e4c-4392-42b6-ae69-a7d3a9dae486)

After (success):
![image](https://github.com/user-attachments/assets/fbfe2d82-2f85-456b-b725-58ba940ce3ac)
