### PR TITLE
Fixing URL passing to PA in config generator logic

### DIFF
--- a/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
+++ b/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
@@ -85,6 +85,7 @@ class PerfAnalyzerConfig:
         cli_args += self._add_verbose_args(config)
         cli_args += self._add_perf_analyzer_args(config)
         cli_args += self._add_protocol_args(config)
+        cli_args += self._add_url_args(config)
         cli_args += self._add_dynamic_grpc_args(config)
         cli_args += self._add_inference_load_args(config)
         cli_args += self._add_prompt_source_args(config)
@@ -270,18 +271,28 @@ class PerfAnalyzerConfig:
 
         return perf_analyzer_args
 
+    def _add_url_args(self, config: ConfigCommand) -> List[str]:
+        url_args = []
+
+        if (
+            config.endpoint.get_field("url").is_set_by_user
+            or config.endpoint.service_kind == "triton"
+            or config.endpoint.service_kind == "dynamic_grpc"
+        ):
+            url_args += ["-u", config.endpoint.url]
+
+        return url_args
+
     def _add_protocol_args(self, config: ConfigCommand) -> List[str]:
         protocol_args = []
 
         if config.endpoint.service_kind == "triton":
-            protocol_args += ["-i", "grpc", "--streaming", "-u", config.endpoint.url]
+            protocol_args += ["-i", "grpc", "--streaming"]
 
             if config.endpoint.backend == OutputFormat.TENSORRTLLM:
                 protocol_args += ["--shape", "max_tokens:1", "--shape", "text_input:1"]
         elif config.endpoint.service_kind == "openai":
             protocol_args += ["-i", "http"]
-        elif config.endpoint.service_kind == "dynamic_grpc":
-            protocol_args += ["-u", config.endpoint.url]
 
         return protocol_args
 

--- a/genai-perf/tests/test_perf_analyzer_config.py
+++ b/genai-perf/tests/test_perf_analyzer_config.py
@@ -331,8 +331,6 @@ class TestPerfAnalyzerConfig(unittest.TestCase):
             "-i",
             "grpc",
             "--streaming",
-            "-u",
-            f"{DEFAULT_GRPC_URL}",
             "--shape",
             "max_tokens:1",
             "--shape",
@@ -353,22 +351,6 @@ class TestPerfAnalyzerConfig(unittest.TestCase):
         self._config.endpoint.service_kind = "openai"
 
         expected_args = ["-i", "http"]
-
-        actual_args = self._default_perf_analyzer_config._add_protocol_args(
-            self._config
-        )
-
-        self.assertEqual(expected_args, actual_args)
-
-    def test_add_protocol_args_with_dynamic_grpc(self):
-        """
-        Test that _add_protocol_args returns the correct arguments
-        when service_kind is 'dynamic_grpc'
-        """
-        self._config.endpoint.service_kind = "dynamic_grpc"
-        self._config.endpoint.get_field("url").is_set_by_user = False
-
-        expected_args = ["-u", f"{DEFAULT_GRPC_URL}"]
 
         actual_args = self._default_perf_analyzer_config._add_protocol_args(
             self._config
@@ -540,6 +522,67 @@ class TestPerfAnalyzerConfig(unittest.TestCase):
         )
 
         self.assertEqual(expected_args, actual_args)
+
+        ###########################################################################
+        # Test _add_url_args
+        ###########################################################################
+        def test_add_url_args_with_user_set_url(self):
+            """
+            Test that _add_url_args returns the correct arguments
+            when the URL is set by the user
+            """
+            self._config.endpoint.get_field("url").is_set_by_user = True
+            self._config.endpoint.url = "http://custom-url:8000"
+
+            expected_args = ["-u", "http://custom-url:8000"]
+
+            actual_args = self._default_perf_analyzer_config._add_url_args(self._config)
+
+            self.assertEqual(expected_args, actual_args)
+
+        def test_add_url_args_with_triton_service_kind(self):
+            """
+            Test that _add_url_args returns the correct arguments
+            when service_kind is 'triton'
+            """
+            self._config.endpoint.get_field("url").is_set_by_user = False
+            self._config.endpoint.service_kind = "triton"
+            self._config.endpoint.url = "http://triton-url:8001"
+
+            expected_args = ["-u", "http://triton-url:8001"]
+
+            actual_args = self._default_perf_analyzer_config._add_url_args(self._config)
+
+            self.assertEqual(expected_args, actual_args)
+
+        def test_add_url_args_with_dynamic_grpc_service_kind(self):
+            """
+            Test that _add_url_args returns the correct arguments
+            when service_kind is 'dynamic_grpc'
+            """
+            self._config.endpoint.get_field("url").is_set_by_user = False
+            self._config.endpoint.service_kind = "dynamic_grpc"
+            self._config.endpoint.url = "http://dynamic-grpc-url:9000"
+
+            expected_args = ["-u", "http://dynamic-grpc-url:9000"]
+
+            actual_args = self._default_perf_analyzer_config._add_url_args(self._config)
+
+            self.assertEqual(expected_args, actual_args)
+
+        def test_add_url_args_with_no_url_and_unknown_service_kind(self):
+            """
+            Test that _add_url_args returns an empty list
+            when the URL is not set and service_kind is unknown
+            """
+            self._config.endpoint.get_field("url").is_set_by_user = False
+            self._config.endpoint.service_kind = "unknown"
+
+            expected_args = []
+
+            actual_args = self._default_perf_analyzer_config._add_url_args(self._config)
+
+            self.assertEqual(expected_args, actual_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The root cause of the bug was that the old code would always pass the URL to PA if one was specified by the user.  And then there were two (special) cases where it would pass a default URL if nothing was specified.

I coded the two special cases (and added unit testing for those), but missed the fact that `url` was not part of the `skip_list`, so in the common case the PA config generator wasn't passing along a user specified url.

I've added unit testing to cover this case and made a slight refactor of the logic to separate out protocol vs. url generation logic.

Note: This would have been caught earlier if we had an CI test that exercised this option.