### PR TITLE
feat: Add ECC and Errors metrics to GPU Telemetry

### DIFF
--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -535,6 +535,25 @@ GenAI-Perf collects the following GPU metrics during benchmarking:
 - `video_encoder_utilization`
 - `video_decoder_utilization`
 
+### ECC Metrics
+- `total_ecc_sbe_volatile`
+- `total_ecc_dbe_volatile`
+- `total_ecc_sbe_aggregate`
+- `total_ecc_dbe_aggregate`
+
+### Errors and Violations Metrics
+- `xid_last_error`
+- `power_throttle_duration`
+- `thermal_throttle_duration`
+
+### Retired Pages Metrics
+- `retired_pages_sbe`
+- `retired_pages_dbe`
+
+### NVLink Error Metrics
+- `total_nvlink_crc_flit_errors`
+- `total_nvlink_crc_data_errors`
+
 > [!Note]
 > Use the `--verbose` flag to print telemetry metrics on the console.
 

--- a/genai-perf/docs/assets/custom_gpu_metrics.csv
+++ b/genai-perf/docs/assets/custom_gpu_metrics.csv
@@ -26,3 +26,22 @@ DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
 DCGM_FI_DEV_ENC_UTIL,      gauge, Encoder utilization (in %).
 DCGM_FI_DEV_DEC_UTIL ,     gauge, Decoder utilization (in %).
 DCGM_FI_PROF_SM_ACTIVE,    gauge, The ratio of cycles an SM has at least 1 warp assigned.
+
+# ECC
+DCGM_FI_DEV_ECC_SBE_VOL_TOTAL, counter, Total number of single-bit volatile ECC errors.
+DCGM_FI_DEV_ECC_DBE_VOL_TOTAL, counter, Total number of double-bit volatile ECC errors.
+DCGM_FI_DEV_ECC_SBE_AGG_TOTAL, counter, Total number of single-bit persistent ECC errors.
+DCGM_FI_DEV_ECC_DBE_AGG_TOTAL, counter, Total number of double-bit persistent ECC errors.
+
+# Errors and violations
+DCGM_FI_DEV_XID_ERRORS,              gauge,   Value of the last XID error encountered.
+DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
+DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in us).
+
+# Retired pages
+DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
+DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
+
+# NVLink
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, counter, Total number of NVLink flow-control CRC errors.
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.

--- a/genai-perf/docs/gpu_telemetry.md
+++ b/genai-perf/docs/gpu_telemetry.md
@@ -65,6 +65,25 @@ DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory copy utilization (in %)
 DCGM_FI_DEV_ENC_UTIL, gauge, Encoder utilization (in %)
 DCGM_FI_DEV_DEC_UTIL, gauge, Decoder utilization (in %)
 DCGM_FI_PROF_SM_ACTIVE, gauge, Ratio of cycles at least one warp is active per SM
+
+# ECC
+DCGM_FI_DEV_ECC_SBE_VOL_TOTAL, counter, Total number of single-bit volatile ECC errors.
+DCGM_FI_DEV_ECC_DBE_VOL_TOTAL, counter, Total number of double-bit volatile ECC errors.
+DCGM_FI_DEV_ECC_SBE_AGG_TOTAL, counter, Total number of single-bit persistent ECC errors.
+DCGM_FI_DEV_ECC_DBE_AGG_TOTAL, counter, Total number of double-bit persistent ECC errors.
+
+# Errors and violations
+DCGM_FI_DEV_XID_ERRORS,              gauge,   Value of the last XID error encountered.
+DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
+DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in us).
+
+# Retired pages
+DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
+DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
+
+# NVLink
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, counter, Total number of NVLink flow-control CRC errors.
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
 EOF
 ```
 This will generate a `custom_gpu_metrics.csv` file that can be mounted into the DCGM Exporter container and

--- a/genai-perf/genai_perf/metrics/telemetry_metrics.py
+++ b/genai-perf/genai_perf/metrics/telemetry_metrics.py
@@ -47,6 +47,17 @@ class TelemetryMetricName(str, Enum):
     GPU_TEMPERATURE = "gpu_temperature"
     GPU_CLOCK_SM = "gpu_clock_sm"
     GPU_CLOCK_MEMORY = "gpu_clock_memory"
+    ECC_SBE_VOLATILE_TOTAL = "total_ecc_sbe_volatile"
+    ECC_DBE_VOLATILE_TOTAL = "total_ecc_dbe_volatile"
+    ECC_SBE_AGGREGATE_TOTAL = "total_ecc_sbe_aggregate"
+    ECC_DBE_AGGREGATE_TOTAL = "total_ecc_dbe_aggregate"
+    XID_LAST_ERROR = "xid_last_error"
+    POWER_THROTTLE_DURATION = "power_throttle_duration"
+    THERMAL_THROTTLE_DURATION = "thermal_throttle_duration"
+    RETIRED_PAGES_SBE = "retired_pages_sbe"
+    RETIRED_PAGES_DBE = "retired_pages_dbe"
+    NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL = "total_nvlink_crc_flit_errors"
+    NVLINK_CRC_DATA_ERROR_COUNT_TOTAL = "total_nvlink_crc_data_errors"
 
     @classmethod
     def values(cls) -> List["TelemetryMetricName"]:
@@ -98,12 +109,31 @@ class TelemetryMetrics:
         MetricMetadata(TelemetryMetricName.GPU_MEMORY_TEMPERATURE.value, "C"),
     ]
 
+    ECC_AND_ERROR_METRICS = [
+        MetricMetadata(TelemetryMetricName.ECC_SBE_VOLATILE_TOTAL.value, "errors"),
+        MetricMetadata(TelemetryMetricName.ECC_DBE_VOLATILE_TOTAL.value, "errors"),
+        MetricMetadata(TelemetryMetricName.ECC_SBE_AGGREGATE_TOTAL.value, "errors"),
+        MetricMetadata(TelemetryMetricName.ECC_DBE_AGGREGATE_TOTAL.value, "errors"),
+        MetricMetadata(TelemetryMetricName.XID_LAST_ERROR.value, "errors"),
+        MetricMetadata(TelemetryMetricName.POWER_THROTTLE_DURATION.value, "us"),
+        MetricMetadata(TelemetryMetricName.THERMAL_THROTTLE_DURATION.value, "us"),
+        MetricMetadata(TelemetryMetricName.RETIRED_PAGES_SBE.value, "pages"),
+        MetricMetadata(TelemetryMetricName.RETIRED_PAGES_DBE.value, "pages"),
+        MetricMetadata(
+            TelemetryMetricName.NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL.value, "errors"
+        ),
+        MetricMetadata(
+            TelemetryMetricName.NVLINK_CRC_DATA_ERROR_COUNT_TOTAL.value, "errors"
+        ),
+    ]
+
     TELEMETRY_METRICS = (
         POWER_METRICS
         + MEMORY_METRICS
         + UTILIZATION_METRICS
         + CLOCK_METRICS
         + TEMPERATURE_METRICS
+        + ECC_AND_ERROR_METRICS
     )
 
     def __init__(
@@ -123,6 +153,17 @@ class TelemetryMetrics:
         gpu_temperature: Optional[Dict[str, List[float]]] = None,
         gpu_clock_sm: Optional[Dict[str, List[float]]] = None,
         gpu_clock_memory: Optional[Dict[str, List[float]]] = None,
+        total_ecc_sbe_volatile: Optional[Dict[str, List[float]]] = None,
+        total_ecc_dbe_volatile: Optional[Dict[str, List[float]]] = None,
+        total_ecc_sbe_aggregate: Optional[Dict[str, List[float]]] = None,
+        total_ecc_dbe_aggregate: Optional[Dict[str, List[float]]] = None,
+        total_nvlink_crc_flit_errors: Optional[Dict[str, List[float]]] = None,
+        total_nvlink_crc_data_errors: Optional[Dict[str, List[float]]] = None,
+        xid_last_error: Optional[Dict[str, List[float]]] = None,
+        power_throttle_duration: Optional[Dict[str, List[float]]] = None,
+        thermal_throttle_duration: Optional[Dict[str, List[float]]] = None,
+        retired_pages_sbe: Optional[Dict[str, List[float]]] = None,
+        retired_pages_dbe: Optional[Dict[str, List[float]]] = None,
     ):
         self.gpu_power_usage = defaultdict(list, gpu_power_usage or {})
         self.gpu_power_limit = defaultdict(list, gpu_power_limit or {})
@@ -143,6 +184,23 @@ class TelemetryMetrics:
         self.gpu_temperature = defaultdict(list, gpu_temperature or {})
         self.gpu_clock_sm = defaultdict(list, gpu_clock_sm or {})
         self.gpu_clock_memory = defaultdict(list, gpu_clock_memory or {})
+        self.total_ecc_sbe_volatile = defaultdict(list, total_ecc_sbe_volatile or {})
+        self.total_ecc_dbe_volatile = defaultdict(list, total_ecc_dbe_volatile or {})
+        self.total_ecc_sbe_aggregate = defaultdict(list, total_ecc_sbe_aggregate or {})
+        self.total_ecc_dbe_aggregate = defaultdict(list, total_ecc_dbe_aggregate or {})
+        self.xid_last_error = defaultdict(list, xid_last_error or {})
+        self.power_throttle_duration = defaultdict(list, power_throttle_duration or {})
+        self.thermal_throttle_duration = defaultdict(
+            list, thermal_throttle_duration or {}
+        )
+        self.retired_pages_sbe = defaultdict(list, retired_pages_sbe or {})
+        self.retired_pages_dbe = defaultdict(list, retired_pages_dbe or {})
+        self.total_nvlink_crc_flit_errors = defaultdict(
+            list, total_nvlink_crc_flit_errors or {}
+        )
+        self.total_nvlink_crc_data_errors = defaultdict(
+            list, total_nvlink_crc_data_errors or {}
+        )
 
     def update_metrics(self, measurement_data: dict) -> None:
         for metric in self.TELEMETRY_METRICS:

--- a/genai-perf/genai_perf/telemetry_data/dcgm_telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/dcgm_telemetry_data_collector.py
@@ -52,6 +52,17 @@ class DCGMTelemetryDataCollector(TelemetryDataCollector):
         "DCGM_FI_DEV_FB_FREE": TelemetryMetricName.GPU_MEMORY_FREE,
         "DCGM_FI_DEV_MEMORY_TEMP": TelemetryMetricName.GPU_MEMORY_TEMPERATURE,
         "DCGM_FI_DEV_GPU_TEMP": TelemetryMetricName.GPU_TEMPERATURE,
+        "DCGM_FI_DEV_ECC_SBE_VOL_TOTAL": TelemetryMetricName.ECC_SBE_VOLATILE_TOTAL,
+        "DCGM_FI_DEV_ECC_DBE_VOL_TOTAL": TelemetryMetricName.ECC_DBE_VOLATILE_TOTAL,
+        "DCGM_FI_DEV_ECC_SBE_AGG_TOTAL": TelemetryMetricName.ECC_SBE_AGGREGATE_TOTAL,
+        "DCGM_FI_DEV_ECC_DBE_AGG_TOTAL": TelemetryMetricName.ECC_DBE_AGGREGATE_TOTAL,
+        "DCGM_FI_DEV_XID_ERRORS": TelemetryMetricName.XID_LAST_ERROR,
+        "DCGM_FI_DEV_POWER_VIOLATION": TelemetryMetricName.POWER_THROTTLE_DURATION,
+        "DCGM_FI_DEV_THERMAL_VIOLATION": TelemetryMetricName.THERMAL_THROTTLE_DURATION,
+        "DCGM_FI_DEV_RETIRED_SBE": TelemetryMetricName.RETIRED_PAGES_SBE,
+        "DCGM_FI_DEV_RETIRED_DBE": TelemetryMetricName.RETIRED_PAGES_DBE,
+        "DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL": TelemetryMetricName.NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL,
+        "DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL": TelemetryMetricName.NVLINK_CRC_DATA_ERROR_COUNT_TOTAL,
     }
 
     def _process_and_update_metrics(self, metrics_data: str) -> None:

--- a/genai-perf/tests/test_collectors/test_dcgm_telemetry_data_collector.py
+++ b/genai-perf/tests/test_collectors/test_dcgm_telemetry_data_collector.py
@@ -60,6 +60,17 @@ def test_process_and_update_metrics_success(collector):
     DCGM_FI_DEV_MEM_COPY_UTIL{gpu="0"} 55
     DCGM_FI_DEV_ENC_UTIL{gpu="0"} 22
     DCGM_FI_DEV_DEC_UTIL{gpu="0"} 17
+    DCGM_FI_DEV_ECC_SBE_VOL_TOTAL{gpu="0"} 1
+    DCGM_FI_DEV_ECC_DBE_VOL_TOTAL{gpu="0"} 2
+    DCGM_FI_DEV_ECC_SBE_AGG_TOTAL{gpu="0"} 3
+    DCGM_FI_DEV_ECC_DBE_AGG_TOTAL{gpu="0"} 4
+    DCGM_FI_DEV_XID_ERRORS{gpu="0"} 5
+    DCGM_FI_DEV_POWER_VIOLATION{gpu="0"} 6
+    DCGM_FI_DEV_THERMAL_VIOLATION{gpu="0"} 7
+    DCGM_FI_DEV_RETIRED_SBE{gpu="0"} 8
+    DCGM_FI_DEV_RETIRED_DBE{gpu="0"} 9
+    DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL{gpu="0"} 10
+    DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL{gpu="0"} 11
     """
 
     collector._process_and_update_metrics(sample_metrics)
@@ -78,6 +89,17 @@ def test_process_and_update_metrics_success(collector):
     assert update_call["memory_copy_utilization"]["0"] == [55.0]
     assert update_call["video_encoder_utilization"]["0"] == [22.0]
     assert update_call["video_decoder_utilization"]["0"] == [17.0]
+    assert update_call["total_ecc_sbe_volatile"]["0"] == [1.0]
+    assert update_call["total_ecc_dbe_volatile"]["0"] == [2.0]
+    assert update_call["total_ecc_sbe_aggregate"]["0"] == [3.0]
+    assert update_call["total_ecc_dbe_aggregate"]["0"] == [4.0]
+    assert update_call["xid_last_error"]["0"] == [5.0]
+    assert update_call["power_throttle_duration"]["0"] == [6.0]
+    assert update_call["thermal_throttle_duration"]["0"] == [7.0]
+    assert update_call["retired_pages_sbe"]["0"] == [8.0]
+    assert update_call["retired_pages_dbe"]["0"] == [9.0]
+    assert update_call["total_nvlink_crc_flit_errors"]["0"] == [10.0]
+    assert update_call["total_nvlink_crc_data_errors"]["0"] == [11.0]
 
 
 def test_process_and_update_metrics_ignores_unmapped_metrics(collector):

--- a/genai-perf/tests/test_metrics/test_telemetry_metrics.py
+++ b/genai-perf/tests/test_metrics/test_telemetry_metrics.py
@@ -62,6 +62,17 @@ class TestTelemetryMetrics:
             video_decoder_utilization={"gpu0": [12.0]},
             gpu_clock_sm={"gpu0": [13.0]},
             gpu_clock_memory={"gpu0": [14.0]},
+            total_ecc_sbe_volatile={"gpu0": [15.0]},
+            total_ecc_dbe_volatile={"gpu0": [16.0]},
+            total_ecc_sbe_aggregate={"gpu0": [17.0]},
+            total_ecc_dbe_aggregate={"gpu0": [18.0]},
+            xid_last_error={"gpu0": [19.0]},
+            power_throttle_duration={"gpu0": [20.0]},
+            thermal_throttle_duration={"gpu0": [21.0]},
+            retired_pages_sbe={"gpu0": [22.0]},
+            retired_pages_dbe={"gpu0": [23.0]},
+            total_nvlink_crc_flit_errors={"gpu0": [24.0]},
+            total_nvlink_crc_data_errors={"gpu0": [25.0]},
         )
 
         assert telemetry.gpu_power_usage == {"gpu0": [0.0]}
@@ -79,6 +90,17 @@ class TestTelemetryMetrics:
         assert telemetry.video_decoder_utilization == {"gpu0": [12.0]}
         assert telemetry.gpu_clock_sm == {"gpu0": [13.0]}
         assert telemetry.gpu_clock_memory == {"gpu0": [14.0]}
+        assert telemetry.total_ecc_sbe_volatile == {"gpu0": [15.0]}
+        assert telemetry.total_ecc_dbe_volatile == {"gpu0": [16.0]}
+        assert telemetry.total_ecc_sbe_aggregate == {"gpu0": [17.0]}
+        assert telemetry.total_ecc_dbe_aggregate == {"gpu0": [18.0]}
+        assert telemetry.xid_last_error == {"gpu0": [19.0]}
+        assert telemetry.power_throttle_duration == {"gpu0": [20.0]}
+        assert telemetry.thermal_throttle_duration == {"gpu0": [21.0]}
+        assert telemetry.retired_pages_sbe == {"gpu0": [22.0]}
+        assert telemetry.retired_pages_dbe == {"gpu0": [23.0]}
+        assert telemetry.total_nvlink_crc_flit_errors == {"gpu0": [24.0]}
+        assert telemetry.total_nvlink_crc_data_errors == {"gpu0": [25.0]}
 
     def test_update_metrics(self) -> None:
         telemetry = TelemetryMetrics()
@@ -98,6 +120,17 @@ class TestTelemetryMetrics:
             "gpu_memory_free": {"gpu0": [4500.0], "gpu1": [4500.0]},
             "gpu_memory_temperature": {"gpu0": [62.0], "gpu1": [63.0]},
             "gpu_temperature": {"gpu0": [72.0], "gpu1": [73.0]},
+            "total_ecc_sbe_volatile": {"gpu0": [1.0]},
+            "total_ecc_dbe_volatile": {"gpu0": [2.0]},
+            "total_ecc_sbe_aggregate": {"gpu0": [3.0]},
+            "total_ecc_dbe_aggregate": {"gpu0": [4.0]},
+            "xid_last_error": {"gpu0": [5.0]},
+            "power_throttle_duration": {"gpu0": [6.0]},
+            "thermal_throttle_duration": {"gpu0": [7.0]},
+            "retired_pages_sbe": {"gpu0": [8.0]},
+            "retired_pages_dbe": {"gpu0": [9.0]},
+            "total_nvlink_crc_flit_errors": {"gpu0": [10.0]},
+            "total_nvlink_crc_data_errors": {"gpu0": [11.0]},
         }
 
         telemetry.update_metrics(measurement_data)


### PR DESCRIPTION
PR to add additional GPU metrics
 
Metrics added
### ECC Metrics
- `total_ecc_sbe_volatile`
- `total_ecc_dbe_volatile`
- `total_ecc_sbe_aggregate`
- `total_ecc_dbe_aggregate`

### Errors and Violations Metrics
- `xid_last_error`
- `power_throttle_duration`
- `thermal_throttle_duration`

### Retired Pages Metrics
- `retired_pages_sbe`
- `retired_pages_dbe`

### NVLink Error Metrics
- `total_nvlink_crc_flit_errors`
- `total_nvlink_crc_data_errors`

<img width="1162" alt="image" src="https://github.com/user-attachments/assets/3453b99c-329c-43d7-8d8d-c4ed2a073cf0" />
