### PR TITLE
Consolidate CLI and Config Checking & Inferencing

### DIFF
--- a/genai-perf/genai_perf/config/input/config_command.py
+++ b/genai-perf/genai_perf/config/input/config_command.py
@@ -54,7 +54,7 @@ class ConfigCommand(BaseConfig):
     def __init__(
         self,
         user_config: Optional[Dict[str, Any]] = None,
-        create_template: bool = False,
+        skip_inferencing_and_checking: bool = False,
     ):
         super().__init__()
 
@@ -72,7 +72,7 @@ class ConfigCommand(BaseConfig):
         self.output = ConfigOutput()
         self.tokenizer = ConfigTokenizer()
 
-        self._parse_yaml(user_config, create_template)
+        self._parse_yaml(user_config, skip_inferencing_and_checking)
 
     ###########################################################################
     # Top-Level Parsing Methods
@@ -88,7 +88,7 @@ class ConfigCommand(BaseConfig):
     def _parse_yaml(
         self,
         user_config: Optional[Dict[str, Any]] = None,
-        create_template: bool = False,
+        skip_inferencing_and_checking: bool = False,
     ) -> None:
         if user_config:
             for key, value in user_config.items():
@@ -111,7 +111,7 @@ class ConfigCommand(BaseConfig):
                         f"User Config: {key} is not a valid top-level parameter"
                     )
 
-        if not create_template:
+        if not skip_inferencing_and_checking:
             self.infer_and_check_options()
 
     def _parse_model_names(self, model_names: Any) -> None:
@@ -143,6 +143,7 @@ class ConfigCommand(BaseConfig):
         self._check_payload_input()
 
         self.endpoint.check_for_illegal_combinations()
+        self.input.check_for_illegal_combinations()
 
     def _check_output_tokens_and_service_kind(self) -> None:
         if self.endpoint.service_kind not in ["triton", "tensorrtllm_engine"]:
@@ -160,7 +161,7 @@ class ConfigCommand(BaseConfig):
         ]:
             if self.output.generate_plots:
                 raise ValueError(
-                    "User Config: generate_plots is not supported with the {self.endpoint.output_format} output format"
+                    f"User Config: generate_plots is not supported with the {self.endpoint.output_format} output format"
                 )
 
     def _check_payload_input(self) -> None:

--- a/genai-perf/genai_perf/config/input/config_command.py
+++ b/genai-perf/genai_perf/config/input/config_command.py
@@ -169,9 +169,11 @@ class ConfigCommand(BaseConfig):
             return
 
         if self.perf_analyzer.get_field("stimulus").is_set_by_user:
-            raise ValueError(
-                f"User Config: perf_analyzer.stimulus is not supported with the payload input source."
-            )
+            for key in self.perf_analyzer.stimulus.keys():
+                if key in ["concurrency", "request_rate"]:
+                    raise ValueError(
+                        f"User Config: perf_analyzer.stimulus: {key} is not supported with the payload input source."
+                    )
 
         if self.perf_analyzer.get_field("warmup_request_count").is_set_by_user:
             raise ValueError(

--- a/genai-perf/genai_perf/config/input/config_endpoint.py
+++ b/genai-perf/genai_perf/config/input/config_endpoint.py
@@ -205,11 +205,13 @@ class ConfigEndPoint(BaseConfig):
                 "User Config: type must be set when service_kind is 'openai'"
             )
 
-        if self.service_kind == "triton" and not self.type:
-            self.type = "kserve"
-
-        if self.service_kind == "tensorrtllm_engine" and not self.type:
-            self.type = "tensorrtllm_engine"
+        if not self.type:
+            if self.service_kind == "triton":
+                self.type = "kserve"
+            elif self.service_kind == "tensorrtllm_engine":
+                self.type = "tensorrtllm_engine"
+            elif self.service_kind == "dynamic_grpc":
+                self.type = "dynamic_grpc"
 
         self._check_inferred_type()
         self.infer_service_kind(model_name)

--- a/genai-perf/genai_perf/config/input/config_field.py
+++ b/genai-perf/genai_perf/config/input/config_field.py
@@ -83,12 +83,12 @@ class ConfigField:
             if self.bounds and "upper" in self.bounds:
                 if self.bounds["upper"] < item:
                     raise ValueError(
-                        f"User Config: {item} exceeds upper bounds (f{self.bounds})"
+                        f"User Config: {item} exceeds upper bounds ({self.bounds})"
                     )
             if self.bounds and "lower" in self.bounds:
                 if self.bounds["lower"] > item:
                     raise ValueError(
-                        f"User Config: {item} exceeds lower bounds (f{self.bounds})"
+                        f"User Config: {item} exceeds lower bounds ({self.bounds})"
                     )
         else:
             if self.bounds:

--- a/genai-perf/genai_perf/config/input/config_field.py
+++ b/genai-perf/genai_perf/config/input/config_field.py
@@ -51,9 +51,7 @@ class ConfigField:
         self._set_bounds(bounds)
         self.choices = choices
         self.is_set_by_user = False
-
-        if value is not None:
-            self.value = value
+        self.value = value
 
     def _set_bounds(self, bounds: Optional[Dict[str, Any]] = None) -> None:
         if not bounds:
@@ -114,7 +112,7 @@ class ConfigField:
             for value in value_list:
                 if not isinstance(value, Enum):
                     raise ValueError(
-                        f"User Config: {value} is not an Enum: f{self.choices}"
+                        f"User Config: {value} is not in list of choices: f{self.choices}"
                     )
                 if value.name not in [e.name for e in self.choices]:
                     raise ValueError(

--- a/genai-perf/genai_perf/config/input/config_field.py
+++ b/genai-perf/genai_perf/config/input/config_field.py
@@ -48,25 +48,53 @@ class ConfigField:
         self.add_to_template = add_to_template
         self.template_comment = template_comment
         self.verbose_template_comment = verbose_template_comment
-        self.bounds = bounds
+        self._set_bounds(bounds)
         self.choices = choices
         self.is_set_by_user = False
 
         if value is not None:
             self.value = value
 
-    def _check_bounds(self) -> None:
-        if isinstance(self.value, (int, float)):
-            if self.bounds and "upper" in self.bounds:
-                if self.bounds["upper"] < self.value:
+    def _set_bounds(self, bounds: Optional[Dict[str, Any]] = None) -> None:
+        if not bounds:
+            self.bounds = None
+        else:
+            self.bounds = {}
+            for key, value in bounds.items():
+                if key not in ["upper", "max", "lower", "min"]:
                     raise ValueError(
-                        f"User Config: {self.value} exceeds upper bounds (f{self.bounds})"
+                        f"User Config: {key} is not a valid key for bounds. "
+                        f"Valid keys are 'upper', 'max, 'lower', or 'min'."
+                    )
+                if key in ["upper", "max"]:
+                    self.bounds["upper"] = value
+                elif key in ["lower", "min"]:
+                    self.bounds["lower"] = value
+
+    def _check_bounds(self) -> None:
+        if isinstance(self.value, list):
+            for item in self.value:
+                self._check_item_bounds(item)
+        else:
+            self._check_item_bounds(self.value)
+
+    def _check_item_bounds(self, item: Any) -> None:
+        if isinstance(item, (int, float)):
+            if self.bounds and "upper" in self.bounds:
+                if self.bounds["upper"] < item:
+                    raise ValueError(
+                        f"User Config: {item} exceeds upper bounds (f{self.bounds})"
                     )
             if self.bounds and "lower" in self.bounds:
-                if self.bounds["lower"] > self.value:
+                if self.bounds["lower"] > item:
                     raise ValueError(
-                        f"User Config: {self.value} exceeds lower bounds (f{self.bounds})"
+                        f"User Config: {item} exceeds lower bounds (f{self.bounds})"
                     )
+        else:
+            if self.bounds:
+                raise ValueError(
+                    f"User Config: {item} is not a valid type for bounds checking (int/float)"
+                )
 
     def _check_choices(self) -> None:
         if not self.choices or not self.value:

--- a/genai-perf/genai_perf/config/input/config_input.py
+++ b/genai-perf/genai_perf/config/input/config_input.py
@@ -80,6 +80,7 @@ class ConfigInput(BaseConfig):
         )
         self.num_dataset_entries: Any = ConfigField(
             default=InputDefaults.NUM_DATASET_ENTRIES,
+            bounds={"min": 1},
             verbose_template_comment="The number of unique payloads to sample from.\
                 \nThese will be reused until benchmarking is complete.",
         )
@@ -161,6 +162,12 @@ class ConfigInput(BaseConfig):
                 raise ValueError(f"'{value}' is not a valid file or directory")
 
     ###########################################################################
+    # Illegal Combination Methods
+    ###########################################################################
+    def check_for_illegal_combinations(self) -> None:
+        self.output_tokens._check_output_tokens()
+
+    ###########################################################################
     # Infer Methods
     ###########################################################################
     def infer_settings(self) -> None:
@@ -231,10 +238,12 @@ class ConfigAudio(BaseConfig):
         )
         self.depths: Any = ConfigField(
             default=AudioDefaults.DEPTHS,
+            bounds={"min": 1},
             verbose_template_comment="A list of audio bit depths to randomly select from in bits.",
         )
         self.sample_rates: Any = ConfigField(
             default=AudioDefaults.SAMPLE_RATES,
+            bounds={"min": 1},
             verbose_template_comment="A list of audio sample rates to randomly select from in kHz.",
         )
         self.num_channels: Any = ConfigField(
@@ -438,21 +447,21 @@ class ConfigOutputTokens(BaseConfig):
                     f"User Config: {key} is not a valid output_tokens parameter"
                 )
 
-        self._check_output_tokens()
-
     def _check_output_tokens(self) -> None:
         if (
             self.get_field("stddev").is_set_by_user
             and not self.get_field("mean").is_set_by_user
         ):
-            raise ValueError("User Config: If stddev is set, mean must also be set")
+            raise ValueError(
+                "User Config: If output tokens stddev is set, mean must also be set"
+            )
 
         if (
             self.get_field("deterministic").is_set_by_user
             and not self.get_field("mean").is_set_by_user
         ):
             raise ValueError(
-                "User Config: If deterministic is set, mean must also be set"
+                "User Config: If output tokens deterministic is set, mean must also be set"
             )
 
 

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -989,6 +989,7 @@ class TestCLIArguments:
         with pytest.raises(ValueError) as execinfo:
             parser.parse_args()
 
+        captured = capsys.readouterr()
         assert expected_error_message == execinfo.value.args[0]
 
     @pytest.mark.parametrize(

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -1197,11 +1197,11 @@ class TestCLIArguments:
         [
             (
                 ["--concurrency", "10"],
-                "User Config: perf_analyzer.stimulus is not supported with the payload input source.",
+                "User Config: perf_analyzer.stimulus: concurrency is not supported with the payload input source.",
             ),
             (
                 ["--request-rate", "5"],
-                "User Config: perf_analyzer.stimulus is not supported with the payload input source.",
+                "User Config: perf_analyzer.stimulus: request_rate is not supported with the payload input source.",
             ),
             (
                 ["--request-count", "3"],

--- a/genai-perf/tests/test_config_field.py
+++ b/genai-perf/tests/test_config_field.py
@@ -1,0 +1,247 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+
+import pytest
+from genai_perf.config.input.config_field import ConfigField
+
+
+def test_config_field_initialization():
+    """
+    Test the initialization of the ConfigField class.
+    This test verifies that the ConfigField object is correctly initialized with the
+    provided parameters and that its attributes have the expected default values.
+    Assertions:
+    - The `default` attribute is set to the provided value.
+    - The `required` attribute is set to the provided value.
+    - The `add_to_template` attribute is set to the provided value.
+    - The `template_comment` attribute is set to the provided value.
+    - The `value` attribute is None by default.
+    - The `bounds` attribute is None by default.
+    - The `choices` attribute is None by default.
+    - The `is_set_by_user` attribute is False by default.
+    """
+
+    field = ConfigField(
+        default=10,
+        required=True,
+        add_to_template=False,
+        template_comment="Test comment",
+    )
+    assert field.default == 10
+    assert field.required is True
+    assert field.add_to_template is False
+    assert field.template_comment == "Test comment"
+    assert field.value is None
+    assert field.bounds is None
+    assert field.choices is None
+    assert field.is_set_by_user is False
+
+
+def test_config_field_set_value_within_bounds():
+    """
+    Test that the `ConfigField` class correctly sets the value within the specified bounds.
+
+    This test verifies that when a value is assigned to the `ConfigField` instance,
+    it respects the defined bounds and updates the value accordingly.
+
+    Steps:
+    1. Create a `ConfigField` instance with a default value of 5 and bounds of 0 (lower) and 10 (upper).
+    2. Set the `value` attribute to 7, which is within the specified bounds.
+    3. Assert that the `value` attribute is updated to 7.
+
+    Expected Result:
+    The `value` attribute of the `ConfigField` instance should be updated to 7 without any errors.
+    """
+    field = ConfigField(default=5, bounds={"lower": 0, "upper": 10})
+    field.value = 7
+    assert field.value == 7
+
+
+def test_config_field_set_value_exceeds_upper_bound():
+    """
+    Test that setting a value exceeding the upper bound of a ConfigField raises a ValueError.
+
+    This test verifies that when a value greater than the specified upper bound is assigned
+    to the `value` attribute of a `ConfigField` instance, a `ValueError` is raised with the
+    appropriate error message.
+
+    Steps:
+    1. Create a `ConfigField` instance with a default value of 5 and bounds of 0 (lower) and 10 (upper).
+    2. Attempt to set the `value` attribute to 15, which exceeds the upper bound.
+    3. Assert that a `ValueError` is raised with a message indicating the value exceeds the upper bounds.
+    """
+    field = ConfigField(default=5, bounds={"lower": 0, "upper": 10})
+    with pytest.raises(ValueError, match="exceeds upper bounds"):
+        field.value = 15
+
+
+def test_config_field_set_value_below_lower_bound():
+    """
+    Test that setting a value below the lower bound of a ConfigField raises a ValueError.
+
+    This test verifies that the ConfigField class enforces its lower bound constraint
+    by raising a ValueError when an attempt is made to set its value below the defined
+    lower bound.
+
+    Steps:
+    1. Create a ConfigField instance with a default value of 5 and bounds of 0 (lower) and 10 (upper).
+    2. Attempt to set the field's value to -1, which is below the lower bound.
+    3. Assert that a ValueError is raised with a message indicating the value exceeds the lower bounds.
+    """
+    field = ConfigField(default=5, bounds={"lower": 0, "upper": 10})
+    with pytest.raises(ValueError, match="exceeds lower bounds"):
+        field.value = -1
+
+
+def test_config_field_set_invalid_bounds_key():
+    """
+    Test that a ValueError is raised when an invalid key is provided in the bounds dictionary
+    of a ConfigField instance.
+
+    This test ensures that the ConfigField class validates the keys in the bounds dictionary
+    and raises an appropriate error if an invalid key is encountered.
+
+    Expected Behavior:
+    - A ValueError is raised with a message indicating that the provided key is not valid.
+
+    Raises:
+    - ValueError: If the bounds dictionary contains an invalid key.
+    """
+    with pytest.raises(ValueError, match="is not a valid key for bounds"):
+        ConfigField(default=5, bounds={"invalid_key": 10})
+
+
+def test_config_field_set_value_with_choices_list():
+    """
+    Test that the `ConfigField` class correctly sets and retrieves a value
+    when the value is within the allowed choices.
+
+    This test verifies:
+    - The `ConfigField` instance is initialized with a default value and a list of valid choices.
+    - The `value` attribute can be updated to a valid choice from the `choices` list.
+    - The updated value is correctly stored and retrieved.
+
+    Steps:
+    1. Create a `ConfigField` instance with a default value of "A" and choices ["A", "B", "C"].
+    2. Set the `value` attribute to "B".
+    3. Assert that the `value` attribute is updated to "B".
+    """
+    field = ConfigField(default="A", choices=["A", "B", "C"])
+    field.value = "B"
+    assert field.value == "B"
+
+
+def test_config_field_set_value_not_in_choices_list():
+    """
+    Test that setting a value not included in the list of valid choices for a ConfigField
+    raises a ValueError with the appropriate error message.
+
+    This test verifies:
+    - A ConfigField instance is initialized with a default value and a list of valid choices.
+    - Attempting to assign a value outside the defined choices raises a ValueError.
+    - The error message explicitly mentions that the value is not in the list of choices.
+    """
+    field = ConfigField(default="A", choices=["A", "B", "C"])
+    with pytest.raises(ValueError, match="not in list of choices"):
+        field.value = "D"
+
+
+def test_config_field_set_value_with_enum_choices():
+    """
+    Test the `set_value` functionality of the `ConfigField` class when using an enum for choices.
+
+    This test ensures that:
+    1. A `ConfigField` instance can be initialized with a default value from an enum.
+    2. The `value` attribute of the `ConfigField` can be updated to another valid enum option.
+    3. The updated value is correctly reflected and matches the expected enum option.
+
+    Assertions:
+    - Verify that the `value` attribute is updated to the new enum option.
+    """
+
+    class TestEnum(Enum):
+        OPTION_A = "A"
+        OPTION_B = "B"
+
+    field = ConfigField(default=TestEnum.OPTION_A, choices=TestEnum)
+    field.value = TestEnum.OPTION_B
+    assert field.value == TestEnum.OPTION_B
+
+
+def test_config_field_set_value_not_in_enum_choices():
+    """
+    Test that assigning a value not present in the enum choices to a ConfigField
+    raises a ValueError.
+
+    This test verifies that when attempting to set the `value` attribute of a
+    `ConfigField` instance to a value that is not part of the specified `choices`
+    (in this case, an enum), a `ValueError` is raised with the appropriate error
+    message.
+
+    Steps:
+    1. Create a `ConfigField` instance with a default value and a set of enum choices.
+    2. Attempt to assign an invalid value to the `value` attribute.
+    3. Assert that a `ValueError` is raised with the expected error message.
+
+    Expected Behavior:
+    - A `ValueError` is raised with the message "not in list of choices" when
+      an invalid value is assigned.
+    """
+
+    class TestEnum(Enum):
+        OPTION_A = "A"
+        OPTION_B = "B"
+
+    field = ConfigField(default=TestEnum.OPTION_A, choices=TestEnum)
+    with pytest.raises(ValueError, match="not in list of choices"):
+        field.value = "INVALID_OPTION"
+
+
+def test_config_field_is_set_by_user():
+    """
+    Test the behavior of the `is_set_by_user` property in the `ConfigField` class.
+
+    This test verifies that:
+    1. The `is_set_by_user` property is initially `False` when the field is set to its default value.
+    2. The `is_set_by_user` property becomes `True` after the field's value is explicitly set by the user.
+    """
+    field = ConfigField(default=10)
+    assert field.is_set_by_user is False
+    field.value = 20
+    assert field.is_set_by_user is True
+
+
+def test_config_field_equality():
+    """
+    Test the equality and inequality behavior of the ConfigField class.
+
+    This test verifies that two ConfigField instances with identical default
+    values and bounds are considered equal. It also ensures that modifying
+    the value of one instance causes the two instances to be considered
+    unequal.
+
+    Assertions:
+        - Two ConfigField instances with the same default value and bounds
+          are equal.
+        - Modifying the value of one ConfigField instance makes it unequal
+          to the other.
+    """
+    field1 = ConfigField(default=10, bounds={"lower": 0, "upper": 20})
+    field2 = ConfigField(default=10, bounds={"lower": 0, "upper": 20})
+    assert field1 == field2
+
+    field2.value = 15
+    assert field1 != field2


### PR DESCRIPTION
This removes the vast majority of CLI checking and inferencing from `parser.py` (only the goodput dictionary checking remains duplicated). This is now all done in the Config class and going forward all future inferencing and checking should be done in there.
I've updated the unit tests to reflect the new error messages that come from the config class. A few unit tests were no longer relevant (the logic is tested elsewhere and already exists) and were removed.