### PR TITLE
Fix broken file input retriever class

### DIFF
--- a/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
@@ -64,11 +64,11 @@ class FileInputRetriever(BaseFileInputRetriever):
         """
 
         files_data: Dict[str, FileData] = {}
-        self.config.input_filename = cast(Path, self.config.input_filename)
-        if self.config.input_filename.is_dir():
+        self.config.input.file = cast(Path, self.config.input.file)
+        if self.config.input.file.is_dir():
             files_data = self._get_input_datasets_from_dir()
         else:
-            input_file = self.config.input_filename
+            input_file = self.config.input.file
             file_data = self._get_input_dataset_from_file(input_file)
             files_data = {str(input_file): file_data}
 

--- a/genai-perf/tests/test_retrievers/test_file_input_retriever.py
+++ b/genai-perf/tests/test_retrievers/test_file_input_retriever.py
@@ -115,6 +115,38 @@ class TestFileInputRetriever:
         return_value="mock_base64_image",
     )
     @patch("builtins.open", side_effect=open_side_effect)
+    def test_retrieve_data_multi_modal(
+        self, mock_file, mock_image, mock_encode_image, mock_exists
+    ):
+        config = ConfigCommand({"model_name": "test_model_A"})
+        config.input.file = Path("multi_modal.jsonl")
+
+        file_retriever = FileInputRetriever(
+            InputsConfig(
+                config=config,
+                tokenizer=get_empty_tokenizer(),
+                output_directory=Path("."),
+            )
+        )
+
+        data = file_retriever.retrieve_data()
+        assert len(data.files_data) == 1
+        assert "multi_modal.jsonl" in data.files_data
+
+        file_data = data.files_data["multi_modal.jsonl"]
+        assert len(file_data.rows) == 2
+        assert file_data.rows[0].texts[0] == "What is this image?"
+        assert file_data.rows[0].images[0] == "mock_base64_image"
+        assert file_data.rows[1].texts[0] == "Who is this person?"
+        assert file_data.rows[1].images[0] == "mock_base64_image"
+
+    @patch("pathlib.Path.exists", return_value=True)
+    @patch("PIL.Image.open", return_value=Image.new("RGB", (10, 10)))
+    @patch(
+        f"{FILE_INPUT_RETRIEVER_PREFIX}._encode_image",
+        return_value="mock_base64_image",
+    )
+    @patch("builtins.open", side_effect=open_side_effect)
     def test_get_input_file_single_image(
         self, mock_file, mock_image, mock_encode_image, mock_exists
     ):


### PR DESCRIPTION
File input retriever was silently broken since there was no test covering `retrieve_data()`, which is the core API of the class.
Made the changes to fix the bug and added tests to cover `retrieve_data()` method.