### PR TITLE
Support benchmarking for the HuggingFace TGI generate endpoint

### DIFF
--- a/genai-perf/docs/huggingface_tgi.md
+++ b/genai-perf/docs/huggingface_tgi.md
@@ -39,7 +39,7 @@ To launch a Hugging Face TGI server, use the official `ghcr.io` image:
 ```bash
 docker run --gpus all --rm -it \
   -p 8080:80 \
-  -e MODEL_ID=gpt2 \
+  -e MODEL_ID=<model> \
   ghcr.io/huggingface/text-generation-inference
 ```
 
@@ -51,13 +51,13 @@ Run with built-in synthetic prompts:
 
 ```bash
 genai-perf profile \
-  -m gpt2 \
+  -m <model> \
   --service-kind openai \
   --endpoint-type huggingface_generate \
-  --port localhost:8080 \
+  --url localhost:8080 \
   --batch-size-image 1 \
-  --image-width-mean 1 \
-  --image-height-mean 1 \
+  --image-width-mean 100 \
+  --image-height-mean 100 \
   --synthetic-input-tokens-mean 10
 ```
 
@@ -83,7 +83,7 @@ For instance, an example of input file would look something as following:
 
 ```bash
 genai-perf profile \
-  -m gpt2 \
+  -m <model> \
   --service-kind openai \
   --endpoint-type huggingface_generate \
   --url localhost:8080 \

--- a/genai-perf/docs/huggingface_tgi.md
+++ b/genai-perf/docs/huggingface_tgi.md
@@ -39,7 +39,7 @@ To launch a Hugging Face TGI server, use the official `ghcr.io` image:
 ```bash
 docker run --gpus all --rm -it \
   -p 8080:80 \
-  -e MODEL_ID=<model> \
+  -e MODEL_ID=llava-hf/llava-v1.6-mistral-7b-hf \
   ghcr.io/huggingface/text-generation-inference
 ```
 
@@ -51,7 +51,7 @@ Run with built-in synthetic prompts:
 
 ```bash
 genai-perf profile \
-  -m <model> \
+  -m llava-hf/llava-v1.6-mistral-7b-hf \
   --service-kind openai \
   --endpoint-type huggingface_generate \
   --url localhost:8080 \
@@ -83,7 +83,7 @@ For instance, an example of input file would look something as following:
 
 ```bash
 genai-perf profile \
-  -m <model> \
+  -m llava-hf/llava-v1.6-mistral-7b-hf \
   --service-kind openai \
   --endpoint-type huggingface_generate \
   --url localhost:8080 \
@@ -95,15 +95,15 @@ genai-perf profile \
 Example output:
 
 ```
-                                    NVIDIA GenAI-Perf | LLM Metrics
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┓
-┃                            Statistic ┃      avg ┃    min ┃      max ┃      p99 ┃      p90 ┃      p75 ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━┩
-│                 Request Latency (ms) │   731.58 │ 251.22 │ 1,556.89 │ 1,552.28 │ 1,510.77 │ 1,275.52 │
-│      Output Sequence Length (tokens) │   853.40 │ 370.00 │ 1,025.00 │ 1,024.91 │ 1,024.10 │ 1,024.00 │
-│       Input Sequence Length (tokens) │   394.00 │  78.00 │   866.00 │   866.00 │   866.00 │   866.00 │
-│ Output Token Throughput (tokens/sec) │ 1,166.41 │    N/A │      N/A │      N/A │      N/A │      N/A │
-│         Request Throughput (per sec) │     1.37 │    N/A │      N/A │      N/A │      N/A │      N/A │
-│                Request Count (count) │    10.00 │    N/A │      N/A │      N/A │      N/A │      N/A │
-└──────────────────────────────────────┴──────────┴────────┴──────────┴──────────┴──────────┴──────────┘
+                                        NVIDIA GenAI-Perf | LLM Metrics
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃                            Statistic ┃       avg ┃      min ┃       max ┃       p99 ┃       p90 ┃       p75 ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━┩
+│                 Request Latency (ms) │  6,675.95 │   234.82 │ 54,474.75 │ 50,240.69 │ 12,134.14 │  1,283.24 │
+│      Output Sequence Length (tokens) │    347.50 │     3.00 │  2,908.00 │  2,681.92 │    647.20 │     59.75 │
+│       Input Sequence Length (tokens) │ 10,164.10 │ 7,293.00 │ 12,113.00 │ 12,113.00 │ 12,113.00 │ 12,112.75 │
+│ Output Token Throughput (tokens/sec) │     52.05 │      N/A │       N/A │       N/A │       N/A │       N/A │
+│         Request Throughput (per sec) │      0.15 │      N/A │       N/A │       N/A │       N/A │       N/A │
+│                Request Count (count) │     10.00 │      N/A │       N/A │       N/A │       N/A │       N/A │
+└──────────────────────────────────────┴───────────┴──────────┴───────────┴───────────┴───────────┴───────────┘
 ```

--- a/genai-perf/docs/huggingface_tgi.md
+++ b/genai-perf/docs/huggingface_tgi.md
@@ -1,0 +1,109 @@
+<!--
+Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of NVIDIA CORPORATION nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+# Profile Hugging Face TGI Models Using GenAI-Perf
+
+GenAI-Perf can profile LLMs running on a
+[Hugging Face's Text Generation Inference (TGI) API-compatible](https://huggingface.co/docs/chat-ui/en/configuration/models/providers/tgi)
+server using the generate API. This guide walks you through:
+
+## Step 1: Start a Hugging Face TGI Server
+
+To launch a Hugging Face TGI server, use the official `ghcr.io` image:
+
+```bash
+docker run --gpus all --rm -it \
+  -p 8080:80 \
+  -e MODEL_ID=gpt2 \
+  ghcr.io/huggingface/text-generation-inference
+```
+
+---
+
+## Approach 1. Profile Using Synthetic Inputs
+
+Run with built-in synthetic prompts:
+
+```bash
+genai-perf profile \
+  -m gpt2 \
+  --service-kind openai \
+  --endpoint-type huggingface_generate \
+  --port localhost:8080 \
+  --batch-size-image 1 \
+  --image-width-mean 1 \
+  --image-height-mean 1 \
+  --synthetic-input-tokens-mean 10
+```
+
+---
+
+### Approach 2: Bring Your Own Data (BYOD)
+
+Instead of letting GenAI-Perf create the synthetic data,
+you can also provide GenAI-Perf with your own data using
+[`--input-file`](../README.md#--input-file-path) CLI option.
+The file needs to be in JSONL format and should contain both the prompt and
+the filepath to the image to send.
+
+For instance, an example of input file would look something as following:
+```bash
+// input.jsonl
+{"text": "What is in this image?", "image": "path/to/image1.png"}
+{"text": "What is the color of the dog?", "image": "path/to/image2.jpeg"}
+{"text": "Describe the scene in the picture.", "image": "path/to/image3.png"}
+```
+
+#### 2. Run GenAI-Perf
+
+```bash
+genai-perf profile \
+  -m gpt2 \
+  --service-kind openai \
+  --endpoint-type huggingface_generate \
+  --url localhost:8080 \
+  --input-file input.jsonl
+```
+
+## Review the Output
+
+Example output:
+
+```
+                                    NVIDIA GenAI-Perf | LLM Metrics
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┓
+┃                            Statistic ┃      avg ┃    min ┃      max ┃      p99 ┃      p90 ┃      p75 ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━┩
+│                 Request Latency (ms) │   731.58 │ 251.22 │ 1,556.89 │ 1,552.28 │ 1,510.77 │ 1,275.52 │
+│      Output Sequence Length (tokens) │   853.40 │ 370.00 │ 1,025.00 │ 1,024.91 │ 1,024.10 │ 1,024.00 │
+│       Input Sequence Length (tokens) │   394.00 │  78.00 │   866.00 │   866.00 │   866.00 │   866.00 │
+│ Output Token Throughput (tokens/sec) │ 1,166.41 │    N/A │      N/A │      N/A │      N/A │      N/A │
+│         Request Throughput (per sec) │     1.37 │    N/A │      N/A │      N/A │      N/A │      N/A │
+│                Request Count (count) │    10.00 │    N/A │      N/A │      N/A │      N/A │      N/A │
+└──────────────────────────────────────┴──────────┴────────┴──────────┴──────────┴──────────┴──────────┘
+```

--- a/genai-perf/genai_perf/config/endpoint_config.py
+++ b/genai-perf/genai_perf/config/endpoint_config.py
@@ -48,6 +48,10 @@ endpoint_type_map = {
     "embeddings": EndpointConfig(
         "v1/embeddings", "openai", OutputFormat.OPENAI_EMBEDDINGS
     ),
+    # HuggingFace TGI only exposes root endpoint, so use that as endpoint
+    "huggingface_generate": EndpointConfig(
+        ".", "openai", OutputFormat.HUGGINGFACE_GENERATE
+    ),
     "image_retrieval": EndpointConfig(
         "v1/infer", "openai", OutputFormat.IMAGE_RETRIEVAL
     ),

--- a/genai-perf/genai_perf/inputs/converters/__init__.py
+++ b/genai-perf/genai_perf/inputs/converters/__init__.py
@@ -25,6 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from .dynamic_grpc_converter import DynamicGRPCConverter
+from .huggingface_generate_converter import HuggingFaceGenerateConverter
 from .image_retrieval_converter import ImageRetrievalConverter
 from .nvclip_converter import NVClipConverter
 from .openai_chat_completions_converter import OpenAIChatCompletionsConverter
@@ -39,6 +40,7 @@ from .vllm_converter import VLLMConverter
 
 __all__ = [
     "DynamicGRPCConverter",
+    "HuggingFaceGenerateConverter",
     "ImageRetrievalConverter",
     "NVClipConverter",
     "OpenAIChatCompletionsConverter",

--- a/genai-perf/genai_perf/inputs/converters/huggingface_generate_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/huggingface_generate_converter.py
@@ -1,0 +1,75 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Any, Dict
+
+from genai_perf.inputs.converters.base_converter import BaseConverter
+from genai_perf.inputs.input_constants import DEFAULT_OUTPUT_TOKENS_MEAN
+from genai_perf.inputs.retrievers.generic_dataset import DataRow, GenericDataset
+
+
+class HuggingFaceGenerateConverter(BaseConverter):
+
+    def convert(
+        self,
+        generic_dataset: GenericDataset,
+    ) -> Dict[Any, Any]:
+        request_body: Dict[str, Any] = {"data": []}
+
+        for file_data in generic_dataset.files_data.values():
+            for index, row in enumerate(file_data.rows):
+                model_name = self._select_model_name(index)
+                prompt = self._create_prompt(row)
+
+                payload = {
+                    "model": model_name,
+                    "inputs": prompt,
+                }
+                request_body["data"].append(self._finalize_payload(payload, row))
+
+        return request_body
+
+    def _create_prompt(self, row: DataRow) -> str:
+        prompt_parts = []
+
+        for image in row.images:
+            prompt_parts.append(f"![]({image})")
+
+        if row.texts:
+            prompt_parts.extend(row.texts)
+
+        return " ".join(prompt_parts)
+
+    def _add_request_params(self, payload: Dict, optional_data: Dict[Any, Any]) -> None:
+        number_of_tokens = self._get_max_tokens(optional_data)
+        if number_of_tokens != DEFAULT_OUTPUT_TOKENS_MEAN:
+            payload.setdefault("parameters", {})["max_new_tokens"] = number_of_tokens
+        if self.config.input.extra:
+            for key, value in self.config.input.extra.items():
+                if key in payload["parameters"]:
+                    payload["parameters"][key] = value
+                else:
+                    payload[key] = value

--- a/genai-perf/genai_perf/inputs/converters/output_format_converter_factory.py
+++ b/genai-perf/genai_perf/inputs/converters/output_format_converter_factory.py
@@ -59,6 +59,7 @@ class OutputFormatConverterFactory:
             OutputFormat.TENSORRTLLM_ENGINE: TensorRTLLMEngineConverter,
             OutputFormat.VLLM: VLLMConverter,
             OutputFormat.TRITON_GENERATE: TritonGenerateConverter,
+            OutputFormat.HUGGINGFACE_GENERATE: HuggingFaceGenerateConverter,
         }
         if output_format not in converters:
             raise GenAIPerfException(f"Output format {output_format} is not supported")

--- a/genai-perf/genai_perf/inputs/input_constants.py
+++ b/genai-perf/genai_perf/inputs/input_constants.py
@@ -80,6 +80,7 @@ class OutputFormat(Enum):
     TEMPLATE = "TEMPLATE"
     TENSORRTLLM_ENGINE = "TENSORRTLLM_ENGINE"
     TRITON_GENERATE = "TRITON_GENERATE"
+    HUGGINGFACE_GENERATE = "HUGGINGFACE_GENERATE"
 
     def to_lowercase(self):
         return self.name.lower()

--- a/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
+++ b/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
@@ -453,6 +453,10 @@ class LLMProfileDataParser(ProfileDataParser):
                 first_item = data[0]  # type: ignore
                 if isinstance(first_item, dict):
                     return first_item.get("generated_text", "")
+                else:
+                    raise ValueError(
+                        f"Unknown HuggingFace response type in list: {type(first_item)}"
+                    )
         else:
             raise ValueError(f"Unknown HuggingFace response type: {type(data)}")
 

--- a/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
+++ b/genai-perf/genai_perf/profile_data_parser/llm_profile_data_parser.py
@@ -256,7 +256,10 @@ class LLMProfileDataParser(ProfileDataParser):
         self, res_timestamps: List[int], res_outputs: List[Dict[str, str]]
     ) -> None:
         """Helper function to preprocess responses of a request."""
-        if self._service_kind == "openai":
+        if (
+            self._service_kind == "openai"
+            and "huggingface" not in self._response_format.name.lower()
+        ):
             # Sometimes streamed chunks are returned in a splintered fashion.
             # This forces a merge with the previous chunk if error detected.
             for i in reversed(range(1, len(res_outputs))):
@@ -304,9 +307,18 @@ class LLMProfileDataParser(ProfileDataParser):
                             [self._extract_generate_text_output(r) for r in responses]
                         )
                         data["text_output"] = merged_text
+                    elif self._response_format == ResponseFormat.HUGGINGFACE_GENERATE:
+                        merged_text = "".join(
+                            [
+                                self._extract_huggingface_generate_text_output(r)
+                                for r in responses
+                            ]
+                        )
+                        if isinstance(data, list) and len(data) > 0:
+                            data[0]["generated_text"] = merged_text  # type: ignore
                     else:
                         merged_text = "".join(
-                            [self._extract_openai_text_output(r) for r in responses]
+                            [self._extract_text_output(r) for r in responses]
                         )
                         if self._response_format == ResponseFormat.OPENAI_COMPLETIONS:
                             data["choices"][0]["text"] = merged_text
@@ -344,6 +356,8 @@ class LLMProfileDataParser(ProfileDataParser):
         payload = load_json_str(req_inputs["payload"])
         if self._response_format == ResponseFormat.TRITON_GENERATE:
             return " ".join(payload["text_input"])
+        elif self._response_format == ResponseFormat.HUGGINGFACE_GENERATE:
+            return payload["inputs"]
         elif self._response_format == ResponseFormat.OPENAI_CHAT_COMPLETIONS:
             return " ".join(m["content"] for m in payload["messages"])
         elif self._response_format == ResponseFormat.OPENAI_COMPLETIONS:
@@ -396,12 +410,31 @@ class LLMProfileDataParser(ProfileDataParser):
         """Return a list of LLM response texts."""
         output_texts = []
         for output in res_outputs:
-            if self._response_format == ResponseFormat.TRITON_GENERATE:
-                text = self._extract_generate_text_output(output["response"])
-            else:
-                text = self._extract_openai_text_output(output["response"])
+            text = self._extract_text_output(output["response"])
             output_texts.append(text)
         return output_texts
+
+    def _extract_text_output(self, response: str) -> str:
+        """Extract text output based on response format."""
+        if not response or not_data_sse_field(response):
+            return ""
+
+        response = remove_sse_prefix(response)
+        if response == "[DONE]":
+            return ""
+
+        # Use a mapping to select the appropriate extraction method
+        extraction_methods = {
+            ResponseFormat.TRITON_GENERATE: self._extract_generate_text_output,
+            ResponseFormat.HUGGINGFACE_GENERATE: self._extract_huggingface_generate_text_output,
+            ResponseFormat.OPENAI_CHAT_COMPLETIONS: self._extract_openai_chat_text_output,
+            ResponseFormat.OPENAI_COMPLETIONS: self._extract_openai_completion_text_output,
+            ResponseFormat.OPENAI_MULTIMODAL: self._extract_openai_multimodal_text_output,
+        }
+        extract_method = extraction_methods.get(
+            self._response_format, self._extract_default_text_output
+        )
+        return extract_method(response)
 
     def _get_response_output_tokens(self, output_texts: List[str]) -> List[List[int]]:
         """Return a list of response output tokens."""
@@ -412,7 +445,65 @@ class LLMProfileDataParser(ProfileDataParser):
         encodings = self._tokenizer(["!" + txt for txt in output_texts])
         return [out[1:] for out in encodings.data["input_ids"]]
 
+    def _extract_huggingface_generate_text_output(self, response: str) -> str:
+        data = load_json_str(response)
+
+        if isinstance(data, list):
+            if len(data) > 0:
+                first_item = data[0]  # type: ignore
+                if isinstance(first_item, dict):
+                    return first_item.get("generated_text", "")
+        else:
+            raise ValueError(f"Unknown HuggingFace response type: {type(data)}")
+
+        return ""
+
+    def _extract_openai_chat_text_output(self, response: str) -> str:
+        data = load_json_str(response)
+        completions = data["choices"][0]  # type: ignore
+
+        if "object" not in data:
+            # FIXME: TPA-47 workaround for vLLM not following OpenAI Completions
+            # API specification when streaming, missing 'object' field:
+            # https://platform.openai.com/docs/api-reference/completions
+            return completions.get("text", "")
+        elif data["object"] == "chat.completion":  # non-streaming
+            return completions["message"].get("content", "")
+        elif data["object"] == "chat.completion.chunk":  # streaming
+            return completions["delta"].get("content", "")
+        else:
+            obj_type = data["object"]
+            raise ValueError(f"Unknown OpenAI response object type '{obj_type}'.")
+
+    def _extract_openai_completion_text_output(self, response: str) -> str:
+        """Extract text from OpenAI completion response."""
+        data = load_json_str(response)
+        completions = data["choices"][0]  # type: ignore
+
+        if "object" not in data:
+            # FIXME: TPA-47 workaround for vLLM not following OpenAI Completions
+            # API specification when streaming, missing 'object' field:
+            # https://platform.openai.com/docs/api-reference/completions
+            return completions.get("text", "")
+        elif data["object"] == "text_completion":  # legacy
+            return completions.get("text", "")
+        else:
+            obj_type = data["object"]
+            raise ValueError(f"Unknown OpenAI response object type '{obj_type}'.")
+
+    def _extract_openai_multimodal_text_output(self, response: str) -> str:
+        return self._extract_openai_chat_text_output(response)
+
+    def _extract_default_text_output(self, response: str) -> str:
+        """Default text extraction method for unknown response formats."""
+        logger.warning(
+            f"Unknown response format: {self._response_format}, using default extraction"
+        )
+        return ""
+
     def _extract_generate_text_output(self, response: str) -> str:
+        # (TODO) TPA-829: Add more proper SSE event stream support
+        # Check for empty, comment, or event SSE response
         if not response or not_data_sse_field(response):
             return ""
 
@@ -422,44 +513,7 @@ class LLMProfileDataParser(ProfileDataParser):
         data = json.loads(response)
         return data["text_output"]
 
-    def _extract_openai_text_output(self, response: str) -> str:
-        """Extracts text/content of the OpenAI response object."""
-        # (TODO) TPA-829: Add more proper SSE event stream support
-        # Check for empty, comment, or event SSE response
-        if not response or not_data_sse_field(response):
-            return ""
-
-        response = remove_sse_prefix(response)
-
-        if response == "[DONE]":
-            return ""
-
-        data = load_json_str(response)
-        completions = data["choices"][0]
-
-        text_output = ""
-        if "object" not in data:
-            # FIXME: TPA-47 workaround for vLLM not following OpenAI Completions
-            # API specification when streaming, missing 'object' field:
-            # https://platform.openai.com/docs/api-reference/completions
-            text_output = completions.get("text", "")
-        elif data["object"] == "text_completion":  # legacy
-            text_output = completions.get("text", "")
-        elif data["object"] == "chat.completion":  # non-streaming
-            text_output = completions["message"].get("content", "")
-        elif data["object"] == "chat.completion.chunk":  # streaming
-            text_output = completions["delta"].get("content", "")
-        else:
-            obj_type = data["object"]
-            raise ValueError(f"Unknown OpenAI response object type '{obj_type}'.")
-        return text_output
-
     def _is_empty_response(self, response: str) -> bool:
         """Returns true if the response is an LLM response with no content (or empty content)"""
-        if self._response_format == ResponseFormat.TRITON_GENERATE:
-            text = self._extract_generate_text_output(response)
-        else:
-            text = self._extract_openai_text_output(response)
-        if text:
-            return False
-        return True
+        text = self._extract_text_output(response)
+        return not bool(text)

--- a/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
+++ b/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 class ResponseFormat(Enum):
+    HUGGINGFACE_GENERATE = auto()
     HUGGINGFACE_RANKINGS = auto()
     OPENAI_CHAT_COMPLETIONS = auto()
     OPENAI_COMPLETIONS = auto()
@@ -90,8 +91,8 @@ class ProfileDataParser:
                 self._response_format = ResponseFormat.RANKINGS
             elif data["endpoint"] == "v1/infer":
                 self._response_format = ResponseFormat.IMAGE_RETRIEVAL
-            elif "generate" in data["endpoint"]:
-                self._response_format = ResponseFormat.TRITON_GENERATE
+            elif "huggingface/generate" in data["endpoint"].lower():
+                self._response_format = ResponseFormat.HUGGINGFACE_GENERATE
             else:
                 # (TPA-66) add PA metadata to handle this case
                 # When endpoint field is either empty or custom endpoint, fall
@@ -112,6 +113,8 @@ class ProfileDataParser:
                     self._response_format = ResponseFormat.RANKINGS
                 elif "image_retrieval" in response:
                     self._response_format = ResponseFormat.IMAGE_RETRIEVAL
+                elif "generated_text" in response:
+                    self._response_format = ResponseFormat.HUGGINGFACE_GENERATE
                 else:
                     raise RuntimeError("Unknown OpenAI response format.")
 

--- a/genai-perf/tests/test_converters/test_huggingface_generate_converter.py
+++ b/genai-perf/tests/test_converters/test_huggingface_generate_converter.py
@@ -39,12 +39,13 @@ from genai_perf.inputs.retrievers.generic_dataset import (
 class TestHuggingFaceGenerateConverter:
 
     def test_convert_default(self):
+        expected_texts = ["Hello world.", "Test prompt."]
         dataset = GenericDataset(
             files_data={
                 "file1": FileData(
                     rows=[
-                        DataRow(texts=["Hello world."]),
-                        DataRow(texts=["Test prompt."]),
+                        DataRow(texts=[expected_texts[0]]),
+                        DataRow(texts=[expected_texts[1]]),
                     ]
                 )
             }
@@ -59,22 +60,26 @@ class TestHuggingFaceGenerateConverter:
         assert isinstance(result, dict)
         assert "data" in result
         assert len(result["data"]) == 2
-        for item in result["data"]:
+        for i, item in enumerate(result["data"]):
             assert "payload" in item
             payload_list = item["payload"]
             assert isinstance(payload_list, list)
             payload = payload_list[0]
             assert "model" in payload
             assert "inputs" in payload
+            assert payload["inputs"] == expected_texts[i]
 
     def test_convert_with_extra_params(self):
         expected_temperature = 0.7
+        expected_max_tokens = 100
+        expected_texts = ["Hello again."]
         dataset = GenericDataset(
             files_data={
                 "file1": FileData(
                     rows=[
                         DataRow(
-                            texts=["Hello again."], optional_data={"max_tokens": 100}
+                            texts=expected_texts,
+                            optional_data={"max_tokens": expected_max_tokens},
                         )
                     ]
                 )
@@ -93,7 +98,9 @@ class TestHuggingFaceGenerateConverter:
         assert payload["model"] == "hf_model"
         assert "inputs" in payload
         assert "parameters" in payload
+        assert payload["inputs"] == expected_texts[0]
         assert payload["temperature"] == expected_temperature
+        assert payload["max_tokens"] == expected_max_tokens
 
     def test_convert_empty_dataset(self):
         dataset = GenericDataset(files_data={})

--- a/genai-perf/tests/test_converters/test_huggingface_generate_converter.py
+++ b/genai-perf/tests/test_converters/test_huggingface_generate_converter.py
@@ -1,0 +1,108 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from genai_perf.config.input.config_command import ConfigCommand
+from genai_perf.inputs.converters.huggingface_generate_converter import (
+    HuggingFaceGenerateConverter,
+)
+from genai_perf.inputs.input_constants import ModelSelectionStrategy, OutputFormat
+from genai_perf.inputs.retrievers.generic_dataset import (
+    DataRow,
+    FileData,
+    GenericDataset,
+)
+
+
+class TestHuggingFaceGenerateConverter:
+
+    def test_convert_default(self):
+        dataset = GenericDataset(
+            files_data={
+                "file1": FileData(
+                    rows=[
+                        DataRow(texts=["Hello world."]),
+                        DataRow(texts=["Test prompt."]),
+                    ]
+                )
+            }
+        )
+        config = ConfigCommand({"model_name": "hf_model"})
+        config.endpoint.model_selection_strategy = ModelSelectionStrategy.ROUND_ROBIN
+        config.endpoint.output_format = OutputFormat.HUGGINGFACE_GENERATE
+
+        converter = HuggingFaceGenerateConverter(config)
+        result = converter.convert(dataset)
+
+        assert isinstance(result, dict)
+        assert "data" in result
+        assert len(result["data"]) == 2
+        for item in result["data"]:
+            assert "payload" in item
+            payload_list = item["payload"]
+            assert isinstance(payload_list, list)
+            payload = payload_list[0]
+            assert "model" in payload
+            assert "inputs" in payload
+
+    def test_convert_with_extra_params(self):
+        expected_temperature = 0.7
+        dataset = GenericDataset(
+            files_data={
+                "file1": FileData(
+                    rows=[
+                        DataRow(
+                            texts=["Hello again."], optional_data={"max_tokens": 100}
+                        )
+                    ]
+                )
+            }
+        )
+        config = ConfigCommand({"model_name": "hf_model"})
+        config.endpoint.model_selection_strategy = ModelSelectionStrategy.ROUND_ROBIN
+        config.endpoint.output_format = OutputFormat.HUGGINGFACE_GENERATE
+        config.input.extra = {"temperature": expected_temperature}
+
+        converter = HuggingFaceGenerateConverter(config)
+        result = converter.convert(dataset)
+
+        payload_list = result["data"][0]["payload"]
+        payload = payload_list[0]
+        assert payload["model"] == "hf_model"
+        assert "inputs" in payload
+        assert "parameters" in payload
+        assert payload["temperature"] == expected_temperature
+
+    def test_convert_empty_dataset(self):
+        dataset = GenericDataset(files_data={})
+
+        config = ConfigCommand({"model_name": "hf_model"})
+        config.endpoint.model_selection_strategy = ModelSelectionStrategy.ROUND_ROBIN
+        config.endpoint.output_format = OutputFormat.HUGGINGFACE_GENERATE
+
+        converter = HuggingFaceGenerateConverter(config)
+        result = converter.convert(dataset)
+
+        assert result == {"data": []}

--- a/genai-perf/tests/test_data_parser/test_llm_profile_data_parser.py
+++ b/genai-perf/tests/test_data_parser/test_llm_profile_data_parser.py
@@ -1379,7 +1379,7 @@ class TestLLMProfileDataParser:
             (
                 ResponseFormat.HUGGINGFACE_GENERATE,
                 '["not a dict"]',
-                "",
+                None,  # Will raise ValueError
             ),
             # HuggingFace dict format (should raise error)
             (
@@ -1535,11 +1535,6 @@ class TestLLMProfileDataParser:
                 "[]",
                 True,
             ),
-            (
-                ResponseFormat.HUGGINGFACE_GENERATE,
-                '["not a dict"]',
-                True,
-            ),
         ],
     )
     @patch("genai_perf.profile_data_parser.profile_data_parser.load_json")
@@ -1653,9 +1648,9 @@ class TestLLMProfileDataParser:
                     "time_to_first_tokens": [2, 2],
                     "time_to_second_tokens": [2, 3],
                     "inter_token_latencies": [2, 2],
-                    "output_token_throughputs_per_request": [
-                        4 / ns_to_sec(7),
-                        5 / ns_to_sec(9),
+                    "output_token_throughputs_per_user": [
+                        1 / ns_to_sec(2),
+                        1 / ns_to_sec(2),
                     ],
                     "output_token_throughputs": [9 / ns_to_sec(10)],
                     "output_sequence_lengths": [4, 5],
@@ -1686,8 +1681,8 @@ class TestLLMProfileDataParser:
             - experiment 1: [((8 - 1) - 2)/(4 - 1), ((11 - 2) - 2)/(5 - 1)]
                           : [5/3, 7/4]
                           : [2, 2]  # rounded
-        * output token throughputs per request
-            - experiment 1: [4/(8 - 1), 5/(11 - 2)] = [4/7, 5/9]
+        * output token throughputs per user
+            - experiment 1: [1 / ns_to_sec(2), 1 / ns_to_sec(2)]
         * output token throughputs
             - experiment 1: [(4 + 5)/(11 - 1)] = [9/10]
         * output sequence lengths


### PR DESCRIPTION
Add support for HuggingFace TGI generate endpoint: https://huggingface.github.io/text-generation-inference/#/Text%20Generation%20Inference/generate

Pending:
- Documentation (a tutorial)

Removal of the service-kind argument will be done in an upcoming PR. Right now, the OpenAI client in Perf Analyzer is used for Hugging Face as well, so that's why the service-kind is OpenAI (plus all the same checks happen). To avoid user confusion, we'll remove service-kind soon and make it detected by GenAI-Perf.

![image](https://github.com/user-attachments/assets/4dd45687-c76e-489b-a090-0dc1e39d97e9)