### PR TITLE
fix ruff linter errors

### DIFF
--- a/genai-perf/genai_perf/config/generate/genai_perf_config.py
+++ b/genai-perf/genai_perf/config/generate/genai_perf_config.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import Namespace
 from copy import deepcopy
 from dataclasses import dataclass
 

--- a/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
+++ b/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
@@ -16,7 +16,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from genai_perf.config.generate.search_parameter import SearchUsage
 from genai_perf.config.input.config_command import ConfigCommand
@@ -137,9 +137,9 @@ class PerfAnalyzerConfig:
     ###########################################################################
     def _get_artifact_paths(self) -> List[str]:
         artifact_paths = [
-            f"--input-data",
+            "--input-data",
             f"{self._artifact_directory / DEFAULT_INPUT_DATA_JSON}",
-            f"--profile-export-file",
+            "--profile-export-file",
             f"{self._profile_export_file}",
         ]
 
@@ -195,7 +195,7 @@ class PerfAnalyzerConfig:
     ) -> Optional[List[str]]:
         if (
             config.input.prompt_source == PromptSource.PAYLOAD
-            and not "session_concurrency" in config.perf_analyzer.stimulus
+            and "session_concurrency" not in config.perf_analyzer.stimulus
         ):
             stimulus = None
         elif "concurrency" in config.perf_analyzer.stimulus:
@@ -208,7 +208,7 @@ class PerfAnalyzerConfig:
             session_concurrency = config.perf_analyzer.stimulus["session_concurrency"]
             stimulus = [f"session_concurrency{session_concurrency}"]
         else:
-            raise GenAIPerfException(f"Stimulus type not found in config")
+            raise GenAIPerfException("Stimulus type not found in config")
 
         return stimulus
 
@@ -239,7 +239,7 @@ class PerfAnalyzerConfig:
         required_args = [f"{config.perf_analyzer.path}"]
 
         if config.endpoint.service_kind != "dynamic_grpc":
-            required_args += [f"-m", f"{config.model_names[0]}", f"--async"]
+            required_args += ["-m", f"{config.model_names[0]}", "--async"]
 
         return required_args
 
@@ -248,9 +248,9 @@ class PerfAnalyzerConfig:
 
         if config.input.prompt_source != PromptSource.PAYLOAD:
             perf_analyzer_args += [
-                f"--stability-percentage",
+                "--stability-percentage",
                 f"{config.perf_analyzer.stability_percentage}",
-                f"--warmup-request-count",
+                "--warmup-request-count",
                 f"{config.perf_analyzer.warmup_request_count}",
             ]
 
@@ -262,7 +262,7 @@ class PerfAnalyzerConfig:
                 ]
             elif mode == PerfAnalyzerMeasurementMode.INTERVAL:
                 perf_analyzer_args += [
-                    f"--measurement-interval",
+                    "--measurement-interval",
                     f"{config.perf_analyzer.measurement.num}",
                 ]
 
@@ -338,7 +338,7 @@ class PerfAnalyzerConfig:
         prompt_source_args = []
         if (
             config.input.prompt_source == PromptSource.PAYLOAD
-            and not "session_concurrency" in config.perf_analyzer.stimulus
+            and "session_concurrency" not in config.perf_analyzer.stimulus
         ):
             prompt_source_args += ["--fixed-schedule"]
 

--- a/genai-perf/genai_perf/config/generate/search_parameters.py
+++ b/genai-perf/genai_perf/config/generate/search_parameters.py
@@ -264,13 +264,13 @@ class SearchParameters:
         else:
             if min_range is None or max_range is None:
                 raise GenAIPerfException(
-                    f"Both min_range and max_range must be specified"
+                    "Both min_range and max_range must be specified"
                 )
 
             if min_range and max_range:
                 if min_range > max_range:
                     raise GenAIPerfException(
-                        f"min_range cannot be larger than max_range"
+                        "min_range cannot be larger than max_range"
                     )
 
     def _check_for_illegal_list_input(
@@ -281,13 +281,13 @@ class SearchParameters:
     ) -> None:
         if not enumerated_list:
             raise GenAIPerfException(
-                f"enumerated_list must be specified for a SearchCategory.LIST"
+                "enumerated_list must be specified for a SearchCategory.LIST"
             )
         elif min_range is not None:
             raise GenAIPerfException(
-                f"min_range cannot be specified for a SearchCategory.LIST"
+                "min_range cannot be specified for a SearchCategory.LIST"
             )
         elif max_range is not None:
             raise GenAIPerfException(
-                f"max_range cannot be specified for a SearchCategory.LIST"
+                "max_range cannot be specified for a SearchCategory.LIST"
             )

--- a/genai-perf/genai_perf/config/input/base_config.py
+++ b/genai-perf/genai_perf/config/input/base_config.py
@@ -196,7 +196,7 @@ class BaseConfig:
         elif name in self._children:
             return self._children[name]
         else:
-            if not name in self._fields:
+            if name not in self._fields:
                 raise AttributeError(f"{name} not found in ConfigFields")
 
             if self._fields[name].is_set_by_user:

--- a/genai-perf/genai_perf/config/input/config_command.py
+++ b/genai-perf/genai_perf/config/input/config_command.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -209,7 +208,7 @@ class ConfigCommand(BaseConfig):
 
         if self.perf_analyzer.get_field("warmup_request_count").is_set_by_user:
             raise ValueError(
-                f"User Config: perf_analyzer.warmup_request_count is not supported with the payload input source."
+                "User Config: perf_analyzer.warmup_request_count is not supported with the payload input source."
             )
         if (
             self.perf_analyzer.measurement.get_field("mode").is_set_by_user
@@ -217,7 +216,7 @@ class ConfigCommand(BaseConfig):
             == PerfAnalyzerMeasurementMode.REQUEST_COUNT
         ):
             raise ValueError(
-                f"User Config: perf_analyzer.measurement.mode of request_count is not supported with the payload input source."
+                "User Config: perf_analyzer.measurement.mode of request_count is not supported with the payload input source."
             )
 
     ###########################################################################

--- a/genai-perf/genai_perf/config/input/config_endpoint.py
+++ b/genai-perf/genai_perf/config/input/config_endpoint.py
@@ -219,5 +219,5 @@ class ConfigEndPoint(BaseConfig):
                 return
             else:
                 raise ValueError(
-                    f"The backend should only be used with the following combination: 'service_kind: triton' & 'type: kserve'"
+                    "The backend should only be used with the following combination: 'service_kind: triton' & 'type: kserve'"
                 )

--- a/genai-perf/genai_perf/export_data/exporter_config.py
+++ b/genai-perf/genai_perf/export_data/exporter_config.py
@@ -25,9 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import argparse as args
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any, Dict
 
 from genai_perf.config.generate.perf_analyzer_config import PerfAnalyzerConfig

--- a/genai-perf/genai_perf/export_data/json_exporter.py
+++ b/genai-perf/genai_perf/export_data/json_exporter.py
@@ -27,7 +27,6 @@
 
 import json
 import os
-from enum import Enum
 from typing import Dict, Union
 
 import genai_perf.logging as logging

--- a/genai-perf/genai_perf/goodput_calculator/llm_goodput_calculator.py
+++ b/genai-perf/genai_perf/goodput_calculator/llm_goodput_calculator.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 import genai_perf.logging as logging
 from genai_perf.goodput_calculator.goodput_calculator import GoodputCalculator

--- a/genai-perf/genai_perf/inputs/converters/dynamic_grpc_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/dynamic_grpc_converter.py
@@ -41,7 +41,7 @@ class DynamicGRPCConverter(BaseConverter):
             )
         if self.config.input.file == "":
             raise GenAIPerfException(
-                f"The dynamic GRPC converter only supports the input file path."
+                "The dynamic GRPC converter only supports the input file path."
             )
 
     def convert(

--- a/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/tensorrtllm_engine_converter.py
@@ -101,7 +101,6 @@ class TensorRTLLMEngineConverter(BaseConverter):
         """
         Apply the default TRT-LLM engine chat template to the prompt
         """
-        import jinja2
 
         default_template = self._construct_default_template(prompt)
         return self.tokenizer.encode(

--- a/genai-perf/genai_perf/inputs/input_constants.py
+++ b/genai-perf/genai_perf/inputs/input_constants.py
@@ -24,7 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from enum import Enum, auto
+from enum import Enum
 
 
 class Subcommand(Enum):

--- a/genai-perf/genai_perf/inputs/retrievers/synthetic_audio_generator.py
+++ b/genai-perf/genai_perf/inputs/retrievers/synthetic_audio_generator.py
@@ -26,8 +26,6 @@
 
 import base64
 import io
-from enum import Enum, auto
-from typing import List
 
 import numpy as np
 import soundfile as sf

--- a/genai-perf/genai_perf/inputs/retrievers/synthetic_image_generator.py
+++ b/genai-perf/genai_perf/inputs/retrievers/synthetic_image_generator.py
@@ -26,7 +26,6 @@
 
 import glob
 import random
-from enum import Enum, auto
 from pathlib import Path
 from typing import Optional
 

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -26,7 +26,6 @@
 
 import argparse
 import sys
-from enum import Enum, auto
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -53,11 +52,11 @@ def _parse_goodput(values):
             constraints[target_metric] = float(target_val)
     except ValueError:
         raise argparse.ArgumentTypeError(
-            f"Invalid format found for goodput constraints. "
-            f"The expected format is 'key:value' pairs. The key should be a "
-            f"service level objective name (e.g. request_latency). The value "
-            f"should be a number representing either milliseconds "
-            f"or a throughput value per second."
+            "Invalid format found for goodput constraints. "
+            "The expected format is 'key:value' pairs. The key should be a "
+            "service level objective name (e.g. request_latency). The value "
+            "should be a number representing either milliseconds "
+            "or a throughput value per second."
         )
     return constraints
 
@@ -194,17 +193,17 @@ def _add_analyze_args(parser):
             "input_sequence_length",
             "request_rate",
         ],
-        help=f"The stimulus type that GAP will sweep.",
+        help="The stimulus type that GAP will sweep.",
     )
     analyze_group.add_argument(
         "--sweep-range",
         type=str,
-        help=f"The range the stimulus will be swept. Represented as 'min:max' or 'min:max:step'.",
+        help="The range the stimulus will be swept. Represented as 'min:max' or 'min:max:step'.",
     )
     analyze_group.add_argument(
         "--sweep-list",
         type=str,
-        help=f"A comma-separated list of values that stimulus will be swept over.",
+        help="A comma-separated list of values that stimulus will be swept over.",
     )
 
 
@@ -214,13 +213,13 @@ def _add_audio_input_args(parser):
     input_group.add_argument(
         "--audio-length-mean",
         type=float,
-        help=f"The mean length of audio data in seconds. Default is 10 seconds.",
+        help="The mean length of audio data in seconds. Default is 10 seconds.",
     )
 
     input_group.add_argument(
         "--audio-length-stddev",
         type=float,
-        help=f"The standard deviation of the length of audio data in seconds. "
+        help="The standard deviation of the length of audio data in seconds. "
         "Default is 0.",
     )
 
@@ -228,7 +227,7 @@ def _add_audio_input_args(parser):
         "--audio-format",
         type=str,
         choices=utils.get_enum_names(ic.AudioFormat),
-        help=f"The format of the audio data. Currently we support wav and "
+        help="The format of the audio data. Currently we support wav and "
         "mp3 format. Default is 'wav'.",
     )
 
@@ -236,7 +235,7 @@ def _add_audio_input_args(parser):
         "--audio-depths",
         type=int,
         nargs="*",
-        help=f"A list of audio bit depths to randomly select from in bits. "
+        help="A list of audio bit depths to randomly select from in bits. "
         "Default is [16].",
     )
 
@@ -244,7 +243,7 @@ def _add_audio_input_args(parser):
         "--audio-sample-rates",
         type=float,
         nargs="*",
-        help=f"A list of audio sample rates to randomly select from in kHz. "
+        help="A list of audio sample rates to randomly select from in kHz. "
         "Default is [16].",
     )
 
@@ -252,7 +251,7 @@ def _add_audio_input_args(parser):
         "--audio-num-channels",
         type=int,
         choices=[1, 2],
-        help=f"The number of audio channels to use for the audio data generation. "
+        help="The number of audio channels to use for the audio data generation. "
         "Currently only 1 (mono) and 2 (stereo) are supported. "
         "Default is 1 (mono channel).",
     )
@@ -294,13 +293,13 @@ def _add_endpoint_args(parser):
         "-m",
         "--model",
         nargs="+",
-        help=f"The name of the model(s) to benchmark.",
+        help="The name of the model(s) to benchmark.",
     )
     endpoint_group.add_argument(
         "--model-selection-strategy",
         type=str,
         choices=utils.get_enum_names(ic.ModelSelectionStrategy),
-        help=f"When multiple model are specified, this is how a specific model "
+        help="When multiple model are specified, this is how a specific model "
         "should be assigned to a prompt.  round_robin means that ith prompt in the "
         "list gets assigned to i mod len(models).  random means that assignment is "
         "uniformly random",
@@ -310,20 +309,20 @@ def _add_endpoint_args(parser):
         "--backend",
         type=str,
         choices=utils.get_enum_names(ic.OutputFormat)[0:2],
-        help=f"When benchmarking Triton, this is the backend of the model. ",
+        help="When benchmarking Triton, this is the backend of the model. ",
     )
 
     endpoint_group.add_argument(
         "--endpoint",
         type=str,
-        help=f"Set a custom endpoint that differs from the OpenAI defaults.",
+        help="Set a custom endpoint that differs from the OpenAI defaults.",
     )
 
     endpoint_group.add_argument(
         "--endpoint-type",
         type=str,
         choices=list(endpoint_type_map.keys()),
-        help=f"The endpoint-type to send requests to on the server.",
+        help="The endpoint-type to send requests to on the server.",
     )
 
     endpoint_group.add_argument(
@@ -340,7 +339,7 @@ def _add_endpoint_args(parser):
     endpoint_group.add_argument(
         "--streaming",
         action="store_true",
-        help=f"An option to enable the use of the streaming API.",
+        help="An option to enable the use of the streaming API.",
     )
 
     endpoint_group.add_argument(
@@ -359,32 +358,32 @@ def _add_image_input_args(parser):
     input_group.add_argument(
         "--image-width-mean",
         type=int,
-        help=f"The mean width of images when generating synthetic image data.",
+        help="The mean width of images when generating synthetic image data.",
     )
 
     input_group.add_argument(
         "--image-width-stddev",
         type=int,
-        help=f"The standard deviation of width of images when generating synthetic image data.",
+        help="The standard deviation of width of images when generating synthetic image data.",
     )
 
     input_group.add_argument(
         "--image-height-mean",
         type=int,
-        help=f"The mean height of images when generating synthetic image data.",
+        help="The mean height of images when generating synthetic image data.",
     )
 
     input_group.add_argument(
         "--image-height-stddev",
         type=int,
-        help=f"The standard deviation of height of images when generating synthetic image data.",
+        help="The standard deviation of height of images when generating synthetic image data.",
     )
 
     input_group.add_argument(
         "--image-format",
         type=str,
         choices=utils.get_enum_names(ic.ImageFormat),
-        help=f"The compression format of the images. "
+        help="The compression format of the images. "
         "If format is not selected, format of generated image is selected at random",
     )
 
@@ -395,14 +394,14 @@ def _add_input_args(parser):
     input_group.add_argument(
         "--batch-size-audio",
         type=int,
-        help=f"The audio batch size of the requests GenAI-Perf should send. "
+        help="The audio batch size of the requests GenAI-Perf should send. "
         "This is currently supported with the OpenAI `multimodal` endpoint type.",
     )
 
     input_group.add_argument(
         "--batch-size-image",
         type=int,
-        help=f"The image batch size of the requests GenAI-Perf should send. "
+        help="The image batch size of the requests GenAI-Perf should send. "
         "This is currently supported with the image retrieval endpoint type.",
     )
 
@@ -411,7 +410,7 @@ def _add_input_args(parser):
         "--batch-size",
         "-b",
         type=int,
-        help=f"The text batch size of the requests GenAI-Perf should send. "
+        help="The text batch size of the requests GenAI-Perf should send. "
         "This is currently supported with the embeddings and rankings "
         "endpoint types.",
     )
@@ -467,14 +466,14 @@ def _add_input_args(parser):
         "--num-dataset-entries",
         "--num-prompts",
         type=positive_integer,
-        help=f"The number of unique payloads to sample from. "
+        help="The number of unique payloads to sample from. "
         "These will be reused until benchmarking is complete.",
     )
 
     input_group.add_argument(
         "--num-prefix-prompts",
         type=int,
-        help=f"The number of prefix prompts to select from. "
+        help="The number of prefix prompts to select from. "
         "If this value is not zero, these are prompts that are "
         "prepended to input prompts. This is useful for "
         "benchmarking models that use a K-V cache.",
@@ -484,14 +483,14 @@ def _add_input_args(parser):
         "--output-tokens-mean",
         "--osl",
         type=int,
-        help=f"The mean number of tokens in each output. "
+        help="The mean number of tokens in each output. "
         "Ensure the --tokenizer value is set correctly. ",
     )
 
     input_group.add_argument(
         "--output-tokens-mean-deterministic",
         action="store_true",
-        help=f"When using --output-tokens-mean, this flag can be set to "
+        help="When using --output-tokens-mean, this flag can be set to "
         "improve precision by setting the minimum number of tokens "
         "equal to the requested number of tokens. This is currently "
         "supported with Triton. "
@@ -503,7 +502,7 @@ def _add_input_args(parser):
     input_group.add_argument(
         "--output-tokens-stddev",
         type=int,
-        help=f"The standard deviation of the number of tokens in each output. "
+        help="The standard deviation of the number of tokens in each output. "
         "This is only used when --output-tokens-mean is provided.",
     )
 
@@ -527,19 +526,19 @@ def _add_input_args(parser):
         "--synthetic-input-tokens-mean",
         "--isl",
         type=int,
-        help=f"The mean of number of tokens in the generated prompts when using synthetic data.",
+        help="The mean of number of tokens in the generated prompts when using synthetic data.",
     )
 
     input_group.add_argument(
         "--synthetic-input-tokens-stddev",
         type=int,
-        help=f"The standard deviation of number of tokens in the generated prompts when using synthetic data.",
+        help="The standard deviation of number of tokens in the generated prompts when using synthetic data.",
     )
 
     input_group.add_argument(
         "--prefix-prompt-length",
         type=int,
-        help=f"The number of tokens in each prefix prompt. This value is only "
+        help="The number of tokens in each prefix prompt. This value is only "
         "used if --num-prefix-prompts is positive. Note that due to "
         "the prefix and user prompts being concatenated, the number of tokens "
         "in the final prompt may be off by one.",
@@ -549,7 +548,7 @@ def _add_input_args(parser):
         "--warmup-request-count",
         "--num-warmup-requests",
         type=int,
-        help=f"The number of warmup requests to send before benchmarking.",
+        help="The number of warmup requests to send before benchmarking.",
     )
 
 
@@ -825,7 +824,7 @@ def init_parsers():
         "--version",
         action="version",
         version="%(prog)s " + __version__,
-        help=f"An option to print the version and exit.",
+        help="An option to print the version and exit.",
     )
 
     # Add subcommands

--- a/genai-perf/genai_perf/plots/plot_config.py
+++ b/genai-perf/genai_perf/plots/plot_config.py
@@ -25,7 +25,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path

--- a/genai-perf/genai_perf/subcommand/analyze.py
+++ b/genai-perf/genai_perf/subcommand/analyze.py
@@ -25,23 +25,13 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import csv
-import os
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import genai_perf.logging as logging
-from genai_perf.checkpoint.checkpoint import Checkpoint
-from genai_perf.config.generate.genai_perf_config import GenAIPerfConfig
-from genai_perf.config.generate.perf_analyzer_config import PerfAnalyzerConfig
 from genai_perf.config.generate.search_parameters import SearchParameters
 from genai_perf.config.generate.sweep_objective_generator import SweepObjectiveGenerator
 from genai_perf.config.input.config_command import ConfigCommand
-from genai_perf.config.run.run_config import RunConfig
-from genai_perf.exceptions import GenAIPerfException
-from genai_perf.export_data.output_reporter import OutputReporter
-from genai_perf.inputs.inputs_config import InputsConfig
-from genai_perf.measurements.run_config_measurement import RunConfigMeasurement
-from genai_perf.metrics.telemetry_statistics import TelemetryStatistics
 from genai_perf.record.types.energy_consumption_p99 import GpuEnergyConsumptionP99
 from genai_perf.record.types.gpu_memory_used_p99 import GpuMemoryUsedP99
 from genai_perf.record.types.gpu_power_limit_avg import GPUPowerLimitAvg
@@ -56,8 +46,6 @@ from genai_perf.record.types.request_throughput_avg import RequestThroughputAvg
 from genai_perf.record.types.time_to_first_token_p99 import TimeToFirstTokenP99
 from genai_perf.record.types.total_gpu_memory_avg import GPUTotalMemoryAvg
 from genai_perf.subcommand.subcommand import Subcommand
-from genai_perf.tokenizer import get_tokenizer
-from genai_perf.types import ModelObjectiveParameters
 
 logger = logging.getLogger(__name__)
 

--- a/genai-perf/genai_perf/subcommand/common.py
+++ b/genai-perf/genai_perf/subcommand/common.py
@@ -24,31 +24,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
-import subprocess  # nosec
 from argparse import Namespace
-from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
 import genai_perf.logging as logging
-from genai_perf.config.generate.perf_analyzer_config import PerfAnalyzerConfig
-from genai_perf.config.input.config_command import ConfigCommand
-from genai_perf.constants import DEFAULT_TRITON_METRICS_URL
-from genai_perf.inputs.input_constants import OutputFormat
-from genai_perf.inputs.inputs import Inputs
-from genai_perf.inputs.inputs_config import InputsConfig
-from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
-from genai_perf.profile_data_parser import (
-    ImageRetrievalProfileDataParser,
-    LLMProfileDataParser,
-    ProfileDataParser,
-)
-from genai_perf.telemetry_data.triton_telemetry_data_collector import (
-    TelemetryDataCollector,
-    TritonTelemetryDataCollector,
-)
-from genai_perf.tokenizer import Tokenizer
-from genai_perf.utils import load_json_str, remove_file
+from genai_perf.utils import load_json_str
 
 logger = logging.getLogger(__name__)
 

--- a/genai-perf/genai_perf/subcommand/profile.py
+++ b/genai-perf/genai_perf/subcommand/profile.py
@@ -26,9 +26,7 @@
 
 from typing import List, Optional
 
-from genai_perf.config.generate.perf_analyzer_config import PerfAnalyzerConfig
 from genai_perf.config.input.config_command import ConfigCommand
-from genai_perf.export_data.output_reporter import OutputReporter
 from genai_perf.plots.plot_config_parser import PlotConfigParser
 from genai_perf.plots.plot_manager import PlotManager
 from genai_perf.subcommand.subcommand import Subcommand

--- a/genai-perf/genai_perf/telemetry_data/triton_telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/triton_telemetry_data_collector.py
@@ -26,7 +26,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Dict, List
 
 import genai_perf.logging as logging
 from genai_perf.telemetry_data.telemetry_data_collector import TelemetryDataCollector

--- a/genai-perf/genai_perf/utils.py
+++ b/genai-perf/genai_perf/utils.py
@@ -27,7 +27,7 @@
 import random
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Type
 
 import genai_perf.logging as logging
 import orjson

--- a/genai-perf/tests/integration_tests/test_telemetry.py
+++ b/genai-perf/tests/integration_tests/test_telemetry.py
@@ -36,7 +36,6 @@ from genai_perf.config.input.config_command import ConfigCommand
 from genai_perf.config.input.create_config import CreateConfig
 from genai_perf.metrics import Metrics, TelemetryMetrics, TelemetryStatistics
 from genai_perf.metrics.statistics import Statistics
-from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
 from genai_perf.profile_data_parser import ProfileDataParser
 from genai_perf.subcommand.profile import Profile
 from genai_perf.telemetry_data.triton_telemetry_data_collector import (

--- a/genai-perf/tests/test_artifacts.py
+++ b/genai-perf/tests/test_artifacts.py
@@ -24,7 +24,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from argparse import Namespace
 from pathlib import Path
 
 import pytest

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -1073,7 +1073,7 @@ class TestCLIArguments:
         combined_args = self.base_args + args
         monkeypatch.setattr("sys.argv", combined_args)
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError):
             args, _ = parser.parse_args()
             CreateConfig.create(args)
 
@@ -1096,7 +1096,7 @@ class TestCLIArguments:
         combined_args = self.base_args + args
         monkeypatch.setattr("sys.argv", combined_args)
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError):
             args, _ = parser.parse_args()
             CreateConfig.create(args)
 

--- a/genai-perf/tests/test_converters/test_embeddings_converter.py
+++ b/genai-perf/tests/test_converters/test_embeddings_converter.py
@@ -29,7 +29,6 @@ from genai_perf.config.input.config_command import ConfigCommand
 from genai_perf.exceptions import GenAIPerfException
 from genai_perf.inputs.converters import OpenAIEmbeddingsConverter
 from genai_perf.inputs.input_constants import ModelSelectionStrategy, OutputFormat
-from genai_perf.inputs.inputs_config import InputsConfig
 from genai_perf.inputs.retrievers.generic_dataset import (
     DataRow,
     FileData,

--- a/genai-perf/tests/test_converters/test_nvclip_converter.py
+++ b/genai-perf/tests/test_converters/test_nvclip_converter.py
@@ -24,7 +24,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from copy import deepcopy
 
 import pytest
 from genai_perf.config.input.config_command import ConfigCommand

--- a/genai-perf/tests/test_converters/test_template_converter.py
+++ b/genai-perf/tests/test_converters/test_template_converter.py
@@ -36,7 +36,6 @@ from genai_perf.inputs.retrievers.generic_dataset import (
     FileData,
     GenericDataset,
 )
-from genai_perf.tokenizer import get_empty_tokenizer
 
 
 class TestTemplateConverter:

--- a/genai-perf/tests/test_converters/test_tensorrtllm_engine_converter.py
+++ b/genai-perf/tests/test_converters/test_tensorrtllm_engine_converter.py
@@ -40,7 +40,6 @@ from genai_perf.inputs.retrievers.generic_dataset import (
     FileData,
     GenericDataset,
 )
-from genai_perf.tokenizer import get_empty_tokenizer
 
 # Mock tokenizer outputs
 MOCK_TOKENIZED_ONE = [1426, 1881, 697]  # "text input one"

--- a/genai-perf/tests/test_converters/test_triton_tensorrtllm_converter.py
+++ b/genai-perf/tests/test_converters/test_triton_tensorrtllm_converter.py
@@ -24,7 +24,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import copy
 
 import pytest
 from genai_perf.config.input.config_command import ConfigCommand

--- a/genai-perf/tests/test_exporters/test_csv_exporter.py
+++ b/genai-perf/tests/test_exporters/test_csv_exporter.py
@@ -173,7 +173,7 @@ class TestCsvExporter:
         exporter = CsvExporter(exporter_config)
         exporter.export()
 
-        expected_filename = f"artifacts/model_name-openai-chat-concurrency1/custom_export_genai_perf.csv"
+        expected_filename = "artifacts/model_name-openai-chat-concurrency1/custom_export_genai_perf.csv"
         expected_content = [
             "Metric,avg,min,max,p99,p95,p90,p75,p50,p25\r\n",
             "Request Latency (ms),5.00,4.00,6.00,5.98,5.90,5.80,5.50,5.00,4.50\r\n",
@@ -463,7 +463,7 @@ class TestCsvExporter:
         mock_logger.error.assert_any_call(
             "Metric 'input_sequence_length' is missing in the provided statistics."
         )
-        expected_filename = f"artifacts/model_name-openai-chat-concurrency1/custom_export_genai_perf.csv"
+        expected_filename = "artifacts/model_name-openai-chat-concurrency1/custom_export_genai_perf.csv"
         expected_content = [
             "Metric,avg,min,max,p99,p95,p90,p75,p50,p25\r\n",
             "Request Latency (ms),N/A,4.00,6.00,5.98,5.90,5.80,5.50,5.00,4.50\r\n",

--- a/genai-perf/tests/test_exporters/test_data_exporter_factory.py
+++ b/genai-perf/tests/test_exporters/test_data_exporter_factory.py
@@ -25,16 +25,13 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-from argparse import Namespace
 
 import genai_perf.export_data.data_exporter_factory as factory
 from genai_perf.config.input.config_command import ConfigCommand
 from genai_perf.export_data.console_exporter import ConsoleExporter
 from genai_perf.export_data.csv_exporter import CsvExporter
-from genai_perf.export_data.exporter_config import ExporterConfig
 from genai_perf.export_data.json_exporter import JsonExporter
 from genai_perf.inputs.input_constants import ModelSelectionStrategy, Subcommand
-from genai_perf.subcommand.common import get_extra_inputs_as_dict
 from tests.test_utils import create_default_exporter_config
 
 

--- a/genai-perf/tests/test_exporters/test_json_exporter.py
+++ b/genai-perf/tests/test_exporters/test_json_exporter.py
@@ -32,7 +32,6 @@ import genai_perf.parser as parser
 import pytest
 from genai_perf.config.input.create_config import CreateConfig
 from genai_perf.export_data.json_exporter import JsonExporter
-from genai_perf.subcommand.common import get_extra_inputs_as_dict
 from tests.test_utils import create_default_exporter_config
 
 

--- a/genai-perf/tests/test_exporters/test_telemetry_data_exporter_util.py
+++ b/genai-perf/tests/test_exporters/test_telemetry_data_exporter_util.py
@@ -35,7 +35,6 @@ from genai_perf.export_data.telemetry_data_exporter_util import (
     merge_telemetry_stats_json,
 )
 from genai_perf.metrics import TelemetryMetrics
-from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
 from genai_perf.subcommand.subcommand import Subcommand
 from rich.console import Console
 

--- a/genai-perf/tests/test_perf_analyzer_config.py
+++ b/genai-perf/tests/test_perf_analyzer_config.py
@@ -17,7 +17,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from genai_perf import parser
 from genai_perf.checkpoint.checkpoint import checkpoint_encoder
 from genai_perf.config.generate.objective_parameter import (
     ObjectiveCategory,

--- a/genai-perf/tests/test_subcommand.py
+++ b/genai-perf/tests/test_subcommand.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import subprocess
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from genai_perf.config.generate.perf_analyzer_config import PerfAnalyzerConfig
 from genai_perf.config.input.config_command import ConfigCommand

--- a/genai-perf/tests/test_utils.py
+++ b/genai-perf/tests/test_utils.py
@@ -24,8 +24,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from argparse import Namespace
-from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 import pytest


### PR DESCRIPTION
Various fixes based on ruff linter errors. Most should be harmless, however worth double checking, in case some rules were broken on purpose in which case we should add a `#noqa` flag to them. In the future I recommend we add `ruff` checks as standard, but open to discussion.

- [redefined-while-unused (F811)](https://docs.astral.sh/ruff/rules/redefined-while-unused/#redefined-while-unused-f811)
- [unused-variable (F841)](https://docs.astral.sh/ruff/rules/unused-variable/#unused-variable-f841)
- [f-string-missing-placeholders (F541)](https://docs.astral.sh/ruff/rules/f-string-missing-placeholders/#f-string-missing-placeholders-f541)
- [not-in-test (E713)](https://docs.astral.sh/ruff/rules/not-in-test/#not-in-test-e713)
- [unused-import (F401)](https://docs.astral.sh/ruff/rules/unused-import/#unused-import-f401)