### PR TITLE
fix: missing header from genai-perf to perf_analyzer

### DIFF
--- a/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
+++ b/genai-perf/genai_perf/config/generate/perf_analyzer_config.py
@@ -88,6 +88,16 @@ class PerfAnalyzerConfig:
         cli_args += self._add_endpoint_args(config)
         cli_args += self._add_extra_args(extra_args)
 
+        header = getattr(config.input, 'header', None)
+        
+        if header:
+            headers = header if isinstance(header, list) else [header]
+            cli_args += [
+                "--header", str(h).strip()
+                for h in headers
+                if h and str(h).strip()
+            ]
+
         return cli_args
 
     def _set_options_based_on_objective(


### PR DESCRIPTION
https://github.com/triton-inference-server/client/pull/575?notification_referrer_id=NT_kwDOAYcbmbQxNjM1ODk3MjAyNToyNTYzMTY0MQ#issuecomment-2877579921