### PR TITLE
Fixing create-template when a custom name is specified

### DIFF
--- a/genai-perf/genai_perf/config/generate/search_parameters.py
+++ b/genai-perf/genai_perf/config/generate/search_parameters.py
@@ -22,7 +22,8 @@ from genai_perf.config.generate.search_parameter import (
     SearchParameter,
     SearchUsage,
 )
-from genai_perf.config.input.config_command import ConfigCommand, Range, Subcommand
+from genai_perf.config.input.config_command import ConfigCommand
+from genai_perf.config.input.config_defaults import Range
 from genai_perf.constants import (
     exponential_range_parameters,
     linear_range_parameters,
@@ -30,6 +31,7 @@ from genai_perf.constants import (
     runtime_pa_parameters,
 )
 from genai_perf.exceptions import GenAIPerfException
+from genai_perf.inputs.input_constants import Subcommand
 
 
 class SearchParameters:

--- a/genai-perf/genai_perf/config/generate/search_parameters.py
+++ b/genai-perf/genai_perf/config/generate/search_parameters.py
@@ -31,7 +31,6 @@ from genai_perf.constants import (
     runtime_pa_parameters,
 )
 from genai_perf.exceptions import GenAIPerfException
-from genai_perf.inputs.input_constants import Subcommand
 
 
 class SearchParameters:

--- a/genai-perf/genai_perf/config/input/config_analyze.py
+++ b/genai-perf/genai_perf/config/input/config_analyze.py
@@ -34,7 +34,8 @@ class ConfigAnalyze(BaseConfig):
         # yapf: disable
         sweep_parameter_template_comment = \
         (f"Uncomment the lines below to enable the analyze subcommand\n"
-         f"For further details see analyze.md sweep_parameters:\n"
+         f"# For further details see analyze.md\n"
+         f"sweep_parameters:\n"
          f"  concurrency:\n"
          f"    start: {AnalyzeDefaults.MIN_CONCURRENCY}\n"
          f"    stop: {AnalyzeDefaults.MAX_CONCURRENCY}")

--- a/genai-perf/genai_perf/config/input/config_command.py
+++ b/genai-perf/genai_perf/config/input/config_command.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Optional, TypeAlias, Union
 import genai_perf.logging as logging
 from genai_perf.config.input.base_config import BaseConfig
 from genai_perf.config.input.config_analyze import ConfigAnalyze
-from genai_perf.config.input.config_defaults import Range, TopLevelDefaults
+from genai_perf.config.input.config_defaults import TopLevelDefaults
 from genai_perf.config.input.config_endpoint import ConfigEndPoint
 from genai_perf.config.input.config_field import ConfigField
 from genai_perf.config.input.config_input import ConfigInput
@@ -30,18 +30,9 @@ from genai_perf.inputs.input_constants import (
     OutputFormat,
     PerfAnalyzerMeasurementMode,
     PromptSource,
+    Subcommand,
 )
 from genai_perf.utils import split_and_strip_whitespace
-
-
-class Subcommand(Enum):
-    COMPARE = "compare"
-    PROFILE = "profile"
-    ANALYZE = "analyze"
-    TEMPLATE = "create-template"
-
-
-ConfigRangeOrList: TypeAlias = Optional[Union[Range, List[int]]]
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +54,21 @@ class ConfigCommand(BaseConfig):
             required=True,
             add_to_template=True,
             verbose_template_comment="The name of the model(s) to benchmark.",
+        )
+
+        self.subcommand: Any = ConfigField(
+            default=TopLevelDefaults.SUBCOMMAND,
+            choices=Subcommand,
+            add_to_template=False,
+        )
+
+        self.verbose: Any = ConfigField(
+            default=TopLevelDefaults.VERBOSE, add_to_template=False
+        )
+
+        self.template_filename: Any = ConfigField(
+            default=Path(TopLevelDefaults.TEMPLATE_FILENAME),
+            add_to_template=False,
         )
 
         self.analyze = ConfigAnalyze()
@@ -248,22 +254,3 @@ class ConfigCommand(BaseConfig):
     ###########################################################################
     def make_template(self) -> str:
         return self.create_template(header="", level=0, verbose=self.verbose)
-
-    ###########################################################################
-    # Utility Methods
-    ###########################################################################
-    def get_max(self, config_value: ConfigRangeOrList) -> int:
-        if type(config_value) is list:
-            return max(config_value)
-        elif type(config_value) is Range:
-            return config_value.max
-        else:
-            return 0
-
-    def get_min(self, config_value: ConfigRangeOrList) -> int:
-        if type(config_value) is list:
-            return min(config_value)
-        elif type(config_value) is Range:
-            return config_value.min
-        else:
-            return 0

--- a/genai-perf/genai_perf/config/input/config_defaults.py
+++ b/genai-perf/genai_perf/config/input/config_defaults.py
@@ -21,6 +21,7 @@ from genai_perf.inputs.input_constants import (
     ModelSelectionStrategy,
     OutputFormat,
     PerfAnalyzerMeasurementMode,
+    Subcommand,
 )
 
 
@@ -40,7 +41,7 @@ class Range:
 @dataclass(frozen=True)
 class TopLevelDefaults:
     MODEL_NAMES = ""
-    SUBCOMMAND = "profile"
+    SUBCOMMAND = Subcommand.PROFILE
     VERBOSE = False
     TEMPLATE_FILENAME = "genai_perf_config.yaml"
 

--- a/genai-perf/genai_perf/config/input/config_defaults.py
+++ b/genai-perf/genai_perf/config/input/config_defaults.py
@@ -40,6 +40,9 @@ class Range:
 @dataclass(frozen=True)
 class TopLevelDefaults:
     MODEL_NAMES = ""
+    SUBCOMMAND = "profile"
+    VERBOSE = False
+    TEMPLATE_FILENAME = "genai_perf_config.yaml"
 
 
 @dataclass(frozen=True)
@@ -173,8 +176,3 @@ class TokenizerDefaults:
     NAME = ""
     REVISION = "main"
     TRUST_REMOTE_CODE = False
-
-
-@dataclass(frozen=True)
-class TemplateDefaults:
-    FILENAME = "genai_perf_config.yaml"

--- a/genai-perf/genai_perf/export_data/data_exporter_factory.py
+++ b/genai-perf/genai_perf/export_data/data_exporter_factory.py
@@ -30,6 +30,7 @@ from genai_perf.export_data.console_exporter import ConsoleExporter
 from genai_perf.export_data.csv_exporter import CsvExporter
 from genai_perf.export_data.exporter_config import ExporterConfig
 from genai_perf.export_data.json_exporter import JsonExporter
+from genai_perf.inputs.input_constants import Subcommand
 
 ProfileDataExporterList = [ConsoleExporter, JsonExporter, CsvExporter]
 AnalyzeDataExporterList = [CsvExporter]
@@ -37,7 +38,7 @@ AnalyzeDataExporterList = [CsvExporter]
 
 class DataExporterFactory:
     def create_data_exporters(self, config: ExporterConfig) -> List[Any]:
-        if config.config.subcommand == "analyze":
+        if config.config.subcommand == Subcommand.ANALYZE:
             DataExporterList: List[Any] = AnalyzeDataExporterList
         else:
             DataExporterList = ProfileDataExporterList

--- a/genai-perf/genai_perf/inputs/input_constants.py
+++ b/genai-perf/genai_perf/inputs/input_constants.py
@@ -27,6 +27,13 @@
 from enum import Enum, auto
 
 
+class Subcommand(Enum):
+    COMPARE = "compare"
+    PROFILE = "profile"
+    ANALYZE = "analyze"
+    TEMPLATE = "create-template"
+
+
 class ModelSelectionStrategy(Enum):
     ROUND_ROBIN = "ROUND_ROBIN"
     RANDOM = "RANDOM"

--- a/genai-perf/genai_perf/main.py
+++ b/genai-perf/genai_perf/main.py
@@ -30,7 +30,7 @@ import traceback
 
 import genai_perf.logging as logging
 from genai_perf import parser
-from genai_perf.config.input.config_command import Subcommand
+from genai_perf.inputs.input_constants import Subcommand
 
 logger = logging.getLogger(__name__)
 
@@ -44,9 +44,9 @@ def run():
     # Compare subcommand is deprecated and does not support config file
     if args.subcommand == Subcommand.COMPARE.value:
         args.func(args)
-    elif config.subcommand == Subcommand.ANALYZE.value:
+    elif config.subcommand == Subcommand.ANALYZE:
         args.func(config, extra_args)
-    elif config.subcommand == Subcommand.TEMPLATE.value:
+    elif config.subcommand == Subcommand.TEMPLATE:
         args.func(config)
     else:  # profile
         args.func(config, extra_args)

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -35,7 +35,7 @@ import genai_perf.logging as logging
 import genai_perf.utils as utils
 from genai_perf.config.endpoint_config import endpoint_type_map
 from genai_perf.config.input.config_command import ConfigCommand
-from genai_perf.config.input.config_defaults import AnalyzeDefaults, EndPointDefaults
+from genai_perf.config.input.config_defaults import AnalyzeDefaults
 from genai_perf.config.input.config_field import ConfigField
 from genai_perf.constants import DEFAULT_ARTIFACT_DIR, DEFAULT_PROFILE_EXPORT_FILE
 from genai_perf.inputs import input_constants as ic

--- a/genai-perf/genai_perf/subcommand/analyze.py
+++ b/genai-perf/genai_perf/subcommand/analyze.py
@@ -36,11 +36,9 @@ from genai_perf.config.generate.perf_analyzer_config import PerfAnalyzerConfig
 from genai_perf.config.generate.search_parameters import SearchParameters
 from genai_perf.config.generate.sweep_objective_generator import SweepObjectiveGenerator
 from genai_perf.config.input.config_command import ConfigCommand
-from genai_perf.config.input.config_defaults import Range
 from genai_perf.config.run.run_config import RunConfig
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.export_data.output_reporter import OutputReporter
-from genai_perf.inputs.input_constants import Subcommand
 from genai_perf.inputs.inputs_config import InputsConfig
 from genai_perf.measurements.run_config_measurement import RunConfigMeasurement
 from genai_perf.metrics.telemetry_statistics import TelemetryStatistics

--- a/genai-perf/genai_perf/subcommand/analyze.py
+++ b/genai-perf/genai_perf/subcommand/analyze.py
@@ -35,10 +35,12 @@ from genai_perf.config.generate.genai_perf_config import GenAIPerfConfig
 from genai_perf.config.generate.perf_analyzer_config import PerfAnalyzerConfig
 from genai_perf.config.generate.search_parameters import SearchParameters
 from genai_perf.config.generate.sweep_objective_generator import SweepObjectiveGenerator
-from genai_perf.config.input.config_command import ConfigCommand, Range, Subcommand
+from genai_perf.config.input.config_command import ConfigCommand
+from genai_perf.config.input.config_defaults import Range
 from genai_perf.config.run.run_config import RunConfig
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.export_data.output_reporter import OutputReporter
+from genai_perf.inputs.input_constants import Subcommand
 from genai_perf.inputs.inputs_config import InputsConfig
 from genai_perf.measurements.run_config_measurement import RunConfigMeasurement
 from genai_perf.metrics.telemetry_statistics import TelemetryStatistics

--- a/genai-perf/tests/test_checkpoint.py
+++ b/genai-perf/tests/test_checkpoint.py
@@ -19,8 +19,9 @@ from unittest.mock import patch
 from genai_perf.checkpoint.checkpoint import Checkpoint
 from genai_perf.config.generate.search_parameters import SearchParameters
 from genai_perf.config.generate.sweep_objective_generator import SweepObjectiveGenerator
-from genai_perf.config.input.config_command import ConfigCommand, Subcommand
+from genai_perf.config.input.config_command import ConfigCommand
 from genai_perf.config.run.results import Results
+from genai_perf.inputs.input_constants import Subcommand
 from tests.test_utils import create_run_config
 
 

--- a/genai-perf/tests/test_checkpoint.py
+++ b/genai-perf/tests/test_checkpoint.py
@@ -21,7 +21,6 @@ from genai_perf.config.generate.search_parameters import SearchParameters
 from genai_perf.config.generate.sweep_objective_generator import SweepObjectiveGenerator
 from genai_perf.config.input.config_command import ConfigCommand
 from genai_perf.config.run.results import Results
-from genai_perf.inputs.input_constants import Subcommand
 from tests.test_utils import create_run_config
 
 

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -717,14 +717,21 @@ class TestCLIArguments:
                 "--wrong-arg",
             ],
         )
-        expected_output = "unrecognized arguments: --wrong-arg"
 
-        with pytest.raises(SystemExit) as excinfo:
+        with pytest.raises(ValueError) as execinfo:
             parser.parse_args()
 
-        assert excinfo.value.code != 0
-        captured = capsys.readouterr()
-        assert expected_output in captured.err
+        expected_error_message = "Unknown arguments passed to GenAI-Perf: --wrong-arg"
+        assert expected_error_message == execinfo.value.args[0]
+
+    def test_non_default_create_template_filename(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "sys.argv",
+            ["genai-perf", "create-template", "custom_template.yaml"],
+        )
+
+        args, config, _ = parser.parse_args()
+        assert config.template_filename == Path("custom_template.yaml")
 
     @pytest.mark.parametrize(
         "args, expected_error_message",
@@ -989,7 +996,6 @@ class TestCLIArguments:
         with pytest.raises(ValueError) as execinfo:
             parser.parse_args()
 
-        captured = capsys.readouterr()
         assert expected_error_message == execinfo.value.args[0]
 
     @pytest.mark.parametrize(

--- a/genai-perf/tests/test_config_command.py
+++ b/genai-perf/tests/test_config_command.py
@@ -20,7 +20,8 @@ from unittest.mock import MagicMock, patch
 # Skip type checking to avoid mypy error
 # Issue: https://github.com/python/mypy/issues/10632
 import yaml  # type: ignore
-from genai_perf.config.input.config_command import ConfigCommand, ConfigInput, Range
+from genai_perf.config.input.config_command import ConfigCommand, ConfigInput
+from genai_perf.config.input.config_defaults import Range
 from genai_perf.inputs.input_constants import (
     ModelSelectionStrategy,
     OutputFormat,

--- a/genai-perf/tests/test_exporters/test_data_exporter_factory.py
+++ b/genai-perf/tests/test_exporters/test_data_exporter_factory.py
@@ -33,7 +33,7 @@ from genai_perf.export_data.console_exporter import ConsoleExporter
 from genai_perf.export_data.csv_exporter import CsvExporter
 from genai_perf.export_data.exporter_config import ExporterConfig
 from genai_perf.export_data.json_exporter import JsonExporter
-from genai_perf.inputs.input_constants import ModelSelectionStrategy
+from genai_perf.inputs.input_constants import ModelSelectionStrategy, Subcommand
 from genai_perf.subcommand.common import get_extra_inputs_as_dict
 from tests.test_utils import create_default_exporter_config
 
@@ -56,7 +56,7 @@ class TestOutputReporter:
     }
     config = ConfigCommand({"model_name": "gpt2_vllm"})
     config.endpoint.model_selection_strategy = ModelSelectionStrategy.ROUND_ROBIN
-    config.subcommand = "profile"
+    config.subcommand = Subcommand.PROFILE
 
     args = {
         "model": ["gpt2_vllm"],


### PR DESCRIPTION
Uncovered a bug in template creation when a custom name is specified for the template. Fixed this and added unit testing to cover this case.

I also went ahead a made a few changes to improve the code cleanliness: 

- moving all the ConfigFields into ConfigCommand (from parser)
- moving the Subcommand enum into constants and using it properly in ConfigCommand
- Removing methods that were never used