### PR TITLE
Fix Triton generate endpoint-type

### DIFF
--- a/genai-perf/genai_perf/config/endpoint_config.py
+++ b/genai-perf/genai_perf/config/endpoint_config.py
@@ -61,7 +61,7 @@ endpoint_type_map = {
         "v1/chat/completions", "openai", OutputFormat.OPENAI_MULTIMODAL
     ),
     "generate": EndpointConfig(
-        "v2/models/{MODEL_NAME}/generate", "triton", OutputFormat.TRITON_GENERATE
+        "v2/models/{MODEL_NAME}/generate", "openai", OutputFormat.TRITON_GENERATE
     ),
     "kserve": EndpointConfig(None, "triton", OutputFormat.TENSORRTLLM),
     "template": EndpointConfig(None, "triton", OutputFormat.TEMPLATE),

--- a/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
+++ b/genai-perf/genai_perf/profile_data_parser/profile_data_parser.py
@@ -115,6 +115,8 @@ class ProfileDataParser:
                     self._response_format = ResponseFormat.IMAGE_RETRIEVAL
                 elif "generated_text" in response:
                     self._response_format = ResponseFormat.HUGGINGFACE_GENERATE
+                elif "/generate" in data["endpoint"]:
+                    self._response_format = ResponseFormat.TRITON_GENERATE
                 else:
                     raise RuntimeError("Unknown OpenAI response format.")
 

--- a/genai-perf/tests/test_config_command.py
+++ b/genai-perf/tests/test_config_command.py
@@ -549,7 +549,7 @@ class TestConfigCommand(unittest.TestCase):
         user_config = yaml.safe_load(yaml_str)
         config = ConfigCommand(user_config)
 
-        self.assertEqual(config.endpoint.service_kind, "triton")
+        self.assertEqual(config.endpoint.service_kind, "openai")
 
     def test_infer_output_format_triton(self):
         """


### PR DESCRIPTION
Fix the Triton generate endpoint. Previously, it stopped working.

These fixes ensure the data format is expected by Perf Analyzer and GAP is able to parse the metrics, as it could before. After the changes, the endpoint works correctly:
![image](https://github.com/user-attachments/assets/7ef33e2d-329a-4596-bad4-ca30eb67c3db)
