### PR TITLE
feat (retriever): support image url for openai multimodal chat api

### DIFF
--- a/genai-perf/docs/multi_modal.md
+++ b/genai-perf/docs/multi_modal.md
@@ -178,16 +178,19 @@ genai-perf profile \
 Instead of letting GenAI-Perf create the synthetic data,
 you can also provide GenAI-Perf with your own data using
 [`--input-file`](../README.md#--input-file-path) CLI option.
-The file needs to be in JSONL format and should contain both the prompt and
-the filepath to the image to send.
+The input file must be in JSONL format, where each line can define both `text` and `image` data.
+The `image` field can be either a path to a local image file or a URL.
+GenAI-Perf converts local image filepaths to base64-encoded strings and leaves URL paths as is,
+consistent with the [OpenAI Vision Guide](https://platform.openai.com/docs/guides/images-vision?api-mode=chat&format=url#giving-a-model-images-as-input).
 
-For instance, an example of input file would look something as following:
+A sample input file `input.jsonl` would look like
 ```bash
-// input.jsonl
+// texts and local image files
 {"text": "What is in this image?", "image": "path/to/image1.png"}
 {"text": "What is the color of the dog?", "image": "path/to/image2.jpeg"}
-{"text": "Describe the scene in the picture.", "image": "path/to/image3.png"}
-...
+
+// Or, text and URL path
+{"text": "What is in this image?", "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"}
 ```
 
 After you create the file, you can run GenAI-Perf using the following command:

--- a/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
@@ -27,6 +27,7 @@
 import random
 from pathlib import Path
 from typing import Dict, List, Tuple, cast
+from urllib.parse import urlparse
 
 from genai_perf import utils
 from genai_perf.config.input.config_defaults import InputDefaults
@@ -189,10 +190,16 @@ class FileInputRetriever(BaseFileInputRetriever):
         str
             The processed image content.
         """
-
-        if "://" in content:  # URL path
+        # Check if the content is a URL with a scheme and netloc
+        url = urlparse(content)
+        if url.scheme and url.netloc:
             return content
+        elif any([url.scheme, url.netloc]):
+            raise GenAIPerfException(
+                f"Valid URL must have both a scheme and netloc: {content}"
+            )
 
+        # Otherwise, it's a local file path
         try:
             img = Image.open(content)
         except FileNotFoundError:

--- a/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
+++ b/genai-perf/genai_perf/inputs/retrievers/file_input_retriever.py
@@ -167,40 +167,45 @@ class FileInputRetriever(BaseFileInputRetriever):
                         prompt = f"{prefix_prompt} {prompt}"
                     if prompt is not None:
                         prompts.append(prompt.strip())
+
                     image = data.get("image")
                     if image is not None:
-                        image = self._encode_image(image.strip())
+                        image = self._handle_image_content(image.strip())
                         images.append(image)
         return prompts, images
 
-    def _encode_image(self, filename: str) -> str:
+    def _handle_image_content(self, content: str) -> str:
         """
-        Encodes the image file from a given filepath to
-        the base64 format of the image.
+        Handles the image content by either encoding it to the base64 format
+        if it's a local file or returning the content as is if it's a URL.
 
         Args
         ----------
-        filename : str
-            The file path of the image to encode.
+        content : str
+            The content of the image. Either a local file path or a URL.
 
         Returns
         -------
         str
-            The base64-encoded image string.
+            The processed image content.
         """
+
+        if "://" in content:  # URL path
+            return content
+
         try:
-            img = Image.open(filename)
+            img = Image.open(content)
         except FileNotFoundError:
-            raise GenAIPerfException(f"Failed to open image '{filename}'.")
+            raise GenAIPerfException(f"Failed to open image '{content}'.")
+
         if img.format is None:
             raise GenAIPerfException(
-                f"Failed to determine image format of '{filename}'."
+                f"Failed to determine image format of '{content}'."
             )
 
         if img.format.lower() not in utils.get_enum_names(ImageFormat):
             raise GenAIPerfException(
-                f"Unsupported image format '{img.format}' of "
-                f"the image '{filename}'."
+                f"Unsupported image format '{img.format}' of " f"the image '{content}'."
             )
 
         img_base64 = utils.encode_image(img, img.format)

--- a/genai-perf/tests/test_retrievers/test_file_input_retriever.py
+++ b/genai-perf/tests/test_retrievers/test_file_input_retriever.py
@@ -78,14 +78,6 @@ class TestFileInputRetriever:
         filename = Path(filepath).name
         return mock_open(read_data=file_contents.get(filename))()
 
-    @staticmethod
-    @patch(
-        f"{FILE_INPUT_RETRIEVER_PREFIX}._encode_image",
-        return_value="mock_base64_image",
-    )
-    def mock_encode_image(mock_encode_image):
-        return mock_encode_image
-
     @patch("pathlib.Path.exists", return_value=True)
     @patch("builtins.open", side_effect=open_side_effect)
     def test_retrieve_data_single_prompt(self, mock_file, mock_exists):
@@ -111,12 +103,12 @@ class TestFileInputRetriever:
     @patch("pathlib.Path.exists", return_value=True)
     @patch("PIL.Image.open", return_value=Image.new("RGB", (10, 10)))
     @patch(
-        f"{FILE_INPUT_RETRIEVER_PREFIX}._encode_image",
+        f"{FILE_INPUT_RETRIEVER_PREFIX}._handle_image_content",
         return_value="mock_base64_image",
     )
     @patch("builtins.open", side_effect=open_side_effect)
     def test_retrieve_data_multi_modal(
-        self, mock_file, mock_image, mock_encode_image, mock_exists
+        self, mock_file, mock_image, mock_image_content, mock_exists
     ):
         config = ConfigCommand({"model_name": "test_model_A"})
         config.input.file = Path("multi_modal.jsonl")
@@ -143,12 +135,12 @@ class TestFileInputRetriever:
     @patch("pathlib.Path.exists", return_value=True)
     @patch("PIL.Image.open", return_value=Image.new("RGB", (10, 10)))
     @patch(
-        f"{FILE_INPUT_RETRIEVER_PREFIX}._encode_image",
+        f"{FILE_INPUT_RETRIEVER_PREFIX}._handle_image_content",
         return_value="mock_base64_image",
     )
     @patch("builtins.open", side_effect=open_side_effect)
     def test_get_input_file_single_image(
-        self, mock_file, mock_image, mock_encode_image, mock_exists
+        self, mock_file, mock_image, mock_image_content, mock_exists
     ):
         config = ConfigCommand({"model_name": "test_model_A"})
         config.endpoint.model_selection_strategy = ModelSelectionStrategy.ROUND_ROBIN
@@ -172,12 +164,12 @@ class TestFileInputRetriever:
     @patch("pathlib.Path.exists", return_value=True)
     @patch("PIL.Image.open", return_value=Image.new("RGB", (10, 10)))
     @patch(
-        f"{FILE_INPUT_RETRIEVER_PREFIX}._encode_image",
+        f"{FILE_INPUT_RETRIEVER_PREFIX}._handle_image_content",
         side_effect=["mock_base64_image1", "mock_base64_image2", "mock_base64_image3"],
     )
     @patch("builtins.open", side_effect=open_side_effect)
     def test_get_input_file_multiple_images(
-        self, mock_file, mock_image_open, mock_encode_image, mock_exists
+        self, mock_file, mock_image_open, mock_image_content, mock_exists
     ):
         config = ConfigCommand({"model_name": "test_model_A"})
         config.endpoint.model_selection_strategy = ModelSelectionStrategy.ROUND_ROBIN
@@ -260,12 +252,12 @@ class TestFileInputRetriever:
     @patch("pathlib.Path.exists", return_value=True)
     @patch("PIL.Image.open", return_value=Image.new("RGB", (10, 10)))
     @patch(
-        f"{FILE_INPUT_RETRIEVER_PREFIX}._encode_image",
+        f"{FILE_INPUT_RETRIEVER_PREFIX}._handle_image_content",
         return_value="mock_base64_image",
     )
     @patch("builtins.open", side_effect=open_side_effect)
     def test_get_input_file_multi_modal(
-        self, mock_file, mock_image, mock_encode_image, mock_exists
+        self, mock_file, mock_image, mock_image_content, mock_exists
     ):
         config = ConfigCommand({"model_name": "test_model_A"})
         config.endpoint.model_selection_strategy = ModelSelectionStrategy.ROUND_ROBIN
@@ -380,7 +372,7 @@ class TestFileInputRetriever:
     )
     @patch("PIL.Image.open", return_value=Image.new("RGB", (10, 10)))
     @patch(
-        f"{FILE_INPUT_RETRIEVER_PREFIX}._encode_image",
+        f"{FILE_INPUT_RETRIEVER_PREFIX}._handle_image_content",
         return_value="mock_base64_image",
     )
     @patch("builtins.open", side_effect=open_side_effect)
@@ -388,7 +380,7 @@ class TestFileInputRetriever:
         self,
         mock_file,
         mock_image_open,
-        mock_encode_image,
+        mock_image_content,
         mock_glob,
         mock_is_dir,
         mock_exists,


### PR DESCRIPTION
This PR allows users to provide an image URL as a custom input data for running benchmarks against multimodal models using OpenAI Chat API as described in #374.

For example, a user can specify text prompt and image url in `input.jsonl` and run GenAI-Perf:
```bash
# create sample input.jsonl
echo '{"text": "What is in this image?", "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"}' > input.jsonl

genai-perf profile \
    -m llava-hf/llava-v1.6-mistral-7b-hf \
    --endpoint-type multimodal \
    --input-data input.jsonl \
    --streaming
```

Running above will generate payload that looks like:
```json
{
  "data": [
    {
      "payload": [
        {
          "model": "llava-hf/llava-v1.6-mistral-7b-hf",
          "messages": [
            {
              "role": "user",
              "content": [
                {
                  "type": "text",
                  "text": "What is in this image?"
                },
                {
                  "type": "image_url",
                  "image_url": {
                    "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
                  }
                }
              ]
            }
          ],
          "stream": true
        }
      ]
    }
  ]
}
```