### PR TITLE
Support new Power, Utilization and Memory metrics

### DIFF
--- a/genai-perf/genai_perf/metrics/telemetry_metrics.py
+++ b/genai-perf/genai_perf/metrics/telemetry_metrics.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,9 +25,32 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from collections import defaultdict
+from enum import Enum
 from typing import Dict, List, Optional
 
 from genai_perf.metrics.metrics import MetricMetadata
+
+
+class TelemetryMetricName(str, Enum):
+    GPU_UTILIZATION = "gpu_utilization"
+    SM_UTILIZATION = "sm_utilization"
+    MEMORY_COPY_UTILIZATION = "memory_copy_utilization"
+    VIDEO_ENCODER_UTILIZATION = "video_encoder_utilization"
+    VIDEO_DECODER_UTILIZATION = "video_decoder_utilization"
+    GPU_POWER_USAGE = "gpu_power_usage"
+    GPU_POWER_LIMIT = "gpu_power_limit"
+    ENERGY_CONSUMPTION = "energy_consumption"
+    TOTAL_GPU_MEMORY = "total_gpu_memory"
+    GPU_MEMORY_USED = "gpu_memory_used"
+    GPU_MEMORY_FREE = "gpu_memory_free"
+    GPU_MEMORY_TEMPERATURE = "gpu_memory_temperature"
+    GPU_TEMPERATURE = "gpu_temperature"
+    GPU_CLOCK_SM = "gpu_clock_sm"
+    GPU_CLOCK_MEMORY = "gpu_clock_memory"
+
+    @classmethod
+    def values(cls) -> List["TelemetryMetricName"]:
+        return list(cls)
 
 
 class TelemetryMetrics:
@@ -47,14 +68,43 @@ class TelemetryMetrics:
         }
     """
 
-    TELEMETRY_METRICS = [
-        MetricMetadata("gpu_power_usage", "W"),
-        MetricMetadata("gpu_power_limit", "W"),
-        MetricMetadata("energy_consumption", "MJ"),
-        MetricMetadata("gpu_utilization", "%"),
-        MetricMetadata("total_gpu_memory", "GB"),
-        MetricMetadata("gpu_memory_used", "GB"),
+    UTILIZATION_METRICS = [
+        MetricMetadata(TelemetryMetricName.GPU_UTILIZATION.value, "%"),
+        MetricMetadata(TelemetryMetricName.SM_UTILIZATION.value, "%"),
+        MetricMetadata(TelemetryMetricName.MEMORY_COPY_UTILIZATION.value, "%"),
+        MetricMetadata(TelemetryMetricName.VIDEO_ENCODER_UTILIZATION.value, "%"),
+        MetricMetadata(TelemetryMetricName.VIDEO_DECODER_UTILIZATION.value, "%"),
     ]
+
+    POWER_METRICS = [
+        MetricMetadata(TelemetryMetricName.GPU_POWER_USAGE.value, "W"),
+        MetricMetadata(TelemetryMetricName.GPU_POWER_LIMIT.value, "W"),
+        MetricMetadata(TelemetryMetricName.ENERGY_CONSUMPTION.value, "MJ"),
+    ]
+
+    CLOCK_METRICS = [
+        MetricMetadata(TelemetryMetricName.GPU_CLOCK_SM.value, "MHz"),
+        MetricMetadata(TelemetryMetricName.GPU_CLOCK_MEMORY.value, "MHz"),
+    ]
+
+    MEMORY_METRICS = [
+        MetricMetadata(TelemetryMetricName.TOTAL_GPU_MEMORY.value, "GB"),
+        MetricMetadata(TelemetryMetricName.GPU_MEMORY_USED.value, "GB"),
+        MetricMetadata(TelemetryMetricName.GPU_MEMORY_FREE.value, "GB"),
+    ]
+
+    TEMPERATURE_METRICS = [
+        MetricMetadata(TelemetryMetricName.GPU_TEMPERATURE.value, "C"),
+        MetricMetadata(TelemetryMetricName.GPU_MEMORY_TEMPERATURE.value, "C"),
+    ]
+
+    TELEMETRY_METRICS = (
+        POWER_METRICS
+        + MEMORY_METRICS
+        + UTILIZATION_METRICS
+        + CLOCK_METRICS
+        + TEMPERATURE_METRICS
+    )
 
     def __init__(
         self,
@@ -62,15 +112,37 @@ class TelemetryMetrics:
         gpu_power_limit: Optional[Dict[str, List[float]]] = None,
         energy_consumption: Optional[Dict[str, List[float]]] = None,
         gpu_utilization: Optional[Dict[str, List[float]]] = None,
+        sm_utilization: Optional[Dict[str, List[float]]] = None,
+        memory_copy_utilization: Optional[Dict[str, List[float]]] = None,
+        video_encoder_utilization: Optional[Dict[str, List[float]]] = None,
+        video_decoder_utilization: Optional[Dict[str, List[float]]] = None,
         total_gpu_memory: Optional[Dict[str, List[float]]] = None,
         gpu_memory_used: Optional[Dict[str, List[float]]] = None,
+        gpu_memory_free: Optional[Dict[str, List[float]]] = None,
+        gpu_memory_temperature: Optional[Dict[str, List[float]]] = None,
+        gpu_temperature: Optional[Dict[str, List[float]]] = None,
+        gpu_clock_sm: Optional[Dict[str, List[float]]] = None,
+        gpu_clock_memory: Optional[Dict[str, List[float]]] = None,
     ):
         self.gpu_power_usage = defaultdict(list, gpu_power_usage or {})
         self.gpu_power_limit = defaultdict(list, gpu_power_limit or {})
         self.energy_consumption = defaultdict(list, energy_consumption or {})
         self.gpu_utilization = defaultdict(list, gpu_utilization or {})
+        self.sm_utilization = defaultdict(list, sm_utilization or {})
+        self.memory_copy_utilization = defaultdict(list, memory_copy_utilization or {})
+        self.video_encoder_utilization = defaultdict(
+            list, video_encoder_utilization or {}
+        )
+        self.video_decoder_utilization = defaultdict(
+            list, video_decoder_utilization or {}
+        )
         self.total_gpu_memory = defaultdict(list, total_gpu_memory or {})
         self.gpu_memory_used = defaultdict(list, gpu_memory_used or {})
+        self.gpu_memory_free = defaultdict(list, gpu_memory_free or {})
+        self.gpu_memory_temperature = defaultdict(list, gpu_memory_temperature or {})
+        self.gpu_temperature = defaultdict(list, gpu_temperature or {})
+        self.gpu_clock_sm = defaultdict(list, gpu_clock_sm or {})
+        self.gpu_clock_memory = defaultdict(list, gpu_clock_memory or {})
 
     def update_metrics(self, measurement_data: dict) -> None:
         for metric in self.TELEMETRY_METRICS:

--- a/genai-perf/genai_perf/metrics/telemetry_statistics.py
+++ b/genai-perf/genai_perf/metrics/telemetry_statistics.py
@@ -82,6 +82,8 @@ class TelemetryStatistics:
             "energy_consumption": 1e-9,  # mJ to megajoules (MJ)
             "gpu_memory_used": 1.048576 * 1e-3,  # MiB to gigabytes (GB)
             "total_gpu_memory": 1.048576 * 1e-3,  # MiB to gigabytes (GB)
+            "gpu_memory_free": 1.048576e-3,  # MiB to gigabytes (GB)
+            "sm_utilization": 100,  # ratio to %
         }
         for metric, data in self._stats_dict.items():
             if metric in SCALING_FACTORS:

--- a/genai-perf/genai_perf/metrics/telemetry_stats_aggregator.py
+++ b/genai-perf/genai_perf/metrics/telemetry_stats_aggregator.py
@@ -38,7 +38,7 @@ class TelemetryStatsAggregator:
     """
 
     def __init__(self, telemetry_dicts: List[Dict[str, Any]]) -> None:
-        self._telemetry_stats = TelemetryStatistics(TelemetryMetrics(None))
+        self._telemetry_stats = TelemetryStatistics(TelemetryMetrics())
         self._telemetry_dicts = telemetry_dicts
         self._aggregate()
 

--- a/genai-perf/genai_perf/record/record.py
+++ b/genai-perf/genai_perf/record/record.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ from genai_perf.types import RecordValue
 class ReductionFactor:
     NS_TO_MS = 6
     NJ_TO_MJ = 6
-    B_TO_GB = 9
+    MIB_TO_GB: float = 1.048576e-3
     PERCENTAGE = -2
     NONE = 0
 
@@ -159,12 +159,12 @@ class Record(metaclass=RecordType):
 
     @property
     @abstractmethod
-    def reduction_factor(self) -> int:
+    def reduction_factor(self) -> float:
         """
         Returns
         -------
-        int
-            the factor (of 10) that the value should be reduced by
+        float
+            the reduction factor of the record type.
         """
 
     def create_checkpoint_object(self):

--- a/genai-perf/genai_perf/record/types/energy_consumption_base.py
+++ b/genai-perf/genai_perf/record/types/energy_consumption_base.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ class GPUEnergyConsumptionBase(DecreasingGPURecord):
     def header(aggregation_tag=False):
         return ("Average " if aggregation_tag else "") + "GPU Energy Consumption (MJ)"
 
-    def __eq__(self, other: "GPUEnegryConsumptionBase") -> bool:  # type: ignore
+    def __eq__(self, other: "GPUEnergyConsumptionBase") -> bool:  # type: ignore
         return self.value() == other.value()
 
     def __lt__(self, other: "GPUEnergyConsumptionBase") -> bool:

--- a/genai-perf/genai_perf/record/types/gpu_clock_memory_avg.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_memory_avg.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_memory_base import GPUClockMemoryBase
+
+
+@total_ordering
+class GpuClockMemoryAvg(GPUClockMemoryBase):
+    """
+    A record for avg GPU Clock Memory metric
+    """
+
+    tag = GPUClockMemoryBase.base_tag + "_avg"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Avg. GPU Clock Memory (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_memory_base.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_memory_base.py
@@ -1,0 +1,54 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.gpu_record import IncreasingGPURecord
+from genai_perf.record.record import ReductionFactor
+
+
+@total_ordering
+class GPUClockMemoryBase(IncreasingGPURecord):
+    """
+    A base class for the Memory Clock metric
+    """
+
+    base_tag = "gpu_clock_memory"
+    reduction_factor = ReductionFactor.NONE
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @staticmethod
+    def aggregation_function():
+        def average(seq):
+            return sum(seq[1:], start=seq[0]) / len(seq)
+
+        return average
+
+    @staticmethod
+    def header(aggregation_tag=False) -> str:
+        return ("Average " if aggregation_tag else "") + "GPU Clock Memory (MHz)"
+
+    def __eq__(self, other: "GPUClockMemoryBase") -> bool:  # type: ignore
+        return self.value() == other.value()
+
+    def __lt__(self, other: "GPUClockMemoryBase") -> bool:
+        return self.value() < other.value()
+
+    def __add__(self, other: "GPUClockMemoryBase") -> "GPUClockMemoryBase":
+        return self.__class__(device_uuid=None, value=(self.value() + other.value()))
+
+    def __sub__(self, other: "GPUClockMemoryBase") -> "GPUClockMemoryBase":
+        return self.__class__(device_uuid=None, value=(self.value() - other.value()))

--- a/genai-perf/genai_perf/record/types/gpu_clock_memory_max.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_memory_max.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_memory_base import GPUClockMemoryBase
+
+
+@total_ordering
+class GpuClockMemoryMax(GPUClockMemoryBase):
+    """
+    A record for max GPU Clock Memory metric
+    """
+
+    tag = GPUClockMemoryBase.base_tag + "_max"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Max GPU Clock Memory (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_memory_min.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_memory_min.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_memory_base import GPUClockMemoryBase
+
+
+@total_ordering
+class GpuClockMemoryMin(GPUClockMemoryBase):
+    """
+    A record for min GPU Clock Memory metric
+    """
+
+    tag = GPUClockMemoryBase.base_tag + "_min"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Min GPU Clock Memory (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_memory_p25.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_memory_p25.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_memory_base import GPUClockMemoryBase
+
+
+@total_ordering
+class GpuClockMemoryP25(GPUClockMemoryBase):
+    """
+    A record for p25 GPU Clock Memory metric
+    """
+
+    tag = GPUClockMemoryBase.base_tag + "_p25"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p25 GPU Clock Memory (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_memory_p50.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_memory_p50.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_memory_base import GPUClockMemoryBase
+
+
+@total_ordering
+class GpuClockMemoryP50(GPUClockMemoryBase):
+    """
+    A record for p50 GPU Clock Memory metric
+    """
+
+    tag = GPUClockMemoryBase.base_tag + "_p50"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p50 GPU Clock Memory (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_memory_p75.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_memory_p75.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_memory_base import GPUClockMemoryBase
+
+
+@total_ordering
+class GpuClockMemoryP75(GPUClockMemoryBase):
+    """
+    A record for p75 GPU Clock Memory metric
+    """
+
+    tag = GPUClockMemoryBase.base_tag + "_p75"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p75 GPU Clock Memory (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_memory_p90.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_memory_p90.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_memory_base import GPUClockMemoryBase
+
+
+@total_ordering
+class GpuClockMemoryP90(GPUClockMemoryBase):
+    """
+    A record for p90 GPU Clock Memory metric
+    """
+
+    tag = GPUClockMemoryBase.base_tag + "_p90"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p90 GPU Clock Memory (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_memory_p95.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_memory_p95.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_memory_base import GPUClockMemoryBase
+
+
+@total_ordering
+class GpuClockMemoryP95(GPUClockMemoryBase):
+    """
+    A record for p95 GPU Clock Memory metric
+    """
+
+    tag = GPUClockMemoryBase.base_tag + "_p95"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p95 GPU Clock Memory (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_memory_p99.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_memory_p99.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_memory_base import GPUClockMemoryBase
+
+
+@total_ordering
+class GpuClockMemoryP99(GPUClockMemoryBase):
+    """
+    A record for p99 GPU Clock Memory metric
+    """
+
+    tag = GPUClockMemoryBase.base_tag + "_p99"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p99 GPU Clock Memory (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_memory_std.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_memory_std.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_memory_base import GPUClockMemoryBase
+
+
+@total_ordering
+class GpuClockMemoryStd(GPUClockMemoryBase):
+    """
+    A record for std GPU Clock Memory metric
+    """
+
+    tag = GPUClockMemoryBase.base_tag + "_std"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Std. GPU Clock Memory (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_sm_avg.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_sm_avg.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_sm_base import GPUClockSMBase
+
+
+@total_ordering
+class GpuClockSMAvg(GPUClockSMBase):
+    """
+    A record for avg GPU Clock SM metric
+    """
+
+    tag = GPUClockSMBase.base_tag + "_avg"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Avg. GPU Clock SM (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_sm_base.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_sm_base.py
@@ -1,0 +1,54 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.gpu_record import IncreasingGPURecord
+from genai_perf.record.record import ReductionFactor
+
+
+@total_ordering
+class GPUClockSMBase(IncreasingGPURecord):
+    """
+    A base class for the SM Clock metric
+    """
+
+    base_tag = "gpu_clock_sm"
+    reduction_factor = ReductionFactor.NONE
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @staticmethod
+    def aggregation_function():
+        def average(seq):
+            return sum(seq[1:], start=seq[0]) / len(seq)
+
+        return average
+
+    @staticmethod
+    def header(aggregation_tag=False) -> str:
+        return ("Average " if aggregation_tag else "") + "GPU Clock SM (MHz)"
+
+    def __eq__(self, other: "GPUClockSMBase") -> bool:  # type: ignore
+        return self.value() == other.value()
+
+    def __lt__(self, other: "GPUClockSMBase") -> bool:
+        return self.value() < other.value()
+
+    def __add__(self, other: "GPUClockSMBase") -> "GPUClockSMBase":
+        return self.__class__(device_uuid=None, value=(self.value() + other.value()))
+
+    def __sub__(self, other: "GPUClockSMBase") -> "GPUClockSMBase":
+        return self.__class__(device_uuid=None, value=(self.value() - other.value()))

--- a/genai-perf/genai_perf/record/types/gpu_clock_sm_max.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_sm_max.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_sm_base import GPUClockSMBase
+
+
+@total_ordering
+class GpuClockSMMax(GPUClockSMBase):
+    """
+    A record for max GPU Clock SM metric
+    """
+
+    tag = GPUClockSMBase.base_tag + "_max"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Max GPU Clock SM (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_sm_min.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_sm_min.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_sm_base import GPUClockSMBase
+
+
+@total_ordering
+class GpuClockSMMin(GPUClockSMBase):
+    """
+    A record for min GPU Clock SM metric
+    """
+
+    tag = GPUClockSMBase.base_tag + "_min"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Min GPU Clock SM (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_sm_p25.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_sm_p25.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_sm_base import GPUClockSMBase
+
+
+@total_ordering
+class GpuClockSMP25(GPUClockSMBase):
+    """
+    A record for p25 GPU Clock SM metric
+    """
+
+    tag = GPUClockSMBase.base_tag + "_p25"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p25 GPU Clock SM (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_sm_p50.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_sm_p50.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_sm_base import GPUClockSMBase
+
+
+@total_ordering
+class GpuClockSMP50(GPUClockSMBase):
+    """
+    A record for p50 GPU Clock SM metric
+    """
+
+    tag = GPUClockSMBase.base_tag + "_p50"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p50 GPU Clock SM (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_sm_p75.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_sm_p75.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_sm_base import GPUClockSMBase
+
+
+@total_ordering
+class GpuClockSMP75(GPUClockSMBase):
+    """
+    A record for p75 GPU Clock SM metric
+    """
+
+    tag = GPUClockSMBase.base_tag + "_p75"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p75 GPU Clock SM (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_sm_p90.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_sm_p90.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_sm_base import GPUClockSMBase
+
+
+@total_ordering
+class GpuClockSMP90(GPUClockSMBase):
+    """
+    A record for p90 GPU Clock SM metric
+    """
+
+    tag = GPUClockSMBase.base_tag + "_p90"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p90 GPU Clock SM (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_sm_p95.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_sm_p95.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_sm_base import GPUClockSMBase
+
+
+@total_ordering
+class GpuClockSMP95(GPUClockSMBase):
+    """
+    A record for p95 GPU Clock SM metric
+    """
+
+    tag = GPUClockSMBase.base_tag + "_p95"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p95 GPU Clock SM (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_sm_p99.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_sm_p99.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_sm_base import GPUClockSMBase
+
+
+@total_ordering
+class GpuClockSMP99(GPUClockSMBase):
+    """
+    A record for p99 GPU Clock SM metric
+    """
+
+    tag = GPUClockSMBase.base_tag + "_p99"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p99 GPU Clock SM (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_clock_sm_std.py
+++ b/genai-perf/genai_perf/record/types/gpu_clock_sm_std.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_clock_sm_base import GPUClockSMBase
+
+
+@total_ordering
+class GpuClockSMStd(GPUClockSMBase):
+    """
+    A record for std GPU Clock SM metric
+    """
+
+    tag = GPUClockSMBase.base_tag + "_std"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Std. GPU Clock SM (MHz)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_free_avg.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_free_avg.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_free_base import GPUMemoryFreeBase
+
+
+@total_ordering
+class GpuMemoryFreeAvg(GPUMemoryFreeBase):
+    """
+    A record for avg GPU memory free metric
+    """
+
+    tag = GPUMemoryFreeBase.base_tag + "_avg"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Avg. GPU Memory Free (GB)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_free_base.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_free_base.py
@@ -1,0 +1,47 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.gpu_record import IncreasingGPURecord
+from genai_perf.record.record import ReductionFactor
+
+
+@total_ordering
+class GPUMemoryFreeBase(IncreasingGPURecord):
+    """
+    A base class for the GPU's memory free metric
+    """
+
+    base_tag = "gpu_memory_free"
+    reduction_factor = ReductionFactor.MIB_TO_GB
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @staticmethod
+    def header(aggregation_tag=False) -> str:
+        return ("Max " if aggregation_tag else "") + "GPU Memory Free (GB)"
+
+    def __eq__(self, other: "GPUMemoryFreeBase") -> bool:  # type: ignore
+        return self.value() == other.value()
+
+    def __lt__(self, other: "GPUMemoryFreeBase") -> bool:
+        return self.value() < other.value()
+
+    def __add__(self, other: "GPUMemoryFreeBase") -> "GPUMemoryFreeBase":
+        return self.__class__(device_uuid=None, value=(self.value() + other.value()))
+
+    def __sub__(self, other: "GPUMemoryFreeBase") -> "GPUMemoryFreeBase":
+        return self.__class__(device_uuid=None, value=(self.value() - other.value()))

--- a/genai-perf/genai_perf/record/types/gpu_memory_free_max.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_free_max.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_free_base import GPUMemoryFreeBase
+
+
+@total_ordering
+class GpuMemoryFreeMax(GPUMemoryFreeBase):
+    """
+    A record for max GPU memory free metric
+    """
+
+    tag = GPUMemoryFreeBase.base_tag + "_max"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Max GPU Memory Free (GB)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_free_min.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_free_min.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_free_base import GPUMemoryFreeBase
+
+
+@total_ordering
+class GpuMemoryFreeMin(GPUMemoryFreeBase):
+    """
+    A record for min GPU memory free metric
+    """
+
+    tag = GPUMemoryFreeBase.base_tag + "_min"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Min GPU Memory Free (GB)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_free_p25.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_free_p25.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_free_base import GPUMemoryFreeBase
+
+
+@total_ordering
+class GpuMemoryFreeP25(GPUMemoryFreeBase):
+    """
+    A record for p25 GPU memory free metric
+    """
+
+    tag = GPUMemoryFreeBase.base_tag + "_p25"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p25 GPU Memory Free (GB)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_free_p50.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_free_p50.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_free_base import GPUMemoryFreeBase
+
+
+@total_ordering
+class GpuMemoryFreeP50(GPUMemoryFreeBase):
+    """
+    A record for p50 GPU memory free metric
+    """
+
+    tag = GPUMemoryFreeBase.base_tag + "_p50"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p50 GPU Memory Free (GB)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_free_p75.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_free_p75.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_free_base import GPUMemoryFreeBase
+
+
+@total_ordering
+class GpuMemoryFreeP75(GPUMemoryFreeBase):
+    """
+    A record for p75 GPU memory free metric
+    """
+
+    tag = GPUMemoryFreeBase.base_tag + "_p75"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p75 GPU Memory Free (GB)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_free_p90.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_free_p90.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_free_base import GPUMemoryFreeBase
+
+
+@total_ordering
+class GpuMemoryFreeP90(GPUMemoryFreeBase):
+    """
+    A record for p90 GPU memory free metric
+    """
+
+    tag = GPUMemoryFreeBase.base_tag + "_p90"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p90 GPU Memory Free (GB)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_free_p95.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_free_p95.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_free_base import GPUMemoryFreeBase
+
+
+@total_ordering
+class GpuMemoryFreeP95(GPUMemoryFreeBase):
+    """
+    A record for p95 GPU memory free metric
+    """
+
+    tag = GPUMemoryFreeBase.base_tag + "_p95"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p95 GPU Memory Free (GB)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_free_p99.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_free_p99.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_free_base import GPUMemoryFreeBase
+
+
+@total_ordering
+class GpuMemoryFreeP99(GPUMemoryFreeBase):
+    """
+    A record for p99 GPU memory free metric
+    """
+
+    tag = GPUMemoryFreeBase.base_tag + "_p99"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p99 GPU Memory Free (GB)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_free_std.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_free_std.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_free_base import GPUMemoryFreeBase
+
+
+@total_ordering
+class GpuMemoryFreeStd(GPUMemoryFreeBase):
+    """
+    A record for std GPU memory free metric
+    """
+
+    tag = GPUMemoryFreeBase.base_tag + "_std"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Std. GPU Memory Free (GB)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_temperature_avg.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_temperature_avg.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_temperature_base import GPUMemoryTemperatureBase
+
+
+@total_ordering
+class GpuMemoryTempAvg(GPUMemoryTemperatureBase):
+    """
+    A record for avg GPU Memory Temperature metric
+    """
+
+    tag = GPUMemoryTemperatureBase.base_tag + "_avg"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Avg. GPU Memory Temperature (°C)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_temperature_base.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_temperature_base.py
@@ -1,0 +1,47 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.gpu_record import DecreasingGPURecord
+from genai_perf.record.record import ReductionFactor
+
+
+@total_ordering
+class GPUMemoryTemperatureBase(DecreasingGPURecord):
+    """
+    A base class for the GPU's memory temperature metric
+    """
+
+    base_tag = "gpu_memory_temperature"
+    reduction_factor = ReductionFactor.NONE
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @staticmethod
+    def header(aggregation_tag=False) -> str:
+        return ("Max " if aggregation_tag else "") + "GPU Memory Temperature (C)"
+
+    def __eq__(self, other: "GPUMemoryTemperatureBase") -> bool:  # type: ignore
+        return self.value() == other.value()
+
+    def __lt__(self, other: "GPUMemoryTemperatureBase") -> bool:
+        return self.value() > other.value()
+
+    def __add__(self, other: "GPUMemoryTemperatureBase") -> "GPUMemoryTemperatureBase":
+        return self.__class__(device_uuid=None, value=(self.value() + other.value()))
+
+    def __sub__(self, other: "GPUMemoryTemperatureBase") -> "GPUMemoryTemperatureBase":
+        return self.__class__(device_uuid=None, value=(other.value() - self.value()))

--- a/genai-perf/genai_perf/record/types/gpu_memory_temperature_max.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_temperature_max.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_temperature_base import GPUMemoryTemperatureBase
+
+
+@total_ordering
+class GpuMemoryTempMax(GPUMemoryTemperatureBase):
+    """
+    A record for max GPU Memory Temperature metric
+    """
+
+    tag = GPUMemoryTemperatureBase.base_tag + "_max"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Max GPU Memory Temperature (C)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_temperature_min.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_temperature_min.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_temperature_base import GPUMemoryTemperatureBase
+
+
+@total_ordering
+class GpuMemoryTempMin(GPUMemoryTemperatureBase):
+    """
+    A record for min GPU Memory Temperature metric
+    """
+
+    tag = GPUMemoryTemperatureBase.base_tag + "_min"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Min GPU Memory Temperature (C)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_temperature_p25.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_temperature_p25.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_temperature_base import GPUMemoryTemperatureBase
+
+
+@total_ordering
+class GpuMemoryTempP25(GPUMemoryTemperatureBase):
+    """
+    A record for p25 GPU Memory Temperature metric
+    """
+
+    tag = GPUMemoryTemperatureBase.base_tag + "_p25"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p25 GPU Memory Temperature (C)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_temperature_p50.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_temperature_p50.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_temperature_base import GPUMemoryTemperatureBase
+
+
+@total_ordering
+class GpuMemoryTempP50(GPUMemoryTemperatureBase):
+    """
+    A record for p50 GPU Memory Temperature metric
+    """
+
+    tag = GPUMemoryTemperatureBase.base_tag + "_p50"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p50 GPU Memory Temperature (C)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_temperature_p75.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_temperature_p75.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_temperature_base import GPUMemoryTemperatureBase
+
+
+@total_ordering
+class GpuMemoryTempP75(GPUMemoryTemperatureBase):
+    """
+    A record for p75 GPU Memory Temperature metric
+    """
+
+    tag = GPUMemoryTemperatureBase.base_tag + "_p75"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p75 GPU Memory Temperature (C)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_temperature_p90.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_temperature_p90.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_temperature_base import GPUMemoryTemperatureBase
+
+
+@total_ordering
+class GpuMemoryTempP90(GPUMemoryTemperatureBase):
+    """
+    A record for p90 GPU Memory Temperature metric
+    """
+
+    tag = GPUMemoryTemperatureBase.base_tag + "_p90"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p90 GPU Memory Temperature (C)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_temperature_p95.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_temperature_p95.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_temperature_base import GPUMemoryTemperatureBase
+
+
+@total_ordering
+class GpuMemoryTemperatureP95(GPUMemoryTemperatureBase):
+    """
+    A record for p95 GPU Memory Temperature metric
+    """
+
+    tag = GPUMemoryTemperatureBase.base_tag + "_p95"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p95 GPU Memory Temperature (C)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_temperature_p99.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_temperature_p99.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_temperature_base import GPUMemoryTemperatureBase
+
+
+@total_ordering
+class GpuMemoryTempP99(GPUMemoryTemperatureBase):
+    """
+    A record for p99 GPU Memory Temperature metric
+    """
+
+    tag = GPUMemoryTemperatureBase.base_tag + "_p99"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p99 GPU Memory Temperature (C)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_temperature_std.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_temperature_std.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_memory_temperature_base import GPUMemoryTemperatureBase
+
+
+@total_ordering
+class GpuMemoryTempStd(GPUMemoryTemperatureBase):
+    """
+    A record for std GPU Memory Temperature metric
+    """
+
+    tag = GPUMemoryTemperatureBase.base_tag + "_std"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Std. GPU Memory Temperature (C)"

--- a/genai-perf/genai_perf/record/types/gpu_memory_used_base.py
+++ b/genai-perf/genai_perf/record/types/gpu_memory_used_base.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ class GPUMemoryUsedBase(IncreasingGPURecord):
     """
 
     base_tag = "gpu_memory_used"
-    reduction_factor = ReductionFactor.B_TO_GB
+    reduction_factor = ReductionFactor.MIB_TO_GB
 
     def __init__(self, value, device_uuid=None, timestamp=0):
         super().__init__(value, device_uuid, timestamp)

--- a/genai-perf/genai_perf/record/types/gpu_temperature_avg.py
+++ b/genai-perf/genai_perf/record/types/gpu_temperature_avg.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_temperature_base import GPUTemperatureBase
+
+
+@total_ordering
+class GpuTemperatureAvg(GPUTemperatureBase):
+    """
+    A record for avg GPU Temperature metric
+    """
+
+    tag = GPUTemperatureBase.base_tag + "_avg"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Avg. GPU Temperature (°C)"

--- a/genai-perf/genai_perf/record/types/gpu_temperature_base.py
+++ b/genai-perf/genai_perf/record/types/gpu_temperature_base.py
@@ -1,0 +1,47 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.gpu_record import DecreasingGPURecord
+from genai_perf.record.record import ReductionFactor
+
+
+@total_ordering
+class GPUTemperatureBase(DecreasingGPURecord):
+    """
+    A base class for the GPU temperature metric
+    """
+
+    base_tag = "gpu_temperature"
+    reduction_factor = ReductionFactor.NONE
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @staticmethod
+    def header(aggregation_tag=False) -> str:
+        return ("Max " if aggregation_tag else "") + "GPU Temperature (C)"
+
+    def __eq__(self, other: "GPUTemperatureBase") -> bool:  # type: ignore
+        return self.value() == other.value()
+
+    def __lt__(self, other: "GPUTemperatureBase") -> bool:
+        return self.value() > other.value()
+
+    def __add__(self, other: "GPUTemperatureBase") -> "GPUTemperatureBase":
+        return self.__class__(device_uuid=None, value=(self.value() + other.value()))
+
+    def __sub__(self, other: "GPUTemperatureBase") -> "GPUTemperatureBase":
+        return self.__class__(device_uuid=None, value=(other.value() - self.value()))

--- a/genai-perf/genai_perf/record/types/gpu_temperature_max.py
+++ b/genai-perf/genai_perf/record/types/gpu_temperature_max.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_temperature_base import GPUTemperatureBase
+
+
+@total_ordering
+class GpuTemperatureMax(GPUTemperatureBase):
+    """
+    A record for max GPU Temperature metric
+    """
+
+    tag = GPUTemperatureBase.base_tag + "_max"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Max GPU Temperature (°C)"

--- a/genai-perf/genai_perf/record/types/gpu_temperature_min.py
+++ b/genai-perf/genai_perf/record/types/gpu_temperature_min.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_temperature_base import GPUTemperatureBase
+
+
+@total_ordering
+class GpuTemperatureMin(GPUTemperatureBase):
+    """
+    A record for min GPU Temperature metric
+    """
+
+    tag = GPUTemperatureBase.base_tag + "_min"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Min GPU Temperature (°C)"

--- a/genai-perf/genai_perf/record/types/gpu_temperature_p25.py
+++ b/genai-perf/genai_perf/record/types/gpu_temperature_p25.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_temperature_base import GPUTemperatureBase
+
+
+@total_ordering
+class GpuTemperatureP25(GPUTemperatureBase):
+    """
+    A record for p25 GPU Temperature metric
+    """
+
+    tag = GPUTemperatureBase.base_tag + "_p25"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p25 GPU Temperature (°C)"

--- a/genai-perf/genai_perf/record/types/gpu_temperature_p50.py
+++ b/genai-perf/genai_perf/record/types/gpu_temperature_p50.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_temperature_base import GPUTemperatureBase
+
+
+@total_ordering
+class GpuTemperatureP50(GPUTemperatureBase):
+    """
+    A record for p50 GPU Temperature metric
+    """
+
+    tag = GPUTemperatureBase.base_tag + "_p50"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p50 GPU Temperature (°C)"

--- a/genai-perf/genai_perf/record/types/gpu_temperature_p75.py
+++ b/genai-perf/genai_perf/record/types/gpu_temperature_p75.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_temperature_base import GPUTemperatureBase
+
+
+@total_ordering
+class GpuTemperatureP75(GPUTemperatureBase):
+    """
+    A record for p75 GPU Temperature metric
+    """
+
+    tag = GPUTemperatureBase.base_tag + "_p75"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p75 GPU Temperature (°C)"

--- a/genai-perf/genai_perf/record/types/gpu_temperature_p90.py
+++ b/genai-perf/genai_perf/record/types/gpu_temperature_p90.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_temperature_base import GPUTemperatureBase
+
+
+@total_ordering
+class GpuTemperatureP90(GPUTemperatureBase):
+    """
+    A record for p90 GPU Temperature metric
+    """
+
+    tag = GPUTemperatureBase.base_tag + "_p90"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p90 GPU Temperature (°C)"

--- a/genai-perf/genai_perf/record/types/gpu_temperature_p95.py
+++ b/genai-perf/genai_perf/record/types/gpu_temperature_p95.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_temperature_base import GPUTemperatureBase
+
+
+@total_ordering
+class GpuTemperatureP95(GPUTemperatureBase):
+    """
+    A record for p95 GPU Temperature metric
+    """
+
+    tag = GPUTemperatureBase.base_tag + "_p95"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p95 GPU Temperature (°C)"

--- a/genai-perf/genai_perf/record/types/gpu_temperature_p99.py
+++ b/genai-perf/genai_perf/record/types/gpu_temperature_p99.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_temperature_base import GPUTemperatureBase
+
+
+@total_ordering
+class GpuTemperatureP99(GPUTemperatureBase):
+    """
+    A record for p99 GPU Temperature metric
+    """
+
+    tag = GPUTemperatureBase.base_tag + "_p99"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p99 GPU Temperature (°C)"

--- a/genai-perf/genai_perf/record/types/gpu_temperature_std.py
+++ b/genai-perf/genai_perf/record/types/gpu_temperature_std.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.gpu_temperature_base import GPUTemperatureBase
+
+
+@total_ordering
+class GpuTemperatureStd(GPUTemperatureBase):
+    """
+    A record for std GPU Temperature metric
+    """
+
+    tag = GPUTemperatureBase.base_tag + "_std"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Std. GPU Temperature (°C)"

--- a/genai-perf/genai_perf/record/types/gpu_utilization_base.py
+++ b/genai-perf/genai_perf/record/types/gpu_utilization_base.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ class GPUUtilizationBase(IncreasingGPURecord):
     """
 
     base_tag = "gpu_utilization"
-    reduction_factor = ReductionFactor.PERCENTAGE
+    reduction_factor = ReductionFactor.NONE
 
     def __init__(self, value, device_uuid=None, timestamp=0):
         super().__init__(value, device_uuid, timestamp)

--- a/genai-perf/genai_perf/record/types/gpu_utilization_std.py
+++ b/genai-perf/genai_perf/record/types/gpu_utilization_std.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ from genai_perf.record.types.gpu_utilization_base import GPUUtilizationBase
 @total_ordering
 class GPUUtilizationStd(GPUUtilizationBase):
     """
-    A record for min GPU Utilization metric
+    A record for std GPU Utilization metric
     """
 
     tag = GPUUtilizationBase.base_tag + "_std"

--- a/genai-perf/genai_perf/record/types/memory_copy_utilization_avg.py
+++ b/genai-perf/genai_perf/record/types/memory_copy_utilization_avg.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.memory_copy_utilization_base import (
+    MemoryCopyUtilizationBase,
+)
+
+
+@total_ordering
+class MemoryCopyUtilizationAvg(MemoryCopyUtilizationBase):
+    """
+    A record for avg Memory Copy Utilization metric
+    """
+
+    tag = MemoryCopyUtilizationBase.base_tag + "_avg"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Avg. Memory Copy Utilization (%)"

--- a/genai-perf/genai_perf/record/types/memory_copy_utilization_base.py
+++ b/genai-perf/genai_perf/record/types/memory_copy_utilization_base.py
@@ -1,0 +1,58 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.gpu_record import IncreasingGPURecord
+from genai_perf.record.record import ReductionFactor
+
+
+@total_ordering
+class MemoryCopyUtilizationBase(IncreasingGPURecord):
+    """
+    A base class for the Memory Copy Utilization percentage metric
+    """
+
+    base_tag = "memory_copy_utilization"
+    reduction_factor = ReductionFactor.NONE
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @staticmethod
+    def aggregation_function():
+        def average(seq):
+            return sum(seq[1:], start=seq[0]) / len(seq)
+
+        return average
+
+    @staticmethod
+    def header(aggregation_tag=False):
+        return ("Average " if aggregation_tag else "") + "Memory Copy Utilization (%)"
+
+    def __eq__(self, other: "MemoryCopyUtilizationBase") -> bool:  # type: ignore
+        return self.value() == other.value()
+
+    def __lt__(self, other: "MemoryCopyUtilizationBase") -> bool:
+        return self.value() < other.value()
+
+    def __add__(
+        self, other: "MemoryCopyUtilizationBase"
+    ) -> "MemoryCopyUtilizationBase":
+        return self.__class__(device_uuid=None, value=(self.value() + other.value()))
+
+    def __sub__(
+        self, other: "MemoryCopyUtilizationBase"
+    ) -> "MemoryCopyUtilizationBase":
+        return self.__class__(device_uuid=None, value=(self.value() - other.value()))

--- a/genai-perf/genai_perf/record/types/memory_copy_utilization_max.py
+++ b/genai-perf/genai_perf/record/types/memory_copy_utilization_max.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.memory_copy_utilization_base import (
+    MemoryCopyUtilizationBase,
+)
+
+
+@total_ordering
+class MemoryCopyUtilizationMax(MemoryCopyUtilizationBase):
+    """
+    A record for max Memory Copy Utilization metric
+    """
+
+    tag = MemoryCopyUtilizationBase.base_tag + "_max"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Max Memory Copy Utilization (%)"

--- a/genai-perf/genai_perf/record/types/memory_copy_utilization_min.py
+++ b/genai-perf/genai_perf/record/types/memory_copy_utilization_min.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.memory_copy_utilization_base import (
+    MemoryCopyUtilizationBase,
+)
+
+
+@total_ordering
+class MemoryCopyUtilizationMin(MemoryCopyUtilizationBase):
+    """
+    A record for min Memory Copy Utilization metric
+    """
+
+    tag = MemoryCopyUtilizationBase.base_tag + "_min"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Min Memory Copy Utilization (%)"

--- a/genai-perf/genai_perf/record/types/memory_copy_utilization_p25.py
+++ b/genai-perf/genai_perf/record/types/memory_copy_utilization_p25.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.memory_copy_utilization_base import (
+    MemoryCopyUtilizationBase,
+)
+
+
+@total_ordering
+class MemoryCopyUtilizationP25(MemoryCopyUtilizationBase):
+    """
+    A record for p25 Memory Copy Utilization metric
+    """
+
+    tag = MemoryCopyUtilizationBase.base_tag + "_p25"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p25 Memory Copy Utilization (%)"

--- a/genai-perf/genai_perf/record/types/memory_copy_utilization_p50.py
+++ b/genai-perf/genai_perf/record/types/memory_copy_utilization_p50.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.memory_copy_utilization_base import (
+    MemoryCopyUtilizationBase,
+)
+
+
+@total_ordering
+class MemoryCopyUtilizationP50(MemoryCopyUtilizationBase):
+    """
+    A record for p50 Memory Copy Utilization metric
+    """
+
+    tag = MemoryCopyUtilizationBase.base_tag + "_p50"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p50 Memory Copy Utilization (%)"

--- a/genai-perf/genai_perf/record/types/memory_copy_utilization_p75.py
+++ b/genai-perf/genai_perf/record/types/memory_copy_utilization_p75.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.memory_copy_utilization_base import (
+    MemoryCopyUtilizationBase,
+)
+
+
+@total_ordering
+class MemoryCopyUtilizationP75(MemoryCopyUtilizationBase):
+    """
+    A record for p75 Memory Copy Utilization metric
+    """
+
+    tag = MemoryCopyUtilizationBase.base_tag + "_p75"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p75 Memory Copy Utilization (%)"

--- a/genai-perf/genai_perf/record/types/memory_copy_utilization_p90.py
+++ b/genai-perf/genai_perf/record/types/memory_copy_utilization_p90.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.memory_copy_utilization_base import (
+    MemoryCopyUtilizationBase,
+)
+
+
+@total_ordering
+class MemoryCopyUtilizationP90(MemoryCopyUtilizationBase):
+    """
+    A record for p90 Memory Copy Utilization metric
+    """
+
+    tag = MemoryCopyUtilizationBase.base_tag + "_p90"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p90 Memory Copy Utilization (%)"

--- a/genai-perf/genai_perf/record/types/memory_copy_utilization_p95.py
+++ b/genai-perf/genai_perf/record/types/memory_copy_utilization_p95.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.memory_copy_utilization_base import (
+    MemoryCopyUtilizationBase,
+)
+
+
+@total_ordering
+class MemoryCopyUtilizationP95(MemoryCopyUtilizationBase):
+    """
+    A record for p95 Memory Copy Utilization metric
+    """
+
+    tag = MemoryCopyUtilizationBase.base_tag + "_p95"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p95 Memory Copy Utilization (%)"

--- a/genai-perf/genai_perf/record/types/memory_copy_utilization_p99.py
+++ b/genai-perf/genai_perf/record/types/memory_copy_utilization_p99.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.memory_copy_utilization_base import (
+    MemoryCopyUtilizationBase,
+)
+
+
+@total_ordering
+class MemoryCopyUtilizationP99(MemoryCopyUtilizationBase):
+    """
+    A record for p99 Memory Copy Utilization metric
+    """
+
+    tag = MemoryCopyUtilizationBase.base_tag + "_p99"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p99 Memory Copy Utilization (%)"

--- a/genai-perf/genai_perf/record/types/memory_copy_utilization_std.py
+++ b/genai-perf/genai_perf/record/types/memory_copy_utilization_std.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.memory_copy_utilization_base import (
+    MemoryCopyUtilizationBase,
+)
+
+
+@total_ordering
+class MemoryCopyUtilizationStd(MemoryCopyUtilizationBase):
+    """
+    A record for std Memory Copy Utilization metric
+    """
+
+    tag = MemoryCopyUtilizationBase.base_tag + "_std"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Std. Memory Copy Utilization (%)"

--- a/genai-perf/genai_perf/record/types/sm_utilization_avg.py
+++ b/genai-perf/genai_perf/record/types/sm_utilization_avg.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.sm_utilization_base import SMUtilizationBase
+
+
+@total_ordering
+class SMUtilizationAvg(SMUtilizationBase):
+    """
+    A record for avg SM Utilization metric
+    """
+
+    tag = SMUtilizationBase.base_tag + "_avg"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Avg. SM Utilization (%)"

--- a/genai-perf/genai_perf/record/types/sm_utilization_base.py
+++ b/genai-perf/genai_perf/record/types/sm_utilization_base.py
@@ -1,0 +1,54 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.gpu_record import IncreasingGPURecord
+from genai_perf.record.record import ReductionFactor
+
+
+@total_ordering
+class SMUtilizationBase(IncreasingGPURecord):
+    """
+    A base class for the SM Utilization percentage metric
+    """
+
+    base_tag = "sm_utilization"
+    reduction_factor = ReductionFactor.PERCENTAGE
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @staticmethod
+    def aggregation_function():
+        def average(seq):
+            return sum(seq[1:], start=seq[0]) / len(seq)
+
+        return average
+
+    @staticmethod
+    def header(aggregation_tag=False):
+        return ("Average " if aggregation_tag else "") + "SM Utilization (%)"
+
+    def __eq__(self, other: "SMUtilizationBase") -> bool:  # type: ignore
+        return self.value() == other.value()
+
+    def __lt__(self, other: "SMUtilizationBase") -> bool:
+        return self.value() < other.value()
+
+    def __add__(self, other: "SMUtilizationBase") -> "SMUtilizationBase":
+        return self.__class__(device_uuid=None, value=(self.value() + other.value()))
+
+    def __sub__(self, other: "SMUtilizationBase") -> "SMUtilizationBase":
+        return self.__class__(device_uuid=None, value=(self.value() - other.value()))

--- a/genai-perf/genai_perf/record/types/sm_utilization_max.py
+++ b/genai-perf/genai_perf/record/types/sm_utilization_max.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.sm_utilization_base import SMUtilizationBase
+
+
+@total_ordering
+class SMUtilizationMax(SMUtilizationBase):
+    """
+    A record for max SM Utilization metric
+    """
+
+    tag = SMUtilizationBase.base_tag + "_max"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Max SM Utilization (%)"

--- a/genai-perf/genai_perf/record/types/sm_utilization_min.py
+++ b/genai-perf/genai_perf/record/types/sm_utilization_min.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.sm_utilization_base import SMUtilizationBase
+
+
+@total_ordering
+class SMUtilizationMin(SMUtilizationBase):
+    """
+    A record for min SM Utilization metric
+    """
+
+    tag = SMUtilizationBase.base_tag + "_min"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Min SM Utilization (%)"

--- a/genai-perf/genai_perf/record/types/sm_utilization_p25.py
+++ b/genai-perf/genai_perf/record/types/sm_utilization_p25.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/genai-perf/genai_perf/record/types/sm_utilization_p50.py
+++ b/genai-perf/genai_perf/record/types/sm_utilization_p50.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.sm_utilization_base import SMUtilizationBase
+
+
+@total_ordering
+class SMUtilizationP50(SMUtilizationBase):
+    """
+    A record for p50 SM Utilization metric
+    """
+
+    tag = SMUtilizationBase.base_tag + "_p50"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "P50 SM Utilization (%)"

--- a/genai-perf/genai_perf/record/types/sm_utilization_p75.py
+++ b/genai-perf/genai_perf/record/types/sm_utilization_p75.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.sm_utilization_base import SMUtilizationBase
+
+
+@total_ordering
+class SMUtilizationP75(SMUtilizationBase):
+    """
+    A record for p75 SM Utilization metric
+    """
+
+    tag = SMUtilizationBase.base_tag + "_p75"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "P75 SM Utilization (%)"

--- a/genai-perf/genai_perf/record/types/sm_utilization_p90.py
+++ b/genai-perf/genai_perf/record/types/sm_utilization_p90.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.sm_utilization_base import SMUtilizationBase
+
+
+@total_ordering
+class SMUtilizationP90(SMUtilizationBase):
+    """
+    A record for p90 SM Utilization metric
+    """
+
+    tag = SMUtilizationBase.base_tag + "_p90"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "P90 SM Utilization (%)"

--- a/genai-perf/genai_perf/record/types/sm_utilization_p95.py
+++ b/genai-perf/genai_perf/record/types/sm_utilization_p95.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.sm_utilization_base import SMUtilizationBase
+
+
+@total_ordering
+class SMUtilizationP95(SMUtilizationBase):
+    """
+    A record for p95 SM Utilization metric
+    """
+
+    tag = SMUtilizationBase.base_tag + "_p95"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "P95 SM Utilization (%)"

--- a/genai-perf/genai_perf/record/types/sm_utilization_p99.py
+++ b/genai-perf/genai_perf/record/types/sm_utilization_p99.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.sm_utilization_base import SMUtilizationBase
+
+
+@total_ordering
+class SMUtilizationP99(SMUtilizationBase):
+    """
+    A record for p99 SM Utilization metric
+    """
+
+    tag = SMUtilizationBase.base_tag + "_p99"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "P99 SM Utilization (%)"

--- a/genai-perf/genai_perf/record/types/sm_utilization_std.py
+++ b/genai-perf/genai_perf/record/types/sm_utilization_std.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.sm_utilization_base import SMUtilizationBase
+
+
+@total_ordering
+class SMUtilizationStd(SMUtilizationBase):
+    """
+    A record for std SM Utilization metric
+    """
+
+    tag = SMUtilizationBase.base_tag + "_std"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Std. SM Utilization (%)"

--- a/genai-perf/genai_perf/record/types/total_gpu_memory_base.py
+++ b/genai-perf/genai_perf/record/types/total_gpu_memory_base.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ class GPUTotalMemoryBase(IncreasingGPURecord):
     """
 
     base_tag = "total_gpu_memory"
-    reduction_factor = ReductionFactor.B_TO_GB
+    reduction_factor = ReductionFactor.MIB_TO_GB
 
     def __init__(self, value, device_uuid=None, timestamp=0):
         super().__init__(value, device_uuid, timestamp)

--- a/genai-perf/genai_perf/record/types/video_decoder_utilization_avg.py
+++ b/genai-perf/genai_perf/record/types/video_decoder_utilization_avg.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_decoder_utilization_base import (
+    VideoDecoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoDecoderUtilizationAvg(VideoDecoderUtilizationBase):
+    """
+    A record for avg Video Decoder Utilization metric
+    """
+
+    tag = VideoDecoderUtilizationBase.base_tag + "_avg"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Avg. Video Decoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_decoder_utilization_base.py
+++ b/genai-perf/genai_perf/record/types/video_decoder_utilization_base.py
@@ -1,0 +1,58 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.gpu_record import IncreasingGPURecord
+from genai_perf.record.record import ReductionFactor
+
+
+@total_ordering
+class VideoDecoderUtilizationBase(IncreasingGPURecord):
+    """
+    A base class for the Video Decoder utilization percentage metric
+    """
+
+    base_tag = "video_decoder_utilization"
+    reduction_factor = ReductionFactor.NONE
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @staticmethod
+    def aggregation_function():
+        def average(seq):
+            return sum(seq[1:], start=seq[0]) / len(seq)
+
+        return average
+
+    @staticmethod
+    def header(aggregation_tag=False):
+        return ("Average " if aggregation_tag else "") + "Video Decoder Utilization (%)"
+
+    def __eq__(self, other: "VideoDecoderUtilizationBase") -> bool:  # type: ignore
+        return self.value() == other.value()
+
+    def __lt__(self, other: "VideoDecoderUtilizationBase") -> bool:
+        return self.value() < other.value()
+
+    def __add__(
+        self, other: "VideoDecoderUtilizationBase"
+    ) -> "VideoDecoderUtilizationBase":
+        return self.__class__(device_uuid=None, value=(self.value() + other.value()))
+
+    def __sub__(
+        self, other: "VideoDecoderUtilizationBase"
+    ) -> "VideoDecoderUtilizationBase":
+        return self.__class__(device_uuid=None, value=(self.value() - other.value()))

--- a/genai-perf/genai_perf/record/types/video_decoder_utilization_max.py
+++ b/genai-perf/genai_perf/record/types/video_decoder_utilization_max.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_decoder_utilization_base import (
+    VideoDecoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationMax(VideoDecoderUtilizationBase):
+    """
+    A record for max Video Decoder Utilization metric
+    """
+
+    tag = VideoDecoderUtilizationBase.base_tag + "_max"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Max Video Decoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_decoder_utilization_min.py
+++ b/genai-perf/genai_perf/record/types/video_decoder_utilization_min.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_decoder_utilization_base import (
+    VideoDecoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationMin(VideoDecoderUtilizationBase):
+    """
+    A record for min Video Decoder Utilization metric
+    """
+
+    tag = VideoDecoderUtilizationBase.base_tag + "_min"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Min Video Decoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_decoder_utilization_p25.py
+++ b/genai-perf/genai_perf/record/types/video_decoder_utilization_p25.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_decoder_utilization_base import (
+    VideoDecoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationP25(VideoDecoderUtilizationBase):
+    """
+    A record for p25 Video Decoder Utilization metric
+    """
+
+    tag = VideoDecoderUtilizationBase.base_tag + "_p25"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "P25 Video Decoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_decoder_utilization_p50.py
+++ b/genai-perf/genai_perf/record/types/video_decoder_utilization_p50.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_decoder_utilization_base import (
+    VideoDecoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationP50(VideoDecoderUtilizationBase):
+    """
+    A record for p50 Video Decoder Utilization metric
+    """
+
+    tag = VideoDecoderUtilizationBase.base_tag + "_p50"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "P50 Video Decoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_decoder_utilization_p75.py
+++ b/genai-perf/genai_perf/record/types/video_decoder_utilization_p75.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_decoder_utilization_base import (
+    VideoDecoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationP75(VideoDecoderUtilizationBase):
+    """
+    A record for p75 Video Decoder Utilization metric
+    """
+
+    tag = VideoDecoderUtilizationBase.base_tag + "_p75"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "P75 Video Decoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_decoder_utilization_p90.py
+++ b/genai-perf/genai_perf/record/types/video_decoder_utilization_p90.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_decoder_utilization_base import (
+    VideoDecoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationP90(VideoDecoderUtilizationBase):
+    """
+    A record for p90 Video Decoder Utilization metric
+    """
+
+    tag = VideoDecoderUtilizationBase.base_tag + "_p90"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "P90 Video Decoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_decoder_utilization_p95.py
+++ b/genai-perf/genai_perf/record/types/video_decoder_utilization_p95.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_decoder_utilization_base import (
+    VideoDecoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationP95(VideoDecoderUtilizationBase):
+    """
+    A record for p95 Video Decoder Utilization metric
+    """
+
+    tag = VideoDecoderUtilizationBase.base_tag + "_p95"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "P95 Video Decoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_decoder_utilization_p99.py
+++ b/genai-perf/genai_perf/record/types/video_decoder_utilization_p99.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_decoder_utilization_base import (
+    VideoDecoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationP99(VideoDecoderUtilizationBase):
+    """
+    A record for p99 Video Decoder Utilization metric
+    """
+
+    tag = VideoDecoderUtilizationBase.base_tag + "_p99"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "P99 Video Decoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_decoder_utilization_std.py
+++ b/genai-perf/genai_perf/record/types/video_decoder_utilization_std.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_decoder_utilization_base import (
+    VideoDecoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationStd(VideoDecoderUtilizationBase):
+    """
+    A record for std Video Decoder Utilization metric
+    """
+
+    tag = VideoDecoderUtilizationBase.base_tag + "_std"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Std. Video Decoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_encoder_utilization_avg.py
+++ b/genai-perf/genai_perf/record/types/video_encoder_utilization_avg.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_encoder_utilization_base import (
+    VideoEncoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationAvg(VideoEncoderUtilizationBase):
+    """
+    A record for avg Video Encoder Utilization metric
+    """
+
+    tag = VideoEncoderUtilizationBase.base_tag + "_avg"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Avg. Video Encoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_encoder_utilization_base.py
+++ b/genai-perf/genai_perf/record/types/video_encoder_utilization_base.py
@@ -1,0 +1,58 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.gpu_record import IncreasingGPURecord
+from genai_perf.record.record import ReductionFactor
+
+
+@total_ordering
+class VideoEncoderUtilizationBase(IncreasingGPURecord):
+    """
+    A base class for the Video Encoder utilization percentage metric
+    """
+
+    base_tag = "video_encoder_utilization"
+    reduction_factor = ReductionFactor.NONE
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @staticmethod
+    def aggregation_function():
+        def average(seq):
+            return sum(seq[1:], start=seq[0]) / len(seq)
+
+        return average
+
+    @staticmethod
+    def header(aggregation_tag=False):
+        return ("Average " if aggregation_tag else "") + "Video Encoder Utilization (%)"
+
+    def __eq__(self, other: "VideoEncoderUtilizationBase") -> bool:  # type: ignore
+        return self.value() == other.value()
+
+    def __lt__(self, other: "VideoEncoderUtilizationBase") -> bool:
+        return self.value() < other.value()
+
+    def __add__(
+        self, other: "VideoEncoderUtilizationBase"
+    ) -> "VideoEncoderUtilizationBase":
+        return self.__class__(device_uuid=None, value=(self.value() + other.value()))
+
+    def __sub__(
+        self, other: "VideoEncoderUtilizationBase"
+    ) -> "VideoEncoderUtilizationBase":
+        return self.__class__(device_uuid=None, value=(self.value() - other.value()))

--- a/genai-perf/genai_perf/record/types/video_encoder_utilization_max.py
+++ b/genai-perf/genai_perf/record/types/video_encoder_utilization_max.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_encoder_utilization_base import (
+    VideoEncoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationMax(VideoEncoderUtilizationBase):
+    """
+    A record for max Video Encoder Utilization metric
+    """
+
+    tag = VideoEncoderUtilizationBase.base_tag + "_max"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Max Video Encoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_encoder_utilization_min.py
+++ b/genai-perf/genai_perf/record/types/video_encoder_utilization_min.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_encoder_utilization_base import (
+    VideoEncoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationMin(VideoEncoderUtilizationBase):
+    """
+    A record for min Video Encoder Utilization metric
+    """
+
+    tag = VideoEncoderUtilizationBase.base_tag + "_min"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Min Video Encoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_encoder_utilization_p25.py
+++ b/genai-perf/genai_perf/record/types/video_encoder_utilization_p25.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_encoder_utilization_base import (
+    VideoEncoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationP25(VideoEncoderUtilizationBase):
+    """
+    A record for p25 Video Encoder Utilization metric
+    """
+
+    tag = VideoEncoderUtilizationBase.base_tag + "_p25"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p25 Video Encoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_encoder_utilization_p50.py
+++ b/genai-perf/genai_perf/record/types/video_encoder_utilization_p50.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_encoder_utilization_base import (
+    VideoEncoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationP50(VideoEncoderUtilizationBase):
+    """
+    A record for p50 Video Encoder Utilization metric
+    """
+
+    tag = VideoEncoderUtilizationBase.base_tag + "_p50"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p50 Video Encoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_encoder_utilization_p75.py
+++ b/genai-perf/genai_perf/record/types/video_encoder_utilization_p75.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_encoder_utilization_base import (
+    VideoEncoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationP75(VideoEncoderUtilizationBase):
+    """
+    A record for p75 Video Encoder Utilization metric
+    """
+
+    tag = VideoEncoderUtilizationBase.base_tag + "_p75"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p75 Video Encoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_encoder_utilization_p90.py
+++ b/genai-perf/genai_perf/record/types/video_encoder_utilization_p90.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_encoder_utilization_base import (
+    VideoEncoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationP90(VideoEncoderUtilizationBase):
+    """
+    A record for p90 Video Encoder Utilization metric
+    """
+
+    tag = VideoEncoderUtilizationBase.base_tag + "_p90"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p90 Video Encoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_encoder_utilization_p95.py
+++ b/genai-perf/genai_perf/record/types/video_encoder_utilization_p95.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_encoder_utilization_base import (
+    VideoEncoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationP95(VideoEncoderUtilizationBase):
+    """
+    A record for p95 Video Encoder Utilization metric
+    """
+
+    tag = VideoEncoderUtilizationBase.base_tag + "_p95"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p95 Video Encoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_encoder_utilization_p99.py
+++ b/genai-perf/genai_perf/record/types/video_encoder_utilization_p99.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_encoder_utilization_base import (
+    VideoEncoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationP99(VideoEncoderUtilizationBase):
+    """
+    A record for p99 Video Encoder Utilization metric
+    """
+
+    tag = VideoEncoderUtilizationBase.base_tag + "_p99"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p99 Video Encoder Utilization (%)"

--- a/genai-perf/genai_perf/record/types/video_encoder_utilization_std.py
+++ b/genai-perf/genai_perf/record/types/video_encoder_utilization_std.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.video_encoder_utilization_base import (
+    VideoEncoderUtilizationBase,
+)
+
+
+@total_ordering
+class VideoEncoderUtilizationStd(VideoEncoderUtilizationBase):
+    """
+    A record for std Video Encoder Utilization metric
+    """
+
+    tag = VideoEncoderUtilizationBase.base_tag + "_std"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Std. Video Encoder Utilization (%)"

--- a/genai-perf/genai_perf/telemetry_data/dcgm_telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/dcgm_telemetry_data_collector.py
@@ -27,6 +27,7 @@
 from typing import Dict, List, Optional, Tuple
 
 import genai_perf.logging as logging
+from genai_perf.metrics.telemetry_metrics import TelemetryMetricName
 from genai_perf.telemetry_data.telemetry_data_collector import TelemetryDataCollector
 
 logger = logging.getLogger(__name__)
@@ -35,13 +36,22 @@ logger = logging.getLogger(__name__)
 class DCGMTelemetryDataCollector(TelemetryDataCollector):
     """Collects telemetry metrics from DCGM metrics endpoint."""
 
-    METRIC_NAME_MAPPING = {
-        "DCGM_FI_DEV_POWER_USAGE": "gpu_power_usage",
-        "DCGM_FI_DEV_POWER_MGMT_LIMIT": "gpu_power_limit",
-        "DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION": "energy_consumption",
-        "DCGM_FI_DEV_GPU_UTIL": "gpu_utilization",
-        "DCGM_FI_DEV_FB_USED": "gpu_memory_used",
-        "DCGM_FI_DEV_FB_TOTAL": "total_gpu_memory",
+    DCGM_TO_INTERNAL_METRIC_NAME = {
+        "DCGM_FI_DEV_POWER_USAGE": TelemetryMetricName.GPU_POWER_USAGE,
+        "DCGM_FI_DEV_POWER_MGMT_LIMIT": TelemetryMetricName.GPU_POWER_LIMIT,
+        "DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION": TelemetryMetricName.ENERGY_CONSUMPTION,
+        "DCGM_FI_DEV_GPU_UTIL": TelemetryMetricName.GPU_UTILIZATION,
+        "DCGM_FI_DEV_MEM_COPY_UTIL": TelemetryMetricName.MEMORY_COPY_UTILIZATION,
+        "DCGM_FI_DEV_ENC_UTIL": TelemetryMetricName.VIDEO_ENCODER_UTILIZATION,
+        "DCGM_FI_DEV_DEC_UTIL": TelemetryMetricName.VIDEO_DECODER_UTILIZATION,
+        "DCGM_FI_PROF_SM_ACTIVE": TelemetryMetricName.SM_UTILIZATION,
+        "DCGM_FI_DEV_SM_CLOCK": TelemetryMetricName.GPU_CLOCK_SM,
+        "DCGM_FI_DEV_MEM_CLOCK": TelemetryMetricName.GPU_CLOCK_MEMORY,
+        "DCGM_FI_DEV_FB_USED": TelemetryMetricName.GPU_MEMORY_USED,
+        "DCGM_FI_DEV_FB_TOTAL": TelemetryMetricName.TOTAL_GPU_MEMORY,
+        "DCGM_FI_DEV_FB_FREE": TelemetryMetricName.GPU_MEMORY_FREE,
+        "DCGM_FI_DEV_MEMORY_TEMP": TelemetryMetricName.GPU_MEMORY_TEMPERATURE,
+        "DCGM_FI_DEV_GPU_TEMP": TelemetryMetricName.GPU_TEMPERATURE,
     }
 
     def _process_and_update_metrics(self, metrics_data: str) -> None:
@@ -74,7 +84,7 @@ class DCGMTelemetryDataCollector(TelemetryDataCollector):
 
             metric_full_name, metric_value = parsed
             metric_name = metric_full_name.split("{")[0]
-            mapped_key = self.METRIC_NAME_MAPPING.get(metric_name)
+            mapped_key = self.DCGM_TO_INTERNAL_METRIC_NAME.get(metric_name)
             if not mapped_key:
                 continue
 

--- a/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/telemetry_data_collector.py
@@ -36,7 +36,7 @@ from genai_perf.metrics import TelemetryMetrics, TelemetryStatistics
 
 class TelemetryDataCollector(ABC):
     def __init__(
-        self, server_metrics_url: str, collection_interval: float = 1.0  # in seconds
+        self, server_metrics_url: str, collection_interval: float = 0.33  # in seconds
     ) -> None:
         self._server_metrics_url = server_metrics_url
         self._collection_interval = collection_interval

--- a/genai-perf/tests/test_collectors/test_dcgm_telemetry_data_collector.py
+++ b/genai-perf/tests/test_collectors/test_dcgm_telemetry_data_collector.py
@@ -40,31 +40,61 @@ def collector():
     )
     collector._metrics = MagicMock(spec=TelemetryMetrics)
     collector._metrics.TELEMETRY_METRICS = [
-        MagicMock(name="gpu_power_usage"),
-        MagicMock(name="gpu_power_limit"),
-        MagicMock(name="energy_consumption"),
-        MagicMock(name="gpu_utilization"),
-        MagicMock(name="gpu_memory_used"),
-        MagicMock(name="total_gpu_memory"),
+        MagicMock(name=n)
+        for n in [
+            "gpu_power_usage",
+            "gpu_power_limit",
+            "energy_consumption",
+            "gpu_utilization",
+            "gpu_memory_used",
+            "total_gpu_memory",
+            "gpu_memory_free",
+            "gpu_memory_temperature",
+            "gpu_temperature",
+            "gpu_clock_sm",
+            "gpu_clock_memory",
+            "sm_utilization",
+            "memory_copy_utilization",
+            "video_encoder_utilization",
+            "video_decoder_utilization",
+        ]
     ]
     return collector
 
 
 def test_process_and_update_metrics_success(collector):
     sample_metrics = """
-    # HELP DCGM_FI_DEV_POWER_USAGE Power draw (in W).
     DCGM_FI_DEV_POWER_USAGE{gpu="0"} 25.0
     DCGM_FI_DEV_GPU_UTIL{gpu="0"} 88.5
     DCGM_FI_DEV_FB_USED{gpu="0"} 4096
+    DCGM_FI_DEV_FB_TOTAL{gpu="0"} 49152
+    DCGM_FI_DEV_FB_FREE{gpu="0"} 8192
+    DCGM_FI_DEV_MEMORY_TEMP{gpu="0"} 60
+    DCGM_FI_DEV_GPU_TEMP{gpu="0"} 70
+    DCGM_FI_DEV_SM_CLOCK{gpu="0"} 1530
+    DCGM_FI_DEV_MEM_CLOCK{gpu="0"} 5050
+    DCGM_FI_PROF_SM_ACTIVE{gpu="0"} 65
+    DCGM_FI_DEV_MEM_COPY_UTIL{gpu="0"} 55
+    DCGM_FI_DEV_ENC_UTIL{gpu="0"} 22
+    DCGM_FI_DEV_DEC_UTIL{gpu="0"} 17
     """
 
     collector._process_and_update_metrics(sample_metrics)
-
     update_call = collector.metrics.update_metrics.call_args[0][0]
 
     assert update_call["gpu_power_usage"]["0"] == [25.0]
     assert update_call["gpu_utilization"]["0"] == [88.5]
     assert update_call["gpu_memory_used"]["0"] == [4096.0]
+    assert update_call["total_gpu_memory"]["0"] == [49152.0]
+    assert update_call["gpu_memory_free"]["0"] == [8192.0]
+    assert update_call["gpu_memory_temperature"]["0"] == [60.0]
+    assert update_call["gpu_temperature"]["0"] == [70.0]
+    assert update_call["gpu_clock_sm"]["0"] == [1530.0]
+    assert update_call["gpu_clock_memory"]["0"] == [5050.0]
+    assert update_call["sm_utilization"]["0"] == [65.0]
+    assert update_call["memory_copy_utilization"]["0"] == [55.0]
+    assert update_call["video_encoder_utilization"]["0"] == [22.0]
+    assert update_call["video_decoder_utilization"]["0"] == [17.0]
 
 
 def test_process_and_update_metrics_ignores_unmapped_metrics(collector):

--- a/genai-perf/tests/test_collectors/test_dcgm_telemetry_data_collector.py
+++ b/genai-perf/tests/test_collectors/test_dcgm_telemetry_data_collector.py
@@ -27,7 +27,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-from genai_perf.metrics.telemetry_metrics import TelemetryMetrics
+from genai_perf.metrics.telemetry_metrics import TelemetryMetricName, TelemetryMetrics
 from genai_perf.telemetry_data.dcgm_telemetry_data_collector import (
     DCGMTelemetryDataCollector,
 )
@@ -40,24 +40,7 @@ def collector():
     )
     collector._metrics = MagicMock(spec=TelemetryMetrics)
     collector._metrics.TELEMETRY_METRICS = [
-        MagicMock(name=n)
-        for n in [
-            "gpu_power_usage",
-            "gpu_power_limit",
-            "energy_consumption",
-            "gpu_utilization",
-            "gpu_memory_used",
-            "total_gpu_memory",
-            "gpu_memory_free",
-            "gpu_memory_temperature",
-            "gpu_temperature",
-            "gpu_clock_sm",
-            "gpu_clock_memory",
-            "sm_utilization",
-            "memory_copy_utilization",
-            "video_encoder_utilization",
-            "video_decoder_utilization",
-        ]
+        MagicMock(name=metric.value) for metric in TelemetryMetricName
     ]
     return collector
 

--- a/genai-perf/tests/test_exporters/test_csv_exporter.py
+++ b/genai-perf/tests/test_exporters/test_csv_exporter.py
@@ -335,8 +335,8 @@ class TestCsvExporter:
 
         assert returned_data[-2] == expected_content
 
-    def test_triton_telemetry_output(
-        self, monkeypatch, mock_read_write: pytest.MonkeyPatch, llm_metrics: LLMMetrics
+    def test_telemetry_output(
+        self, monkeypatch, mock_read_write, llm_metrics: LLMMetrics
     ) -> None:
         argv = [
             "genai-perf",
@@ -357,8 +357,17 @@ class TestCsvExporter:
             gpu_power_limit={"gpu0": [250.0, 250.0]},
             energy_consumption={"gpu0": [0.5, 0.6]},
             gpu_utilization={"gpu0": [75.0, 80.0]},
+            sm_utilization={"gpu0": [60.0, 70.0]},
+            memory_copy_utilization={"gpu0": [55.0, 60.0]},
+            video_encoder_utilization={"gpu0": [20.0, 25.0]},
+            video_decoder_utilization={"gpu0": [15.0, 18.0]},
             total_gpu_memory={"gpu0": [8.0, 8.0]},
             gpu_memory_used={"gpu0": [4.0, 4.0]},
+            gpu_memory_free={"gpu0": [3.5, 3.6]},
+            gpu_memory_temperature={"gpu0": [60.0, 65.0]},
+            gpu_temperature={"gpu0": [70.0, 75.0]},
+            gpu_clock_sm={"gpu0": [1500.0, 1550.0]},
+            gpu_clock_memory={"gpu0": [5000.0, 5100.0]},
         )
 
         stats = Statistics(metrics=llm_metrics)
@@ -393,8 +402,17 @@ class TestCsvExporter:
             "Metric,GPU,avg,min,max,p99,p95,p90,p75,p50,p25\r\n",
             "GPU Power Usage (W),gpu0,45.85,45.20,46.50,46.49,46.44,46.37,46.17,45.85,45.53\r\n",
             "Energy Consumption (MJ),gpu0,0.55,0.50,0.60,0.60,0.59,0.59,0.57,0.55,0.53\r\n",
-            "GPU Utilization (%),gpu0,77.50,75.00,80.00,79.95,79.75,79.50,78.75,77.50,76.25\r\n",
             "GPU Memory Used (GB),gpu0,4.00,4.00,4.00,4.00,4.00,4.00,4.00,4.00,4.00\r\n",
+            "GPU Memory Free (GB),gpu0,3.55,3.50,3.60,3.60,3.60,3.59,3.58,3.55,3.52\r\n",
+            "GPU Utilization (%),gpu0,77.50,75.00,80.00,79.95,79.75,79.50,78.75,77.50,76.25\r\n",
+            "Sm Utilization (%),gpu0,65.00,60.00,70.00,69.90,69.50,69.00,67.50,65.00,62.50\r\n",
+            "Memory Copy Utilization (%),gpu0,57.50,55.00,60.00,59.95,59.75,59.50,58.75,57.50,56.25\r\n",
+            "Video Encoder Utilization (%),gpu0,22.50,20.00,25.00,24.95,24.75,24.50,23.75,22.50,21.25\r\n",
+            "Video Decoder Utilization (%),gpu0,16.50,15.00,18.00,17.97,17.85,17.70,17.25,16.50,15.75\r\n",
+            'GPU Clock Sm (MHz),gpu0,"1,525.00","1,500.00","1,550.00","1,549.50","1,547.50","1,545.00","1,537.50","1,525.00","1,512.50"\r\n',
+            'GPU Clock Memory (MHz),gpu0,"5,050.00","5,000.00","5,100.00","5,099.00","5,095.00","5,090.00","5,075.00","5,050.00","5,025.00"\r\n',
+            "GPU Temperature (C),gpu0,72.50,70.00,75.00,74.95,74.75,74.50,73.75,72.50,71.25\r\n",
+            "GPU Memory Temperature (C),gpu0,62.50,60.00,65.00,64.95,64.75,64.50,63.75,62.50,61.25\r\n",
             "\r\n",
             "Metric,GPU,Value\r\n",
             "GPU Power Limit (W),gpu0,250.00\r\n",
@@ -407,6 +425,8 @@ class TestCsvExporter:
             for filename, data in mock_read_write
             if os.path.basename(filename) == expected_filename
         ]
+
+        print(returned_data)
 
         assert returned_data == expected_content
 

--- a/genai-perf/tests/test_metrics/test_telemetry_metrics.py
+++ b/genai-perf/tests/test_metrics/test_telemetry_metrics.py
@@ -29,65 +29,62 @@
 from collections import defaultdict
 from typing import Dict, List
 
-from genai_perf.metrics.telemetry_metrics import MetricMetadata, TelemetryMetrics
+from genai_perf.metrics.telemetry_metrics import (
+    MetricMetadata,
+    TelemetryMetricName,
+    TelemetryMetrics,
+)
 
 
 class TestTelemetryMetrics:
 
     def test_initialization(self):
         telemetry = TelemetryMetrics()
-        for metric in telemetry.telemetry_metrics:
-            assert isinstance(getattr(telemetry, metric.name), defaultdict)
-            assert len(getattr(telemetry, metric.name)) == 0
+        for metric in TelemetryMetricName.values():
+            attr = getattr(telemetry, metric.value)
+            assert isinstance(attr, defaultdict)
+            assert len(attr) == 0
 
     def test_initialization_with_params(self):
-        gpu_power_usage = {"gpu0": [10.0]}
-        gpu_power_limit = {"gpu0": [100.0]}
-        energy_consumption = {"gpu0": [1000.0]}
-        gpu_utilization = {"gpu0": [80.0]}
-        total_gpu_memory = {"gpu0": [8000.0]}
-        gpu_memory_used = {"gpu0": [4000.0]}
         telemetry = TelemetryMetrics(
-            gpu_power_usage=gpu_power_usage,
-            gpu_power_limit=gpu_power_limit,
-            energy_consumption=energy_consumption,
-            gpu_utilization=gpu_utilization,
-            total_gpu_memory=total_gpu_memory,
-            gpu_memory_used=gpu_memory_used,
+            gpu_power_usage={"gpu0": [0.0]},
+            gpu_power_limit={"gpu0": [1.0]},
+            energy_consumption={"gpu0": [2.0]},
+            gpu_utilization={"gpu0": [3.0]},
+            total_gpu_memory={"gpu0": [4.0]},
+            gpu_memory_used={"gpu0": [5.0]},
+            gpu_memory_free={"gpu0": [6.0]},
+            gpu_memory_temperature={"gpu0": [7.0]},
+            gpu_temperature={"gpu0": [8.0]},
+            sm_utilization={"gpu0": [9.0]},
+            memory_copy_utilization={"gpu0": [10.0]},
+            video_encoder_utilization={"gpu0": [11.0]},
+            video_decoder_utilization={"gpu0": [12.0]},
+            gpu_clock_sm={"gpu0": [13.0]},
+            gpu_clock_memory={"gpu0": [14.0]},
         )
-        assert telemetry.gpu_power_usage == gpu_power_usage
-        assert telemetry.gpu_power_limit == gpu_power_limit
-        assert telemetry.energy_consumption == energy_consumption
-        assert telemetry.gpu_utilization == gpu_utilization
-        assert telemetry.total_gpu_memory == total_gpu_memory
-        assert telemetry.gpu_memory_used == gpu_memory_used
 
-    def test_update_metrics(self) -> None:
-        telemetry = TelemetryMetrics()
-        measurement_data: Dict[str, Dict[str, List[float]]] = {
-            "gpu_power_usage": {"gpu0": [11.1], "gpu1": [11.2]},
-            "gpu_power_limit": {"gpu0": [101.2], "gpu1": [101.2]},
-            "energy_consumption": {"gpu0": [1004.0], "gpu1": [1005.0]},
-            "gpu_utilization": {"gpu0": [85.0], "gpu1": [90.0]},
-            "total_gpu_memory": {"gpu0": [9000.0], "gpu1": [9000.0]},
-            "gpu_memory_used": {"gpu0": [4500.0], "gpu1": [4500.0]},
-        }
-        telemetry.update_metrics(measurement_data)
-
-        assert telemetry.gpu_power_usage == {"gpu0": [11.1], "gpu1": [11.2]}
-        assert telemetry.gpu_power_limit == {"gpu0": [101.2], "gpu1": [101.2]}
-        assert telemetry.energy_consumption == {"gpu0": [1004.0], "gpu1": [1005.0]}
-        assert telemetry.gpu_utilization == {"gpu0": [85.0], "gpu1": [90.0]}
-        assert telemetry.total_gpu_memory == {"gpu0": [9000.0], "gpu1": [9000.0]}
-        assert telemetry.gpu_memory_used == {"gpu0": [4500.0], "gpu1": [4500.0]}
+        assert telemetry.gpu_power_usage == {"gpu0": [0.0]}
+        assert telemetry.gpu_power_limit == {"gpu0": [1.0]}
+        assert telemetry.energy_consumption == {"gpu0": [2.0]}
+        assert telemetry.gpu_utilization == {"gpu0": [3.0]}
+        assert telemetry.total_gpu_memory == {"gpu0": [4.0]}
+        assert telemetry.gpu_memory_used == {"gpu0": [5.0]}
+        assert telemetry.gpu_memory_free == {"gpu0": [6.0]}
+        assert telemetry.gpu_memory_temperature == {"gpu0": [7.0]}
+        assert telemetry.gpu_temperature == {"gpu0": [8.0]}
+        assert telemetry.sm_utilization == {"gpu0": [9.0]}
+        assert telemetry.memory_copy_utilization == {"gpu0": [10.0]}
+        assert telemetry.video_encoder_utilization == {"gpu0": [11.0]}
+        assert telemetry.video_decoder_utilization == {"gpu0": [12.0]}
+        assert telemetry.gpu_clock_sm == {"gpu0": [13.0]}
+        assert telemetry.gpu_clock_memory == {"gpu0": [14.0]}
 
     def test_update_metrics_with_empty_data(self):
-        """Test that updating metrics with empty data does not modify existing data."""
         telemetry = TelemetryMetrics()
         telemetry.update_metrics({})
-        for metric in telemetry.telemetry_metrics:
-            print(getattr(telemetry, metric.name))
-            assert len(getattr(telemetry, metric.name)) == 0
+        for metric in TelemetryMetricName.values():
+            assert len(getattr(telemetry, metric.value)) == 0
 
     def test_update_metrics_multiple_times(self):
         telemetry = TelemetryMetrics()
@@ -100,16 +97,7 @@ class TestTelemetryMetrics:
         telemetry = TelemetryMetrics()
         telemetry_metrics: List[MetricMetadata] = telemetry.telemetry_metrics
 
-        assert len(telemetry_metrics) == 6
-        assert telemetry_metrics[0].name == "gpu_power_usage"
-        assert telemetry_metrics[0].unit == "W"
-        assert telemetry_metrics[1].name == "gpu_power_limit"
-        assert telemetry_metrics[1].unit == "W"
-        assert telemetry_metrics[2].name == "energy_consumption"
-        assert telemetry_metrics[2].unit == "MJ"
-        assert telemetry_metrics[3].name == "gpu_utilization"
-        assert telemetry_metrics[3].unit == "%"
-        assert telemetry_metrics[4].name == "total_gpu_memory"
-        assert telemetry_metrics[4].unit == "GB"
-        assert telemetry_metrics[5].name == "gpu_memory_used"
-        assert telemetry_metrics[5].unit == "GB"
+        assert len(telemetry_metrics) == len(TelemetryMetricName)
+        defined_names = {m.name for m in telemetry_metrics}
+        enum_names = {m.value for m in TelemetryMetricName.values()}
+        assert defined_names == enum_names

--- a/genai-perf/tests/test_metrics/test_telemetry_metrics.py
+++ b/genai-perf/tests/test_metrics/test_telemetry_metrics.py
@@ -80,6 +80,31 @@ class TestTelemetryMetrics:
         assert telemetry.gpu_clock_sm == {"gpu0": [13.0]}
         assert telemetry.gpu_clock_memory == {"gpu0": [14.0]}
 
+    def test_update_metrics(self) -> None:
+        telemetry = TelemetryMetrics()
+        measurement_data: Dict[str, Dict[str, List[float]]] = {
+            "gpu_power_usage": {"gpu0": [11.1], "gpu1": [11.2]},
+            "gpu_power_limit": {"gpu0": [101.2], "gpu1": [101.2]},
+            "energy_consumption": {"gpu0": [1004.0], "gpu1": [1005.0]},
+            "gpu_utilization": {"gpu0": [85.0], "gpu1": [90.0]},
+            "sm_utilization": {"gpu0": [65.0], "gpu1": [68.0]},
+            "memory_copy_utilization": {"gpu0": [55.0], "gpu1": [58.0]},
+            "video_encoder_utilization": {"gpu0": [20.0], "gpu1": [25.0]},
+            "video_decoder_utilization": {"gpu0": [15.0], "gpu1": [18.0]},
+            "gpu_clock_sm": {"gpu0": [1520.0], "gpu1": [1510.0]},
+            "gpu_clock_memory": {"gpu0": [5050.0], "gpu1": [5000.0]},
+            "total_gpu_memory": {"gpu0": [9000.0], "gpu1": [9000.0]},
+            "gpu_memory_used": {"gpu0": [4500.0], "gpu1": [4500.0]},
+            "gpu_memory_free": {"gpu0": [4500.0], "gpu1": [4500.0]},
+            "gpu_memory_temperature": {"gpu0": [62.0], "gpu1": [63.0]},
+            "gpu_temperature": {"gpu0": [72.0], "gpu1": [73.0]},
+        }
+
+        telemetry.update_metrics(measurement_data)
+
+        for metric_name, expected in measurement_data.items():
+            assert getattr(telemetry, metric_name) == expected
+
     def test_update_metrics_with_empty_data(self):
         telemetry = TelemetryMetrics()
         telemetry.update_metrics({})

--- a/genai-perf/tests/test_record.py
+++ b/genai-perf/tests/test_record.py
@@ -42,133 +42,15 @@ class TestRecord(unittest.TestCase):
         record_types = RecordType.get_all_record_types()
         self.all_record_types = record_types.values()
 
-        self.less_is_better_types = {
-            record_types[t]
-            for t in [
-                "request_latency_min",
-                "request_latency_max",
-                "request_latency_avg",
-                "request_latency_std",
-                "request_latency_p25",
-                "request_latency_p50",
-                "request_latency_p75",
-                "request_latency_p90",
-                "request_latency_p95",
-                "request_latency_p99",
-                "inter_token_latency_min",
-                "inter_token_latency_max",
-                "inter_token_latency_avg",
-                "inter_token_latency_std",
-                "inter_token_latency_p25",
-                "inter_token_latency_p50",
-                "inter_token_latency_p75",
-                "inter_token_latency_p90",
-                "inter_token_latency_p95",
-                "inter_token_latency_p99",
-                "time_to_first_token_min",
-                "time_to_first_token_max",
-                "time_to_first_token_avg",
-                "time_to_first_token_std",
-                "time_to_first_token_p25",
-                "time_to_first_token_p50",
-                "time_to_first_token_p75",
-                "time_to_first_token_p90",
-                "time_to_first_token_p95",
-                "time_to_first_token_p99",
-                "time_to_second_token_min",
-                "time_to_second_token_max",
-                "time_to_second_token_avg",
-                "time_to_second_token_std",
-                "time_to_second_token_p25",
-                "time_to_second_token_p50",
-                "time_to_second_token_p75",
-                "time_to_second_token_p90",
-                "time_to_second_token_p95",
-                "time_to_second_token_p99",
-                "gpu_power_usage_avg",
-                "gpu_power_usage_min",
-                "gpu_power_usage_max",
-                "gpu_power_usage_std",
-                "gpu_power_usage_p25",
-                "gpu_power_usage_p50",
-                "gpu_power_usage_p75",
-                "gpu_power_usage_p90",
-                "gpu_power_usage_p95",
-                "gpu_power_usage_p99",
-                "energy_consumption_avg",
-                "energy_consumption_min",
-                "energy_consumption_max",
-                "energy_consumption_std",
-                "energy_consumption_p25",
-                "energy_consumption_p50",
-                "energy_consumption_p75",
-                "energy_consumption_p90",
-                "energy_consumption_p95",
-                "energy_consumption_p99",
-            ]
-        }
+        self.less_is_better_types = set()
+        self.more_is_better_types = set()
 
-        self.more_is_better_types = {
-            record_types[t]
-            for t in [
-                "request_throughput_avg",
-                "request_goodput_avg",
-                "request_count_avg",
-                "output_token_throughput_avg",
-                "output_token_throughput_per_user_min",
-                "output_token_throughput_per_user_max",
-                "output_token_throughput_per_user_avg",
-                "output_token_throughput_per_user_std",
-                "output_token_throughput_per_user_p25",
-                "output_token_throughput_per_user_p50",
-                "output_token_throughput_per_user_p75",
-                "output_token_throughput_per_user_p90",
-                "output_token_throughput_per_user_p95",
-                "output_token_throughput_per_user_p99",
-                "output_sequence_length_min",
-                "output_sequence_length_max",
-                "output_sequence_length_avg",
-                "output_sequence_length_std",
-                "output_sequence_length_p25",
-                "output_sequence_length_p50",
-                "output_sequence_length_p75",
-                "output_sequence_length_p90",
-                "output_sequence_length_p95",
-                "output_sequence_length_p99",
-                "input_sequence_length_min",
-                "input_sequence_length_max",
-                "input_sequence_length_avg",
-                "input_sequence_length_std",
-                "input_sequence_length_p25",
-                "input_sequence_length_p50",
-                "input_sequence_length_p75",
-                "input_sequence_length_p90",
-                "input_sequence_length_p95",
-                "input_sequence_length_p99",
-                "gpu_power_limit_avg",
-                "gpu_utilization_min",
-                "gpu_utilization_max",
-                "gpu_utilization_avg",
-                "gpu_utilization_std",
-                "gpu_utilization_p25",
-                "gpu_utilization_p50",
-                "gpu_utilization_p75",
-                "gpu_utilization_p90",
-                "gpu_utilization_p95",
-                "gpu_utilization_p99",
-                "total_gpu_memory_avg",
-                "gpu_memory_used_min",
-                "gpu_memory_used_max",
-                "gpu_memory_used_avg",
-                "gpu_memory_used_std",
-                "gpu_memory_used_p25",
-                "gpu_memory_used_p50",
-                "gpu_memory_used_p75",
-                "gpu_memory_used_p90",
-                "gpu_memory_used_p95",
-                "gpu_memory_used_p99",
-            ]
-        }
+        for record_cls in self.all_record_types:
+            metric = record_cls(value=1)
+            if metric._positive_is_better():
+                self.more_is_better_types.add(record_cls)
+            else:
+                self.less_is_better_types.add(record_cls)
 
     def tearDown(self):
         patch.stopall()
@@ -176,6 +58,7 @@ class TestRecord(unittest.TestCase):
     ###########################################################################
     # Completeness Tests
     ###########################################################################
+
     def test_counts(self):
         """
         Make sure that all 'worse than' and 'better than' tests are tested
@@ -188,6 +71,7 @@ class TestRecord(unittest.TestCase):
     ###########################################################################
     # Basic Operation Tests
     ###########################################################################
+
     def test_add(self):
         """
         Test __add__ function for
@@ -212,10 +96,8 @@ class TestRecord(unittest.TestCase):
             metric2 = record_type(value=3)
             metric3 = metric1 - metric2
             self.assertIsInstance(metric3, record_type)
-            if record_type in self.less_is_better_types:
-                self.assertEqual(metric3.value(), -7)
-            elif record_type in self.more_is_better_types:
-                self.assertEqual(metric3.value(), 7)
+            expected = -7 if record_type in self.less_is_better_types else 7
+            self.assertEqual(metric3.value(), expected)
 
     def test_mult(self):
         """
@@ -259,7 +141,7 @@ class TestRecord(unittest.TestCase):
 
             # Test __gt__ (True if 1 better than 2)
             if record_type in self.less_is_better_types:
-                self.assertLess(metric1, metric2)
+                self.assertGreater(metric2, metric1)
             elif record_type in self.more_is_better_types:
                 self.assertGreater(metric1, metric2)
 
@@ -294,10 +176,8 @@ class TestRecord(unittest.TestCase):
             metric1 = record_type(value=10)
             metric2 = record_type(value=5)
 
-            if record_type in self.less_is_better_types:
-                self.assertEqual(metric1.calculate_percentage_gain(metric2), -50)
-            else:
-                self.assertEqual(metric1.calculate_percentage_gain(metric2), 100)
+            expected_gain = -50 if record_type in self.less_is_better_types else 100
+            self.assertEqual(metric1.calculate_percentage_gain(metric2), expected_gain)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Support new power, utilization and memory metrics
```
dcgm_sm_utilization: SM (Streaming Multiprocessor) utilization.
dcgm_mem_copy_utilization: Memory copy engine utilization.
dcgm_enc_utilization: Video encoder utilization.
dcgm_dec_utilization: Video decoder utilization.
dcgm_gpu_temperature: GPU temperature in °C.
dcgm_gpu_clock_sm: SM clock in MHz.
dcgm_gpu_clock_mem: Memory clock in MHz.
dcgm_gpu_clock_graphics: Graphics clock in MHz.
dcgm_fb_free: Frame buffer memory free (bytes).
dcgm_memory_temp: Memory temperature in °C.
```

These new metrics are only added in JSON and CSV outputs. The console output displays only the initial 6 metrics in `verbose` mode.

**Console output**

<img src="https://github.com/user-attachments/assets/2e09256f-f034-4d57-a4e0-918194b4a183" width="600"/>


**CSV output**

![image](https://github.com/user-attachments/assets/9d735412-e83e-442e-ac2e-025c3f4fbac6)
