### PR TITLE
Add support for fixed schedule warmup

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -291,6 +291,17 @@ duration of execution exceeds the amount of time specified by the intervals.
 This option can not be used with `--request-rate-range` or
 `--concurrency-range`.
 
+#### `--fixed-schedule`
+
+Enables fixed schedule inference load mode. In this mode, Perf Analyzer runs
+through the `--input-data` JSON once. Each entry represents a request and must
+have a `timestamp` "input", which tells Perf Analyzer when to send that request.
+A timestamp of `N` means Perf Analyzer will send that request `N` milliseconds
+after the start of the benchmark.
+
+See [fixed schedule](inference_load_modes.md#fixed-schedule-mode) documentation
+for more info.
+
 #### `--max-threads=<n>`
 
 Specifies the maximum number of threads that will be created for providing

--- a/docs/inference_load_modes.md
+++ b/docs/inference_load_modes.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -98,3 +98,45 @@ where `my_intervals.txt` contains:
 
 Perf Analyzer will attempt to send requests at the following times: 0.1s, 0.3s,
 0.8s, 0.9s, 1.1s, 1.6s, and so on, during profiling.
+
+## Fixed Schedule Mode
+
+In fixed schedule inference load mode, Perf Analyzer runs through the
+[`--input-data`](cli.md#--input-datazerorandompath) JSON once. Each entry
+represents a request and must have a `timestamp` "input", which tells Perf
+Analyzer when to send that request. A timestamp of `N` means Perf Analyzer will
+send that request `N` milliseconds after the start of the benchmark. For
+example:
+
+```json
+# input_data.json
+{
+  "data": [
+    {
+      "payload": [{
+          "model": "facebook/opt-125m",
+          "messages": [{"role": "user","content": "What is the capital of France?"}],
+          "max_completion_tokens": 1
+        }],
+      "timestamp": [1000]
+    },
+    {
+      "payload": [{
+          "model": "facebook/opt-125m",
+          "messages": [{"role": "user","content": "What is 1+1?"}],
+          "max_completion_tokens": 1
+        }],
+      "timestamp": [2000]
+    }
+  ]
+}
+```
+
+Using this `input_data.json` with fixed schedule mode will run a benchmark that
+sends 2 requests total.
+
+The first request gets sent 1000ms after the start of the benchmark with the
+prompt `What is the capital of France?`.
+
+The second request gets sent 2000ms after the start of the benchmark with the
+prompt `What is 1+1?`.

--- a/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
+++ b/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
@@ -246,12 +246,16 @@ class PerfAnalyzerConfig:
     def _add_perf_analyzer_args(self, config: ConfigCommand) -> List[str]:
         perf_analyzer_args = []
 
+        if config.perf_analyzer.warmup_request_count > 0:
+            perf_analyzer_args += [
+                "--warmup-request-count",
+                f"{config.perf_analyzer.warmup_request_count}",
+            ]
+
         if config.input.prompt_source != PromptSource.PAYLOAD:
             perf_analyzer_args += [
                 f"--stability-percentage",
                 f"{config.perf_analyzer.stability_percentage}",
-                f"--warmup-request-count",
-                f"{config.perf_analyzer.warmup_request_count}",
             ]
 
             mode = config.perf_analyzer.measurement.mode
@@ -290,8 +294,6 @@ class PerfAnalyzerConfig:
                 protocol_args += ["--shape", "max_tokens:1", "--shape", "text_input:1"]
         elif config.endpoint.service_kind == "openai":
             protocol_args += ["-i", "http"]
-        elif config.endpoint.service_kind == "tensorrtllm_engine":
-            protocol_args += ["--service-kind", "triton_c_api", "--streaming"]
 
         return protocol_args
 
@@ -346,7 +348,10 @@ class PerfAnalyzerConfig:
 
     def _add_endpoint_args(self, config: ConfigCommand) -> List[str]:
         endpoint_args = []
-        endpoint_args += ["--service-kind", f"{config.endpoint.service_kind}"]
+        if config.endpoint.service_kind == "tensorrtllm_engine":
+            endpoint_args += ["--service-kind", "triton_c_api", "--streaming"]
+        else:
+            endpoint_args += ["--service-kind", f"{config.endpoint.service_kind}"]
 
         if config.endpoint.custom:
             endpoint_args += ["--endpoint", f"{config.endpoint.custom}"]

--- a/genai-perf/genai_perf/config/input/config_command.py
+++ b/genai-perf/genai_perf/config/input/config_command.py
@@ -207,10 +207,6 @@ class ConfigCommand(BaseConfig):
                         f"User Config: perf_analyzer.stimulus: {key} is not supported with the payload input source."
                     )
 
-        if self.perf_analyzer.get_field("warmup_request_count").is_set_by_user:
-            raise ValueError(
-                f"User Config: perf_analyzer.warmup_request_count is not supported with the payload input source."
-            )
         if (
             self.perf_analyzer.measurement.get_field("mode").is_set_by_user
             and self.perf_analyzer.measurement.mode

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
@@ -30,7 +30,7 @@ from genai_perf.config.input.config_defaults import InputDefaults
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.inputs.converters.base_converter import BaseConverter
 from genai_perf.inputs.input_constants import DEFAULT_TENSORRTLLM_MAX_TOKENS
-from genai_perf.inputs.retrievers.generic_dataset import GenericDataset
+from genai_perf.inputs.retrievers.generic_dataset import DataRow, GenericDataset
 from genai_perf.utils import sample_bounded_normal
 
 
@@ -112,3 +112,10 @@ class TensorRTLLMEngineConverter(BaseConverter):
 
     def _construct_default_template(self, prompt: str) -> List[Dict[str, str]]:
         return [{"role": "user", "content": prompt}]
+
+    def _add_payload_optional_data(self, payload: Dict[Any, Any], row: DataRow) -> None:
+        for key, value in row.optional_data.items():
+            if key == "max_tokens":
+                payload["request_output_len"] = [value]
+            else:
+                payload[key] = value

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -1115,10 +1115,6 @@ class TestCLIArguments:
                 ["--request-count", "3"],
                 "User Config: perf_analyzer.measurement.mode of request_count is not supported with the payload input source.",
             ),
-            (
-                ["--warmup-request-count", "7"],
-                "User Config: perf_analyzer.warmup_request_count is not supported with the payload input source.",
-            ),
         ],
     )
     def test_check_payload_input_args_invalid_args(

--- a/genai-perf/tests/test_perf_analyzer_config.py
+++ b/genai-perf/tests/test_perf_analyzer_config.py
@@ -110,8 +110,6 @@ class TestPerfAnalyzerConfig(unittest.TestCase):
             "999",
             "--request-count",
             "128",
-            "--warmup-request-count",
-            "0",
             "--input-data",
             "artifacts/test_model-triton-tensorrtllm-runtime_batch_size1-concurrency64/inputs.json",
             "--profile-export-file",
@@ -144,8 +142,6 @@ class TestPerfAnalyzerConfig(unittest.TestCase):
                 "999",
                 "--request-count",
                 "128",
-                "--warmup-request-count",
-                "0",
                 "--streaming",
                 "--shape",
                 "max_tokens:1",
@@ -300,10 +296,10 @@ class TestPerfAnalyzerConfig(unittest.TestCase):
         self._config.perf_analyzer.warmup_request_count = 30
 
         expected_args = [
-            "--stability-percentage",
-            "567",
             "--warmup-request-count",
             "30",
+            "--stability-percentage",
+            "567",
             "--measurement-interval",
             "5000",
         ]
@@ -350,21 +346,6 @@ class TestPerfAnalyzerConfig(unittest.TestCase):
         self._config.endpoint.service_kind = "openai"
 
         expected_args = ["-i", "http"]
-
-        actual_args = self._default_perf_analyzer_config._add_protocol_args(
-            self._config
-        )
-
-        self.assertEqual(expected_args, actual_args)
-
-    def test_add_protocol_args_with_tensorrtllm_engine(self):
-        """
-        Test that _add_protocol_args returns the correct arguments
-        when service_kind is 'tensorrtllm_engine'
-        """
-        self._config.endpoint.service_kind = "tensorrtllm_engine"
-
-        expected_args = ["--service-kind", "triton_c_api", "--streaming"]
 
         actual_args = self._default_perf_analyzer_config._add_protocol_args(
             self._config
@@ -528,6 +509,21 @@ class TestPerfAnalyzerConfig(unittest.TestCase):
         self._config.endpoint.custom = None
 
         expected_args = ["--service-kind", "triton"]
+
+        actual_args = self._default_perf_analyzer_config._add_endpoint_args(
+            self._config
+        )
+
+        self.assertEqual(expected_args, actual_args)
+
+    def test_add_endpoint_args_with_tensorrtllm_engine_endpoint(self):
+        """
+        Test that _add_endpoint_args returns the correct arguments
+        when tensorrtllm_engine endpoint is set
+        """
+        self._config.endpoint.service_kind = "tensorrtllm_engine"
+
+        expected_args = ["--service-kind", "triton_c_api", "--streaming"]
 
         actual_args = self._default_perf_analyzer_config._add_endpoint_args(
             self._config

--- a/src/custom_request_schedule_manager.cc
+++ b/src/custom_request_schedule_manager.cc
@@ -62,8 +62,7 @@ CustomRequestScheduleManager::CustomRequestScheduleManager(
           params.max_threads, params.num_of_sequences,
           params.shared_memory_type, params.output_shm_size,
           params.serial_sequences, parser, factory, params.request_parameters),
-      warmup_request_count_(params.warmup_request_count),
-      benchmark_request_count_(params.request_count)
+      warmup_request_count_(params.warmup_request_count)
 {
 }
 
@@ -108,12 +107,6 @@ CustomRequestScheduleManager::GetSchedulesFromDataset() const
   if (warmup_request_count_ >= dataset_size) {
     throw std::runtime_error(
         "Expected warmup request count to be less than the dataset size.");
-  }
-
-  if (dataset_size != warmup_request_count_ + benchmark_request_count_) {
-    throw std::runtime_error(
-        "Expected input data JSON size to be equal to the warmup request count "
-        "plus the benchmark request count.");
   }
 
   for (size_t dataset_index{0}; dataset_index < warmup_request_count_;

--- a/src/custom_request_schedule_manager.h
+++ b/src/custom_request_schedule_manager.h
@@ -93,7 +93,6 @@ class CustomRequestScheduleManager : public RequestRateManager {
   void InitCustomSchedule(const Schedule& schedule, size_t dataset_offset = 0);
 
   /// Creates worker schedules based on the provided schedule
-  /// \param duration The maximum duration for the schedule
   /// \param schedule The vector containing the schedule for requests
   /// \return A vector of RateSchedulePtr_t representing the worker schedules
   std::vector<RateSchedulePtr_t> CreateWorkerSchedules(
@@ -102,7 +101,6 @@ class CustomRequestScheduleManager : public RequestRateManager {
   void StartBenchmark();
 
   const size_t warmup_request_count_{0};
-  const size_t benchmark_request_count_{0};
   Schedule warmup_schedule_{};
   Schedule benchmark_schedule_{};
 };

--- a/src/infer_context.cc
+++ b/src/infer_context.cc
@@ -104,6 +104,12 @@ InferContext::CompleteOngoingSequence(uint32_t seq_stat_index)
 }
 
 void
+InferContext::ApplyDatasetOffset(size_t dataset_offset)
+{
+  data_step_id_ += dataset_offset;
+}
+
+void
 InferContext::SendRequest(
     const uint64_t request_id, const bool delayed, const uint64_t sequence_id)
 {

--- a/src/infer_context.h
+++ b/src/infer_context.h
@@ -115,6 +115,8 @@ class InferContext {
     num_active_threads_ = num_threads;
   }
 
+  void ApplyDatasetOffset(size_t dataset_offset);
+
   bool HasReceivedFinalResponse() { return has_received_final_response_; }
 
  protected:

--- a/src/inference_profiler.cc
+++ b/src/inference_profiler.cc
@@ -618,12 +618,12 @@ InferenceProfiler::Profile(
   auto* custom_manager =
       dynamic_cast<CustomRequestScheduleManager*>(manager_.get());
   if (custom_manager) {
-    RETURN_IF_ERROR(custom_manager->InitCustomSchedule(request_count));
+    custom_manager->Start();
   } else {
     auto* request_rate_manager =
         dynamic_cast<RequestRateManager*>(manager_.get());
-    RETURN_IF_ERROR(
-        request_rate_manager->PerformWarmup(request_rate, request_count));
+    RETURN_IF_ERROR(request_rate_manager->PerformWarmup(
+        request_rate, warmup_request_count));
     std::cout << "Request Rate: " << request_rate
               << " inference requests per second" << std::endl;
     RETURN_IF_ERROR(

--- a/src/mock_request_rate_worker.h
+++ b/src/mock_request_rate_worker.h
@@ -1,4 +1,4 @@
-// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -46,12 +46,13 @@ class NaggyMockRequestRateWorker : public RequestRateWorker {
       std::chrono::steady_clock::time_point& start_time,
       const bool serial_sequences,
       const std::shared_ptr<IInferDataManager>& infer_data_manager,
-      std::shared_ptr<SequenceManager> sequence_manager)
+      std::shared_ptr<SequenceManager> sequence_manager, size_t dataset_offset)
       : RequestRateWorker(
             id, thread_stat, thread_config, parser, data_loader, factory,
             on_sequence_model, async, max_threads, using_json_data, streaming,
             batch_size, wake_signal, wake_mutex, execute, start_time,
-            serial_sequences, infer_data_manager, sequence_manager)
+            serial_sequences, infer_data_manager, sequence_manager,
+            dataset_offset)
   {
     ON_CALL(*this, Infer()).WillByDefault([this]() -> void {
       RequestRateWorker::Infer();

--- a/src/model_parser.h
+++ b/src/model_parser.h
@@ -68,15 +68,8 @@ class ModelParser {
     ENSEMBLE_SEQUENCE
   };
 
-  explicit ModelParser()
-      : inputs_(std::make_shared<ModelTensorMap>()),
-        outputs_(std::make_shared<ModelTensorMap>()),
-        composing_models_map_(std::make_shared<ComposingModelMap>()),
-        scheduler_type_(NONE), max_batch_size_(0), is_decoupled_(false),
-        response_cache_enabled_(false),
-        top_level_response_caching_enabled_(false)
-  {
-  }
+  explicit ModelParser(
+      InferenceLoadMode inference_load_mode = InferenceLoadMode::None);
 
   /// Initializes the ModelParser with the metadata and config rapidjson DOM
   /// for the target model obtained from Triton service
@@ -118,7 +111,7 @@ class ModelParser {
 
   cb::Error InitOpenAI(
       const std::string& model_name, const std::string& model_version,
-      const int32_t batch_size, InferenceLoadMode inference_load_mode);
+      const int32_t batch_size);
 
   cb::Error InitTorchServe(
       const std::string& model_name, const std::string& model_version,

--- a/src/perf_analyzer.cc
+++ b/src/perf_analyzer.cc
@@ -93,7 +93,7 @@ PerfAnalyzer::CreateAnalyzerObjects()
       factory->CreateClientBackend(&backend_),
       "failed to create triton client backend");
 
-  parser_ = std::make_shared<pa::ModelParser>();
+  parser_ = std::make_shared<pa::ModelParser>(params_->inference_load_mode);
   if (params_->kind == cb::BackendKind::TRITON ||
       params_->kind == cb::BackendKind::TRITON_C_API) {
     rapidjson::Document model_metadata;
@@ -120,8 +120,7 @@ PerfAnalyzer::CreateAnalyzerObjects()
   } else if (params_->kind == cb::BackendKind::OPENAI) {
     FAIL_IF_ERR(
         parser_->InitOpenAI(
-            params_->model_name, params_->model_version, params_->batch_size,
-            params_->inference_load_mode),
+            params_->model_name, params_->model_version, params_->batch_size),
         "failed to create model parser");
   } else if (params_->kind == cb::BackendKind::TENSORFLOW_SERVING) {
     rapidjson::Document model_metadata;

--- a/src/request_rate_manager.cc
+++ b/src/request_rate_manager.cc
@@ -240,7 +240,8 @@ RequestRateManager::PauseWorkers()
 }
 
 void
-RequestRateManager::ConfigureThreads(const size_t request_count)
+RequestRateManager::ConfigureThreads(
+    const size_t request_count, size_t dataset_offset)
 {
   if (threads_.empty()) {
     size_t num_of_threads = DetermineNumThreads();
@@ -249,8 +250,8 @@ RequestRateManager::ConfigureThreads(const size_t request_count)
       threads_stat_.emplace_back(new ThreadStat());
       threads_config_.emplace_back(new ThreadConfig(workers_.size()));
 
-      workers_.push_back(
-          MakeWorker(threads_stat_.back(), threads_config_.back()));
+      workers_.push_back(MakeWorker(
+          threads_stat_.back(), threads_config_.back(), dataset_offset));
     }
     // Compute the number of sequences for each thread (take floor)
     // and spread the remaining value
@@ -293,7 +294,7 @@ RequestRateManager::ResumeWorkers()
 std::shared_ptr<IWorker>
 RequestRateManager::MakeWorker(
     std::shared_ptr<ThreadStat> thread_stat,
-    std::shared_ptr<ThreadConfig> thread_config)
+    std::shared_ptr<ThreadConfig> thread_config, size_t dataset_offset)
 {
   size_t id = workers_.size();
   size_t num_of_threads = DetermineNumThreads();
@@ -301,7 +302,8 @@ RequestRateManager::MakeWorker(
       id, thread_stat, thread_config, parser_, data_loader_, factory_,
       on_sequence_model_, async_, num_of_threads, using_json_data_, streaming_,
       batch_size_, wake_signal_, wake_mutex_, execute_, start_time_,
-      serial_sequences_, infer_data_manager_, sequence_manager_);
+      serial_sequences_, infer_data_manager_, sequence_manager_,
+      dataset_offset);
 }
 
 size_t

--- a/src/request_rate_manager.h
+++ b/src/request_rate_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -150,14 +150,16 @@ class RequestRateManager : public LoadManager {
   // Pauses the worker threads
   void PauseWorkers();
 
-  void ConfigureThreads(const size_t request_count = 0);
+  void ConfigureThreads(
+      const size_t request_count = 0, size_t dataset_offset = 0);
 
   // Resets the counters and resumes the worker threads
   void ResumeWorkers();
 
   // Makes a new worker
   virtual std::shared_ptr<IWorker> MakeWorker(
-      std::shared_ptr<ThreadStat>, std::shared_ptr<ThreadConfig>);
+      std::shared_ptr<ThreadStat>, std::shared_ptr<ThreadConfig>,
+      size_t dataset_offset = 0);
 
   size_t DetermineNumThreads();
 

--- a/src/request_rate_worker.h
+++ b/src/request_rate_worker.h
@@ -66,14 +66,14 @@ class RequestRateWorker : public LoadWorker, public IScheduler {
       std::chrono::steady_clock::time_point& start_time,
       const bool serial_sequences,
       const std::shared_ptr<IInferDataManager>& infer_data_manager,
-      std::shared_ptr<SequenceManager> sequence_manager)
+      std::shared_ptr<SequenceManager> sequence_manager, size_t dataset_offset)
       : LoadWorker(
             id, thread_stat, thread_config, parser, data_loader, factory,
             on_sequence_model, async, streaming, batch_size, using_json_data,
             wake_signal, wake_mutex, execute, infer_data_manager,
             sequence_manager),
         num_threads_(num_threads), start_time_(start_time),
-        serial_sequences_(serial_sequences)
+        serial_sequences_(serial_sequences), dataset_offset_(dataset_offset)
   {
   }
 
@@ -114,9 +114,13 @@ class RequestRateWorker : public LoadWorker, public IScheduler {
         std::placeholders::_1));
 
     ctx->SetNumActiveThreads(num_threads_);
+
+    ctx->ApplyDatasetOffset(dataset_offset_);
   }
 
   const std::chrono::milliseconds delay_tolerance_{1};
+
+  const size_t dataset_offset_{0};
 
 #ifndef DOCTEST_CONFIG_DISABLE
   friend NaggyMockRequestRateWorker;

--- a/src/test_command_line_parser.cc
+++ b/src/test_command_line_parser.cc
@@ -1575,6 +1575,18 @@ TEST_CASE("Testing Command Line Parser")
           PerfAnalyzerException);
       check_params = false;
     }
+    SUBCASE("zero value")
+    {
+      int argc = 5;
+      char* argv[argc] = {app_name, "-m", model_name, "--request-count", "0"};
+
+      expected_msg =
+          CreateUsageMessage("--request-count", "The value must be > 0.");
+      CHECK_THROWS_WITH_AS(
+          act = parser.Parse(argc, argv), expected_msg.c_str(),
+          PerfAnalyzerException);
+      check_params = false;
+    }
     SUBCASE("less than request rate")
     {
       int argc = 7;

--- a/src/test_command_line_parser.cc
+++ b/src/test_command_line_parser.cc
@@ -1657,40 +1657,6 @@ TEST_CASE("Testing Command Line Parser")
       exp->measurement_mode = MeasurementMode::COUNT_WINDOWS;
       exp->measurement_request_count = 2000;
     }
-    SUBCASE("zero value (no override to measurement mode)")
-    {
-      int argc = 7;
-      char* argv[argc] = {app_name,          "-m", model_name,
-                          "--request-count", "0",  "--measurement-mode",
-                          "time_windows"};
-
-      REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
-      CHECK(!parser.UsageCalled());
-
-      exp->request_count = 0;
-      exp->measurement_mode = MeasurementMode::TIME_WINDOWS;
-    }
-    SUBCASE("zero value (no override to measurement request count)")
-    {
-      int argc = 9;
-      char* argv[argc] = {
-          app_name,
-          "-m",
-          model_name,
-          "--request-count",
-          "0",
-          "--measurement-mode",
-          "count_windows",
-          "--measurement-request-count",
-          "50"};
-
-      REQUIRE_NOTHROW(act = parser.Parse(argc, argv));
-      CHECK(!parser.UsageCalled());
-
-      exp->request_count = 0;
-      exp->measurement_mode = MeasurementMode::COUNT_WINDOWS;
-      exp->measurement_request_count = 50;
-    }
   }
 
   SUBCASE("Option : --warmup-request-count")

--- a/src/test_custom_load_manager.cc
+++ b/src/test_custom_load_manager.cc
@@ -1,4 +1,4 @@
-// Copyright 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -70,14 +70,16 @@ class TestCustomLoadManager : public TestLoadManagerBase,
 
   std::shared_ptr<IWorker> MakeWorker(
       std::shared_ptr<ThreadStat> thread_stat,
-      std::shared_ptr<ThreadConfig> thread_config) override
+      std::shared_ptr<ThreadConfig> thread_config,
+      size_t dataset_offset = 0) override
   {
     size_t id = workers_.size();
     auto worker = std::make_shared<MockRequestRateWorker>(
         id, thread_stat, thread_config, parser_, data_loader_, factory_,
         on_sequence_model_, async_, max_threads_, using_json_data_, streaming_,
         batch_size_, wake_signal_, wake_mutex_, execute_, start_time_,
-        serial_sequences_, infer_data_manager_, sequence_manager_);
+        serial_sequences_, infer_data_manager_, sequence_manager_,
+        dataset_offset);
 
     if (use_mock_infer_) {
       EXPECT_CALL(*worker, Infer())

--- a/src/test_custom_request_schedule_manager.cc
+++ b/src/test_custom_request_schedule_manager.cc
@@ -46,15 +46,15 @@ class TestCustomRequestScheduleManager : public TestLoadManagerBase,
 
   void TestSchedule(const std::vector<std::chrono::milliseconds> schedule)
   {
-    schedule_ = schedule;
-    int request_count = schedule_.size();
+    const size_t request_count = schedule.size();
+    max_threads_ = std::min(max_threads_, request_count);
     PauseWorkers();
     ConfigureThreads(request_count);
-    GenerateSchedule();
+    DistributeScheduleToWorkers(schedule);
 
     std::vector<std::chrono::nanoseconds> expected_timestamps{};
 
-    for (const auto& timestamp_ms : schedule_) {
+    for (const auto& timestamp_ms : schedule) {
       const auto timestamp{
           std::chrono::duration_cast<std::chrono::nanoseconds>(timestamp_ms)};
       expected_timestamps.push_back(timestamp);

--- a/src/test_model_parser.cc
+++ b/src/test_model_parser.cc
@@ -180,8 +180,7 @@ TEST_CASE("ModelParser: test Init* functions")
 
   SUBCASE("InitOpenAI")
   {
-    status = mmp.InitOpenAI(
-        model_name, model_version, batch_size, InferenceLoadMode::Concurrency);
+    status = mmp.InitOpenAI(model_name, model_version, batch_size);
     expected_input_names.push_back("payload");
     expected_output_names.push_back("response");
   }

--- a/src/test_request_rate_manager.cc
+++ b/src/test_request_rate_manager.cc
@@ -68,14 +68,16 @@ class TestRequestRateManager : public TestLoadManagerBase,
 
   std::shared_ptr<IWorker> MakeWorker(
       std::shared_ptr<ThreadStat> thread_stat,
-      std::shared_ptr<ThreadConfig> thread_config) override
+      std::shared_ptr<ThreadConfig> thread_config,
+      size_t dataset_offset = 0) override
   {
     size_t id = workers_.size();
     auto worker = std::make_shared<MockRequestRateWorker>(
         id, thread_stat, thread_config, parser_, data_loader_, factory_,
         on_sequence_model_, async_, max_threads_, using_json_data_, streaming_,
         batch_size_, wake_signal_, wake_mutex_, execute_, start_time_,
-        serial_sequences_, infer_data_manager_, sequence_manager_);
+        serial_sequences_, infer_data_manager_, sequence_manager_,
+        dataset_offset);
 
     if (use_mock_infer_) {
       EXPECT_CALL(*worker, Infer())


### PR DESCRIPTION
Previously, someone would run PA fixed schedule mode like this:

```bash
perf_analyzer \
  --fixed-schedule \
  --input-data=input_data.json \
  -m facebook/opt-125m \
  --service-kind=openai \
  --endpoint=v1/chat/completions \
  --async
```

with an `input_data.json` like this:

```json
{
  "data": [
    {
      "payload": [{
          "model": "facebook/opt-125m",
          "messages": [{"role": "user","content": "my_prompt_1"}],
          "max_completion_tokens": 1
        }],
      "timestamp": [1000]
    },
    {
      "payload": [{
          "model": "facebook/opt-125m",
          "messages": [{"role": "user","content": "my_prompt_2"}],
          "max_completion_tokens": 1
        }],
      "timestamp": [2000]
    }
  ]
}
```

But they wouldn't be able to use the warmup feature ([`--warmup-request-count`](https://github.com/triton-inference-server/perf_analyzer/blob/main/docs/cli.md#--warmup-request-countn)).

Now, with this PR, users can use the warmup feature with the fixed schedule feature:

```bash
perf_analyzer \
  --fixed-schedule \
  --warmup-request-count=1 \
  --input-data=input_data.json \
  -m facebook/opt-125m \
  --service-kind=openai \
  --endpoint=v1/chat/completions \
  --async
```

Basically, if `--warmup-request-count=N`, the first `N` payloads in `input_data.json` are sent as "warmup" requests (i.e. excluded from the final performance metric/statistic calculations and profile export JSON), and the rest are part of the standard benchmark.