### PR TITLE
Fixing Compare Subcommand Parsing

### DIFF
--- a/genai-perf/genai_perf/main.py
+++ b/genai-perf/genai_perf/main.py
@@ -41,8 +41,9 @@ def run():
     # TMA-1900: refactor CLI handler
     logging.init_logging()
     args, config, extra_args = parser.parse_args()
-    if config.subcommand == Subcommand.COMPARE.value:
-        args.func(config)
+    # Compare subcommand is deprecated and does not support config file
+    if args.subcommand == Subcommand.COMPARE.value:
+        args.func(args)
     elif config.subcommand == Subcommand.ANALYZE.value:
         args.func(config, extra_args)
     elif config.subcommand == Subcommand.TEMPLATE.value:

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -1445,6 +1445,9 @@ def parse_args():
             config = _create_template_config(args, argv)
 
             return args, config, None
+        elif args.subcommand == Subcommand.COMPARE.value:
+            # this subcommand is deprecated and is not supported in the config file
+            return args, None, argv[passthrough_index + 1 :]
         else:
             # For all other subcommands, parse the CLI fully (no config file)
             config = ConfigCommand({"model_name": args.formatted_model_name})


### PR DESCRIPTION
This fixes the bug I introduced into the compare subcommand with the config file support work.

The issue is that the compare subcommand is not supported via the config and therefore I should not have changed the top-level parsing in main to use the config file when doing a compare action.

This could have been caught if we had any L0 testing using the compare subcommand.