### PR TITLE
fix: forward --header arguments to Perf Analyzer CLI

### DIFF
--- a/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
+++ b/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
@@ -86,6 +86,7 @@ class PerfAnalyzerConfig:
         cli_args += self._add_inference_load_args(config)
         cli_args += self._add_prompt_source_args(config)
         cli_args += self._add_endpoint_args(config)
+        cli_args += self._add_header_args(config)
         cli_args += self._add_extra_args(extra_args)
 
         return cli_args
@@ -357,6 +358,14 @@ class PerfAnalyzerConfig:
             endpoint_args += ["--endpoint", f"{config.endpoint.custom}"]
 
         return endpoint_args
+
+    def _add_header_args(self, config: ConfigCommand) -> List[str]:
+        header_args = []
+
+        for h in config.input.header:
+            header_args += ["-H", h]
+
+        return header_args
 
     def _add_extra_args(self, extra_args: Optional[List[str]]) -> List[str]:
         if not extra_args:

--- a/genai-perf/tests/test_perf_analyzer_config.py
+++ b/genai-perf/tests/test_perf_analyzer_config.py
@@ -591,6 +591,49 @@ class TestPerfAnalyzerConfig(unittest.TestCase):
 
         self.assertEqual(expected_args, actual_args)
 
+    ###########################################################################
+    # Test _add_header_args
+    ###########################################################################
+    def test_add_header_args_with_no_headers(self):
+        """
+        Test that _add_header_args returns an empty list when no headers are set
+        """
+        self._config.input.header = []
+        expected_args = []
+        actual_args = self._default_perf_analyzer_config._add_header_args(self._config)
+        self.assertEqual(expected_args, actual_args)
+
+    def test_add_header_args_with_single_header(self):
+        """
+        Test that _add_header_args returns correct arguments for a single header
+        """
+        self._config.input.header = ["Authorization: Bearer token123"]
+        expected_args = ["-H", "Authorization: Bearer token123"]
+        actual_args = self._default_perf_analyzer_config._add_header_args(self._config)
+        self.assertEqual(expected_args, actual_args)
+
+    def test_add_header_args_with_multiple_headers(self):
+        """
+        Test that _add_header_args returns correct arguments for multiple headers
+        """
+        self._config.input.header = [
+            "Authorization: Bearer token123",
+            "Content-Type: application/json",
+            "Custom-Header: custom-value",
+        ]
+
+        expected_args = [
+            "-H",
+            "Authorization: Bearer token123",
+            "-H",
+            "Content-Type: application/json",
+            "-H",
+            "Custom-Header: custom-value",
+        ]
+
+        actual_args = self._default_perf_analyzer_config._add_header_args(self._config)
+        self.assertEqual(expected_args, actual_args)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes issue where --header args to GAP are not forwarded to PA.