### PR TITLE
Fix bug in tensorrtllm PA config generation

### DIFF
--- a/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
+++ b/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
@@ -293,6 +293,8 @@ class PerfAnalyzerConfig:
                 protocol_args += ["--shape", "max_tokens:1", "--shape", "text_input:1"]
         elif config.endpoint.service_kind == "openai":
             protocol_args += ["-i", "http"]
+        elif config.endpoint.service_kind == "tensorrtllm_engine":
+            protocol_args += ["--service-kind", "triton_c_api", "--streaming"]
 
         return protocol_args
 
@@ -353,27 +355,6 @@ class PerfAnalyzerConfig:
             endpoint_args += ["--endpoint", f"{config.endpoint.custom}"]
 
         return endpoint_args
-
-    def _add_boolean_arg(self, arg: str) -> List[str]:
-        if len(arg) == 1:
-            return [f"-{arg}"]
-        else:
-            return [f"--{arg}"]
-
-    def _add_non_boolean_arg(self, arg: str, value: Any) -> List[str]:
-        if len(arg) == 1:
-            return [f"-{arg}", f"{value}"]
-        else:
-            converted_arg = convert_option_name(arg)
-            return [f"--{converted_arg}", f"{value}"]
-
-    def _add_tensorrtllm_engine_args(self) -> List[str]:
-        # GAP needs to call PA using triton_c_api service kind when running
-        # against tensorrtllm engine.
-        return ["--service-kind", "triton_c_api", "--streaming"]
-
-    def _arg_is_tensorrtllm_engine(self, arg: str, value: str) -> bool:
-        return arg == "service_kind" and value == "tensorrtllm_engine"
 
     def _add_extra_args(self, extra_args: Optional[List[str]]) -> List[str]:
         if not extra_args:

--- a/genai-perf/tests/test_perf_analyzer_config.py
+++ b/genai-perf/tests/test_perf_analyzer_config.py
@@ -358,6 +358,21 @@ class TestPerfAnalyzerConfig(unittest.TestCase):
 
         self.assertEqual(expected_args, actual_args)
 
+    def test_add_protocol_args_with_tensorrtllm_engine(self):
+        """
+        Test that _add_protocol_args returns the correct arguments
+        when service_kind is 'tensorrtllm_engine'
+        """
+        self._config.endpoint.service_kind = "tensorrtllm_engine"
+
+        expected_args = ["--service-kind", "triton_c_api", "--streaming"]
+
+        actual_args = self._default_perf_analyzer_config._add_protocol_args(
+            self._config
+        )
+
+        self.assertEqual(expected_args, actual_args)
+
     ###########################################################################
     # Test _add_inference_load_args
     ###########################################################################


### PR DESCRIPTION
David found some PA config generation dead code, and after I inspected it I realized I missed a case when converting from args to config. This escaped because we don't have coverage for this in the CI.

I've removed the dead code and added in unit testing to cover this missing case.