### PR TITLE
Collect telemetry metrics from DCGM metrics endpoint

### DIFF
--- a/genai-perf/genai_perf/config/input/config_defaults.py
+++ b/genai-perf/genai_perf/config/input/config_defaults.py
@@ -15,6 +15,7 @@
 from copy import deepcopy
 from dataclasses import dataclass, field
 
+from genai_perf.constants import DEFAULT_DCGM_METRICS_URL
 from genai_perf.inputs.input_constants import (
     AudioFormat,
     ImageFormat,
@@ -71,7 +72,7 @@ class EndPointDefaults:
     TYPE = "kserve"
     SERVICE_KIND = "triton"
     STREAMING = False
-    SERVER_METRICS_URLS = ["http://localhost:8002/metrics"]
+    SERVER_METRICS_URLS = [DEFAULT_DCGM_METRICS_URL]
     URL = "localhost:8001"
     GRPC_METHOD = ""
 

--- a/genai-perf/genai_perf/constants.py
+++ b/genai-perf/genai_perf/constants.py
@@ -26,7 +26,7 @@
 
 ABBREVIATIONS = ["gpu"]
 DEFAULT_LRU_CACHE_SIZE = 100_000
-DEFAULT_TRITON_METRICS_URL = "http://localhost:8002/metrics"
+DEFAULT_DCGM_METRICS_URL = "http://localhost:9400/metrics"
 EMPTY_RESPONSE_TOKEN = 0
 
 # These map to the various fields that can be set for PA and model configs

--- a/genai-perf/genai_perf/metrics/telemetry_statistics.py
+++ b/genai-perf/genai_perf/metrics/telemetry_statistics.py
@@ -79,10 +79,9 @@ class TelemetryStatistics:
 
     def scale_data(self) -> None:
         SCALING_FACTORS = {
-            "energy_consumption": 1e-6,  # joules to megajoules (MJ)
-            "gpu_memory_used": 1e-9,  # bytes to gigabytes (GB)
-            "total_gpu_memory": 1e-9,  # bytes to gigabytes (GB)
-            "gpu_utilization": 100,  # ratio to percentage (%)
+            "energy_consumption": 1e-9,  # mJ to megajoules (MJ)
+            "gpu_memory_used": 1.048576 * 1e-3,  # MiB to gigabytes (GB)
+            "total_gpu_memory": 1.048576 * 1e-3,  # MiB to gigabytes (GB)
         }
         for metric, data in self._stats_dict.items():
             if metric in SCALING_FACTORS:

--- a/genai-perf/genai_perf/subcommand/common.py
+++ b/genai-perf/genai_perf/subcommand/common.py
@@ -33,7 +33,6 @@ from typing import Any, Dict, List, Optional
 import genai_perf.logging as logging
 from genai_perf.config.generate.perf_analyzer_config import PerfAnalyzerConfig
 from genai_perf.config.input.config_command import ConfigCommand
-from genai_perf.constants import DEFAULT_TRITON_METRICS_URL
 from genai_perf.inputs.input_constants import OutputFormat
 from genai_perf.inputs.inputs import Inputs
 from genai_perf.inputs.inputs_config import InputsConfig

--- a/genai-perf/genai_perf/telemetry_data/__init__.py
+++ b/genai-perf/genai_perf/telemetry_data/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -24,6 +24,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from genai_perf.telemetry_data.dcgm_telemetry_data_collector import (
+    DCGMTelemetryDataCollector,
+)
 from genai_perf.telemetry_data.telemetry_data_collector import TelemetryDataCollector
 from genai_perf.telemetry_data.triton_telemetry_data_collector import (
     TritonTelemetryDataCollector,

--- a/genai-perf/genai_perf/telemetry_data/dcgm_telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/dcgm_telemetry_data_collector.py
@@ -1,0 +1,120 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Dict, List, Optional, Tuple
+
+import genai_perf.logging as logging
+from genai_perf.telemetry_data.telemetry_data_collector import TelemetryDataCollector
+
+logger = logging.getLogger(__name__)
+
+
+class DCGMTelemetryDataCollector(TelemetryDataCollector):
+    """Collects telemetry metrics from DCGM metrics endpoint."""
+
+    METRIC_NAME_MAPPING = {
+        "DCGM_FI_DEV_POWER_USAGE": "gpu_power_usage",
+        "DCGM_FI_DEV_POWER_MGMT_LIMIT": "gpu_power_limit",
+        "DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION": "energy_consumption",
+        "DCGM_FI_DEV_GPU_UTIL": "gpu_utilization",
+        "DCGM_FI_DEV_FB_USED": "gpu_memory_used",
+        "DCGM_FI_DEV_FB_TOTAL": "total_gpu_memory",
+    }
+
+    def _process_and_update_metrics(self, metrics_data: str) -> None:
+        """Process GPU metrics from the DCGM endpoint and update internal metrics data.
+
+        Each metric line is expected to follow the format:
+        metric_name{label1="value1", ...} value
+
+        Only metrics listed in METRIC_NAME_MAPPING are processed. The 'gpu' label is
+        extracted from each line and used to group values by GPU (e.g., '0', '1', etc.).
+        Parsed values are grouped by metric and GPU and used to update metrics data.
+        """
+
+        if not metrics_data.strip():
+            logger.info("Response from DCGM metrics endpoint is empty")
+            return
+
+        current_measurement_interval: Dict[str, Dict[str, List[float]]] = {
+            metric.name: {} for metric in self.metrics.TELEMETRY_METRICS
+        }
+
+        for line in metrics_data.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            parsed = self._parse_metric_line(line)
+            if not parsed:
+                continue
+
+            metric_full_name, metric_value = parsed
+            metric_name = metric_full_name.split("{")[0]
+            mapped_key = self.METRIC_NAME_MAPPING.get(metric_name)
+            if not mapped_key:
+                continue
+
+            gpu_label = self._extract_gpu_label(metric_full_name)
+            if not gpu_label:
+                continue
+
+            self._append_metric_value(
+                current_measurement_interval, mapped_key, gpu_label, metric_value
+            )
+
+        self.metrics.update_metrics(current_measurement_interval)
+
+    def _parse_metric_line(self, line: str) -> Optional[Tuple[str, float]]:
+        try:
+            metric_full_name, value_str = line.rsplit(" ", 1)
+            metric_value = float(value_str.strip())
+            return metric_full_name, metric_value
+        except (ValueError, IndexError) as e:
+            logger.warning(f"Could not parse metric value from line: {line}")
+        return None
+
+    def _extract_gpu_label(self, metric_full_name: str) -> Optional[str]:
+        try:
+            labels_str = metric_full_name.partition("{")[2].partition("}")[0]
+            labels = dict(kv.split("=", 1) for kv in labels_str.split(",") if "=" in kv)
+            gpu_value = labels.get("gpu")
+            return gpu_value.strip('"') if gpu_value else None
+        except Exception as e:
+            logger.warning(
+                f"Failed to extract GPU label from: {metric_full_name} — {e}"
+            )
+            return None
+
+    def _append_metric_value(
+        self,
+        current_measurement_interval: Dict[str, Dict[str, List[float]]],
+        mapped_key: str,
+        gpu_label: str,
+        metric_value: float,
+    ) -> None:
+        gpu_metrics = current_measurement_interval.setdefault(mapped_key, {})
+        gpu_metrics.setdefault(gpu_label, []).append(metric_value)

--- a/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/genai-perf/genai_perf/telemetry_data/triton_telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/triton_telemetry_data_collector.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/genai-perf/tests/test_collectors/test_dcgm_telemetry_data_collector.py
+++ b/genai-perf/tests/test_collectors/test_dcgm_telemetry_data_collector.py
@@ -1,0 +1,108 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from unittest.mock import MagicMock
+
+import pytest
+from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
+from genai_perf.telemetry_data.dcgm_telemetry_data_collector import (
+    DCGMTelemetryDataCollector,
+)
+
+
+@pytest.fixture
+def collector():
+    collector = DCGMTelemetryDataCollector(
+        server_metrics_url="http://localhost:9400/metrics"
+    )
+    collector._metrics = MagicMock(spec=TelemetryMetrics)
+    collector._metrics.TELEMETRY_METRICS = [
+        MagicMock(name="gpu_power_usage"),
+        MagicMock(name="gpu_power_limit"),
+        MagicMock(name="energy_consumption"),
+        MagicMock(name="gpu_utilization"),
+        MagicMock(name="gpu_memory_used"),
+        MagicMock(name="total_gpu_memory"),
+    ]
+    return collector
+
+
+def test_process_and_update_metrics_success(collector):
+    sample_metrics = """
+    # HELP DCGM_FI_DEV_POWER_USAGE Power draw (in W).
+    DCGM_FI_DEV_POWER_USAGE{gpu="0"} 25.0
+    DCGM_FI_DEV_GPU_UTIL{gpu="0"} 88.5
+    DCGM_FI_DEV_FB_USED{gpu="0"} 4096
+    """
+
+    collector._process_and_update_metrics(sample_metrics)
+
+    update_call = collector.metrics.update_metrics.call_args[0][0]
+
+    assert update_call["gpu_power_usage"]["0"] == [25.0]
+    assert update_call["gpu_utilization"]["0"] == [88.5]
+    assert update_call["gpu_memory_used"]["0"] == [4096.0]
+
+
+def test_process_and_update_metrics_ignores_unmapped_metrics(collector):
+    sample_metrics = """
+    DCGM_FI_DEV_UNRELATED{gpu="0"} 100.0
+    DCGM_FI_DEV_FB_TOTAL{gpu="0"} 49152
+    """
+
+    collector._process_and_update_metrics(sample_metrics)
+    update_call = collector.metrics.update_metrics.call_args[0][0]
+
+    assert "total_gpu_memory" in update_call
+    assert update_call["total_gpu_memory"]["0"] == [49152.0]
+    assert "unrelated" not in update_call
+
+
+def test_parse_metric_line_success(collector):
+    line = 'DCGM_FI_DEV_GPU_UTIL{gpu="0"} 76.5'
+    metric_full_name, value = collector._parse_metric_line(line)
+    assert metric_full_name == 'DCGM_FI_DEV_GPU_UTIL{gpu="0"}'
+    assert value == 76.5
+
+
+def test_parse_metric_line_failure(collector):
+    assert collector._parse_metric_line("bad_line_without_value") is None
+
+
+def test_extract_gpu_label_success(collector):
+    line = 'DCGM_FI_DEV_POWER_USAGE{gpu="1",UUID="abc"}'
+    assert collector._extract_gpu_label(line) == "1"
+
+
+def test_extract_gpu_label_missing(collector):
+    line = 'DCGM_FI_DEV_POWER_USAGE{UUID="abc"}'
+    assert collector._extract_gpu_label(line) is None
+
+
+def test_append_metric_value_new_gpu(collector):
+    metric_data = {}
+    collector._append_metric_value(metric_data, "gpu_utilization", "2", 90.0)
+    assert metric_data["gpu_utilization"]["2"] == [90.0]

--- a/genai-perf/tests/test_collectors/test_telemetry_data_collector.py
+++ b/genai-perf/tests/test_collectors/test_telemetry_data_collector.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python3
-
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/genai-perf/tests/test_statistics/test_telemetry_statistics.py
+++ b/genai-perf/tests/test_statistics/test_telemetry_statistics.py
@@ -40,9 +40,9 @@ class TestTelemetryStatistics:
             {
                 "gpu_power_usage": {"gpu0": [10.0, 20.0, 30.0], "gpu1": [40.0, 50.0]},
                 "gpu_utilization": {"gpu0": [60.0, 70.0, 80.0], "gpu1": [90.0]},
-                "energy_consumption": {"gpu0": [1000000.0], "gpu1": [2000000.0]},
+                "energy_consumption": {"gpu0": [1000000000.0], "gpu1": [2000000000.0]},
                 "total_gpu_memory": {"gpu0": [8000000000.0], "gpu1": [16000000000.0]},
-                "gpu_memory_used": {"gpu0": [4000000000.0], "gpu1": [8000000000.0]},
+                "gpu_memory_used": {"gpu0": [4000], "gpu1": [5000]},
             }
         )
         return telemetry
@@ -87,8 +87,12 @@ class TestTelemetryStatistics:
         assert stats_dict["energy_consumption"]["gpu0"]["avg"] == 1.0  # 1 MJ
         assert stats_dict["energy_consumption"]["gpu1"]["avg"] == 2.0  # 2 MJ
 
-        assert stats_dict["gpu_memory_used"]["gpu0"]["avg"] == 4.0  # 4 GB
-        assert stats_dict["gpu_memory_used"]["gpu1"]["avg"] == 8.0  # 8 GB
+        assert (
+            round(stats_dict["gpu_memory_used"]["gpu0"]["avg"], 2) == 4.19
+        )  # 4.194304 GB
+        assert (
+            round(stats_dict["gpu_memory_used"]["gpu1"]["avg"], 2) == 5.24
+        )  # 5.24288 GB
 
     def test_create_records(self, telemetry_statistics):
         telemetry_statistics._stats_dict = telemetry_statistics.stats_dict


### PR DESCRIPTION
PR to collect telemetry metrics using dcgm-exporter /metrics endpoint.

GAP supports collecting GPU metrics from Triton /metrics endpoint. But this means, GPU telemetry metrics can be collected when only using Triton. When using vllm, GPU metrics are not collected.

This PR adds support to collecting GPU metrics irrespective of the server, as long as dcgm-exporter docker is running on the machine the server runs and the URL is provided using` --server-metrics-url` option.

```
genai-perf profile -m gpt2 \
	--endpoint-type chat \
	--url http://localhost:8000 \
	--synthetic-input-tokens-mean 100 \
	--synthetic-input-tokens-stddev 20 \
	--output-tokens-mean 50 \
	--output-tokens-stddev 15 \
	--streaming \
	--concurrency 1 \
	-v -- -v
```

![image](https://github.com/user-attachments/assets/d8464dfc-2965-4780-9fa4-1028ea77c1f7)
