### PR TITLE
feat: Add PCie metrics to GPU Telemetry

### DIFF
--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -554,6 +554,11 @@ GenAI-Perf collects the following GPU metrics during benchmarking:
 - `total_nvlink_crc_flit_errors`
 - `total_nvlink_crc_data_errors`
 
+### PCIE Metrics
+- `pcie_transmit_throughput`
+- `pcie_receive_throughput`
+- `pcie_replay_counter`
+
 > [!Note]
 > Use the `--verbose` flag to print telemetry metrics on the console.
 

--- a/genai-perf/docs/assets/custom_gpu_metrics.csv
+++ b/genai-perf/docs/assets/custom_gpu_metrics.csv
@@ -45,3 +45,8 @@ DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to doubl
 # NVLink
 DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, counter, Total number of NVLink flow-control CRC errors.
 DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
+
+# PCIE
+DCGM_FI_PROF_PCIE_TX_BYTES,      gauge, The rate of data transmitted over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
+DCGM_FI_PROF_PCIE_RX_BYTES,      gauge, The rate of data received over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
+DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.

--- a/genai-perf/docs/gpu_telemetry.md
+++ b/genai-perf/docs/gpu_telemetry.md
@@ -84,6 +84,11 @@ DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to doubl
 # NVLink
 DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, counter, Total number of NVLink flow-control CRC errors.
 DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
+
+# PCIE
+DCGM_FI_PROF_PCIE_TX_BYTES,      gauge, The rate of data transmitted over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
+DCGM_FI_PROF_PCIE_RX_BYTES,      gauge, The rate of data received over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
+DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
 EOF
 ```
 This will generate a `custom_gpu_metrics.csv` file that can be mounted into the DCGM Exporter container and

--- a/genai-perf/genai_perf/metrics/telemetry_metrics.py
+++ b/genai-perf/genai_perf/metrics/telemetry_metrics.py
@@ -58,6 +58,9 @@ class TelemetryMetricName(str, Enum):
     RETIRED_PAGES_DBE = "retired_pages_dbe"
     NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL = "total_nvlink_crc_flit_errors"
     NVLINK_CRC_DATA_ERROR_COUNT_TOTAL = "total_nvlink_crc_data_errors"
+    PCIE_TRANSMIT_THROUGHPUT = "pcie_transmit_throughput"
+    PCIE_RECEIVE_THROUGHPUT = "pcie_receive_throughput"
+    PCIE_REPLAY_COUNTER = "pcie_replay_counter"
 
     @classmethod
     def values(cls) -> List["TelemetryMetricName"]:
@@ -127,6 +130,12 @@ class TelemetryMetrics:
         ),
     ]
 
+    PCIE_METRICS = [
+        MetricMetadata(TelemetryMetricName.PCIE_TRANSMIT_THROUGHPUT.value, "KB/s"),
+        MetricMetadata(TelemetryMetricName.PCIE_RECEIVE_THROUGHPUT.value, "KB/s"),
+        MetricMetadata(TelemetryMetricName.PCIE_REPLAY_COUNTER.value, "retries"),
+    ]
+
     TELEMETRY_METRICS = (
         POWER_METRICS
         + MEMORY_METRICS
@@ -134,6 +143,7 @@ class TelemetryMetrics:
         + CLOCK_METRICS
         + TEMPERATURE_METRICS
         + ECC_AND_ERROR_METRICS
+        + PCIE_METRICS
     )
 
     def __init__(
@@ -164,6 +174,9 @@ class TelemetryMetrics:
         thermal_throttle_duration: Optional[Dict[str, List[float]]] = None,
         retired_pages_sbe: Optional[Dict[str, List[float]]] = None,
         retired_pages_dbe: Optional[Dict[str, List[float]]] = None,
+        pcie_transmit_throughput: Optional[Dict[str, List[float]]] = None,
+        pcie_receive_throughput: Optional[Dict[str, List[float]]] = None,
+        pcie_replay_counter: Optional[Dict[str, List[float]]] = None,
     ):
         self.gpu_power_usage = defaultdict(list, gpu_power_usage or {})
         self.gpu_power_limit = defaultdict(list, gpu_power_limit or {})
@@ -201,6 +214,11 @@ class TelemetryMetrics:
         self.total_nvlink_crc_data_errors = defaultdict(
             list, total_nvlink_crc_data_errors or {}
         )
+        self.pcie_transmit_throughput = defaultdict(
+            list, pcie_transmit_throughput or {}
+        )
+        self.pcie_receive_throughput = defaultdict(list, pcie_receive_throughput or {})
+        self.pcie_replay_counter = defaultdict(list, pcie_replay_counter or {})
 
     def update_metrics(self, measurement_data: dict) -> None:
         for metric in self.TELEMETRY_METRICS:

--- a/genai-perf/genai_perf/metrics/telemetry_statistics.py
+++ b/genai-perf/genai_perf/metrics/telemetry_statistics.py
@@ -84,6 +84,8 @@ class TelemetryStatistics:
             "total_gpu_memory": 1.048576 * 1e-3,  # MiB to gigabytes (GB)
             "gpu_memory_free": 1.048576e-3,  # MiB to gigabytes (GB)
             "sm_utilization": 100,  # ratio to %
+            "pcie_transmit_throughput": 1 / 1024,  # bytes/sec to KB/sec
+            "pcie_receive_throughput": 1 / 1024,  # bytes/sec to KB/sec
         }
         for metric, data in self._stats_dict.items():
             if metric in SCALING_FACTORS:

--- a/genai-perf/genai_perf/record/record.py
+++ b/genai-perf/genai_perf/record/record.py
@@ -30,6 +30,7 @@ class ReductionFactor:
     MIB_TO_GB: float = 1.048576e-3
     PERCENTAGE = -2
     NONE = 0
+    BYTES_TO_KB: float = 1 / 1024
 
 
 class RecordType(ABCMeta):

--- a/genai-perf/genai_perf/record/types/pcie_receive_throughput_avg.py
+++ b/genai-perf/genai_perf/record/types/pcie_receive_throughput_avg.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_receive_throughput_base import (
+    PCieReceiveThroughputBase,
+)
+
+
+@total_ordering
+class PCieReceiveThroughputAvg(PCieReceiveThroughputBase):
+    """
+    A record for avg PCie Receive Throughput metric
+    """
+
+    tag = PCieReceiveThroughputBase.base_tag + "_avg"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Avg. PCie Receive Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_receive_throughput_base.py
+++ b/genai-perf/genai_perf/record/types/pcie_receive_throughput_base.py
@@ -14,38 +14,47 @@
 
 from functools import total_ordering
 
-from genai_perf.record.gpu_record import DecreasingGPURecord
+from genai_perf.record.gpu_record import IncreasingGPURecord
 from genai_perf.record.record import ReductionFactor
 
 
 @total_ordering
-class TotalNVLinkCRCDataErrorsBase(DecreasingGPURecord):
+class PCieReceiveThroughputBase(IncreasingGPURecord):
     """
-    A base class for the Total NVLink CRC Data Errors metric.
+    A base class for the PCie Receive Throughput metric
     """
 
-    base_tag = "total_nvlink_crc_data_errors"
-    reduction_factor = ReductionFactor.NONE
+    base_tag = "pcie_receive_throughput"
+    reduction_factor = ReductionFactor.BYTES_TO_KB
 
     def __init__(self, value, device_uuid=None, timestamp=0):
         super().__init__(value, device_uuid, timestamp)
 
     @staticmethod
-    def header(aggregation_tag=False):
-        return ("Max " if aggregation_tag else "") + "Total NVLink CRC Data Errors"
+    def aggregation_function():
+        def average(seq):
+            return sum(seq[1:], start=seq[0]) / len(seq)
 
-    def __eq__(self, other: "TotalNVLinkCRCDataErrorsBase") -> bool:  # type: ignore
+        return average
+
+    @staticmethod
+    def header(aggregation_tag=False):
+        return (
+            "Average " if aggregation_tag else ""
+        ) + "PCie Receive Throughput (KB/s)"
+
+    def __eq__(self, other: "PCieReceiveThroughputBase") -> bool:  # type: ignore
         return self.value() == other.value()
 
-    def __lt__(self, other: "TotalNVLinkCRCDataErrorsBase") -> bool:
-        return other.value() < self.value()
+    def __lt__(self, other: "PCieReceiveThroughputBase") -> bool:
+        return self.value() < other.value()
 
     def __add__(
-        self, other: "TotalNVLinkCRCDataErrorsBase"
-    ) -> "TotalNVLinkCRCDataErrorsBase":
+        self, other: "PCieReceiveThroughputBase"
+    ) -> "PCieReceiveThroughputBase":
         return self.__class__(device_uuid=None, value=(self.value() + other.value()))
 
     def __sub__(
-        self, other: "TotalNVLinkCRCDataErrorsBase"
-    ) -> "TotalNVLinkCRCDataErrorsBase":
-        return self.__class__(device_uuid=None, value=(other.value() - self.value()))
+        self, other: "PCieReceiveThroughputBase"
+    ) -> "PCieReceiveThroughputBase":
+        return self.__class__(device_uuid=None, value=(self.value() - other.value()))

--- a/genai-perf/genai_perf/record/types/pcie_receive_throughput_max.py
+++ b/genai-perf/genai_perf/record/types/pcie_receive_throughput_max.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_receive_throughput_base import (
+    PCieReceiveThroughputBase,
+)
+
+
+@total_ordering
+class PCieReceiveThroughputMax(PCieReceiveThroughputBase):
+    """
+    A record for max PCie Receive Throughput metric
+    """
+
+    tag = PCieReceiveThroughputBase.base_tag + "_max"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Max PCie Receive Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_receive_throughput_min.py
+++ b/genai-perf/genai_perf/record/types/pcie_receive_throughput_min.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_receive_throughput_base import (
+    PCieReceiveThroughputBase,
+)
+
+
+@total_ordering
+class PCieReceiveThroughputMin(PCieReceiveThroughputBase):
+    """
+    A record for min PCie Receive Throughput metric
+    """
+
+    tag = PCieReceiveThroughputBase.base_tag + "_min"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Min PCie Receive Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_receive_throughput_p1.py
+++ b/genai-perf/genai_perf/record/types/pcie_receive_throughput_p1.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_receive_throughput_base import (
+    PCieReceiveThroughputBase,
+)
+
+
+@total_ordering
+class PCieReceiveThroughputP1(PCieReceiveThroughputBase):
+    """
+    A record for p1 PCie Receive Throughput metric
+    """
+
+    tag = PCieReceiveThroughputBase.base_tag + "_p1"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p1 PCie Receive Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_receive_throughput_p10.py
+++ b/genai-perf/genai_perf/record/types/pcie_receive_throughput_p10.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_receive_throughput_base import (
+    PCieReceiveThroughputBase,
+)
+
+
+@total_ordering
+class PCieReceiveThroughputP10(PCieReceiveThroughputBase):
+    """
+    A record for p10 PCie Receive Throughput metric
+    """
+
+    tag = PCieReceiveThroughputBase.base_tag + "_p10"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p10 PCie Receive Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_receive_throughput_p25.py
+++ b/genai-perf/genai_perf/record/types/pcie_receive_throughput_p25.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_receive_throughput_base import (
+    PCieReceiveThroughputBase,
+)
+
+
+@total_ordering
+class PCieReceiveThroughputP25(PCieReceiveThroughputBase):
+    """
+    A record for p25 PCie Receive Throughput metric
+    """
+
+    tag = PCieReceiveThroughputBase.base_tag + "_p25"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p25 PCie Receive Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_receive_throughput_p5.py
+++ b/genai-perf/genai_perf/record/types/pcie_receive_throughput_p5.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_receive_throughput_base import (
+    PCieReceiveThroughputBase,
+)
+
+
+@total_ordering
+class PCieReceiveThroughputP5(PCieReceiveThroughputBase):
+    """
+    A record for p5 PCie Receive Throughput metric
+    """
+
+    tag = PCieReceiveThroughputBase.base_tag + "_p5"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p5 PCie Receive Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_receive_throughput_p50.py
+++ b/genai-perf/genai_perf/record/types/pcie_receive_throughput_p50.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_receive_throughput_base import (
+    PCieReceiveThroughputBase,
+)
+
+
+@total_ordering
+class PCieReceiveThroughputP50(PCieReceiveThroughputBase):
+    """
+    A record for p50 PCie Receive Throughput metric
+    """
+
+    tag = PCieReceiveThroughputBase.base_tag + "_p50"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p50 PCie Receive Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_receive_throughput_p75.py
+++ b/genai-perf/genai_perf/record/types/pcie_receive_throughput_p75.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_receive_throughput_base import (
+    PCieReceiveThroughputBase,
+)
+
+
+@total_ordering
+class PCieReceiveThroughputP75(PCieReceiveThroughputBase):
+    """
+    A record for p75 PCie Receive Throughput metric
+    """
+
+    tag = PCieReceiveThroughputBase.base_tag + "_p75"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p75 PCie Receive Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_receive_throughput_p90.py
+++ b/genai-perf/genai_perf/record/types/pcie_receive_throughput_p90.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_receive_throughput_base import (
+    PCieReceiveThroughputBase,
+)
+
+
+@total_ordering
+class PCieReceiveThroughputP90(PCieReceiveThroughputBase):
+    """
+    A record for p90 PCie Receive Throughput metric
+    """
+
+    tag = PCieReceiveThroughputBase.base_tag + "_p90"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p90 PCie Receive Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_receive_throughput_p95.py
+++ b/genai-perf/genai_perf/record/types/pcie_receive_throughput_p95.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_receive_throughput_base import (
+    PCieReceiveThroughputBase,
+)
+
+
+@total_ordering
+class PCieReceiveThroughputP95(PCieReceiveThroughputBase):
+    """
+    A record for p95 PCie Receive Throughput metric
+    """
+
+    tag = PCieReceiveThroughputBase.base_tag + "_p95"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p95 PCie Receive Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_receive_throughput_p99.py
+++ b/genai-perf/genai_perf/record/types/pcie_receive_throughput_p99.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_receive_throughput_base import (
+    PCieReceiveThroughputBase,
+)
+
+
+@total_ordering
+class PCieReceiveThroughputP99(PCieReceiveThroughputBase):
+    """
+    A record for p99 PCie Receive Throughput metric
+    """
+
+    tag = PCieReceiveThroughputBase.base_tag + "_p99"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p99 PCie Receive Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_receive_throughput_std.py
+++ b/genai-perf/genai_perf/record/types/pcie_receive_throughput_std.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_receive_throughput_base import (
+    PCieReceiveThroughputBase,
+)
+
+
+@total_ordering
+class PCieReceiveThroughputStd(PCieReceiveThroughputBase):
+    """
+    A record for std PCie Receive Throughput metric
+    """
+
+    tag = PCieReceiveThroughputBase.base_tag + "_std"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Std. PCie Receive Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_replay_counter_avg.py
+++ b/genai-perf/genai_perf/record/types/pcie_replay_counter_avg.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_replay_counter_base import PCieReplayCounterBase
+
+
+@total_ordering
+class PCieReplayCounterAvg(PCieReplayCounterBase):
+    """
+    A record for avg PCie Replay Counter metric
+    """
+
+    tag = PCieReplayCounterBase.base_tag + "_avg"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Avg. PCie Replay Counter"

--- a/genai-perf/genai_perf/record/types/pcie_replay_counter_base.py
+++ b/genai-perf/genai_perf/record/types/pcie_replay_counter_base.py
@@ -19,12 +19,12 @@ from genai_perf.record.record import ReductionFactor
 
 
 @total_ordering
-class TotalNVLinkCRCDataErrorsBase(DecreasingGPURecord):
+class PCieReplayCounterBase(DecreasingGPURecord):
     """
-    A base class for the Total NVLink CRC Data Errors metric.
+    A base class for the PCie Replay Counter metric
     """
 
-    base_tag = "total_nvlink_crc_data_errors"
+    base_tag = "pcie_replay_counter"
     reduction_factor = ReductionFactor.NONE
 
     def __init__(self, value, device_uuid=None, timestamp=0):
@@ -32,20 +32,16 @@ class TotalNVLinkCRCDataErrorsBase(DecreasingGPURecord):
 
     @staticmethod
     def header(aggregation_tag=False):
-        return ("Max " if aggregation_tag else "") + "Total NVLink CRC Data Errors"
+        return ("Max " if aggregation_tag else "") + "PCIe Replay Counter"
 
-    def __eq__(self, other: "TotalNVLinkCRCDataErrorsBase") -> bool:  # type: ignore
+    def __eq__(self, other: "PCieReplayCounterBase") -> bool:  # type: ignore
         return self.value() == other.value()
 
-    def __lt__(self, other: "TotalNVLinkCRCDataErrorsBase") -> bool:
+    def __lt__(self, other: "PCieReplayCounterBase") -> bool:
         return other.value() < self.value()
 
-    def __add__(
-        self, other: "TotalNVLinkCRCDataErrorsBase"
-    ) -> "TotalNVLinkCRCDataErrorsBase":
+    def __add__(self, other: "PCieReplayCounterBase") -> "PCieReplayCounterBase":
         return self.__class__(device_uuid=None, value=(self.value() + other.value()))
 
-    def __sub__(
-        self, other: "TotalNVLinkCRCDataErrorsBase"
-    ) -> "TotalNVLinkCRCDataErrorsBase":
+    def __sub__(self, other: "PCieReplayCounterBase") -> "PCieReplayCounterBase":
         return self.__class__(device_uuid=None, value=(other.value() - self.value()))

--- a/genai-perf/genai_perf/record/types/pcie_replay_counter_max.py
+++ b/genai-perf/genai_perf/record/types/pcie_replay_counter_max.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_replay_counter_base import PCieReplayCounterBase
+
+
+@total_ordering
+class PCieReplayCounterMax(PCieReplayCounterBase):
+    """
+    A record for max PCie Replay Counter metric
+    """
+
+    tag = PCieReplayCounterBase.base_tag + "_max"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Max PCie Replay Counter"

--- a/genai-perf/genai_perf/record/types/pcie_replay_counter_min.py
+++ b/genai-perf/genai_perf/record/types/pcie_replay_counter_min.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_replay_counter_base import PCieReplayCounterBase
+
+
+@total_ordering
+class PCieReplayCounterMin(PCieReplayCounterBase):
+    """
+    A record for min PCie Replay Counter metric
+    """
+
+    tag = PCieReplayCounterBase.base_tag + "_min"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Min PCie Replay Counter"

--- a/genai-perf/genai_perf/record/types/pcie_replay_counter_p1.py
+++ b/genai-perf/genai_perf/record/types/pcie_replay_counter_p1.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_replay_counter_base import PCieReplayCounterBase
+
+
+@total_ordering
+class PCieReplayCounterP1(PCieReplayCounterBase):
+    """
+    A record for p1 PCie Replay Counter metric
+    """
+
+    tag = PCieReplayCounterBase.base_tag + "_p1"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p1 PCie Replay Counter"

--- a/genai-perf/genai_perf/record/types/pcie_replay_counter_p10.py
+++ b/genai-perf/genai_perf/record/types/pcie_replay_counter_p10.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_replay_counter_base import PCieReplayCounterBase
+
+
+@total_ordering
+class PCieReplayCounterP10(PCieReplayCounterBase):
+    """
+    A record for p10 PCie Replay Counter metric
+    """
+
+    tag = PCieReplayCounterBase.base_tag + "_p10"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p10 PCie Replay Counter"

--- a/genai-perf/genai_perf/record/types/pcie_replay_counter_p25.py
+++ b/genai-perf/genai_perf/record/types/pcie_replay_counter_p25.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_replay_counter_base import PCieReplayCounterBase
+
+
+@total_ordering
+class PCieReplayCounterP25(PCieReplayCounterBase):
+    """
+    A record for p25 PCie Replay Counter metric
+    """
+
+    tag = PCieReplayCounterBase.base_tag + "_p25"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p25 PCie Replay Counter"

--- a/genai-perf/genai_perf/record/types/pcie_replay_counter_p5.py
+++ b/genai-perf/genai_perf/record/types/pcie_replay_counter_p5.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_replay_counter_base import PCieReplayCounterBase
+
+
+@total_ordering
+class PCieReplayCounterP5(PCieReplayCounterBase):
+    """
+    A record for p5 PCie Replay Counter metric
+    """
+
+    tag = PCieReplayCounterBase.base_tag + "_p5"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p5 PCie Replay Counter"

--- a/genai-perf/genai_perf/record/types/pcie_replay_counter_p50.py
+++ b/genai-perf/genai_perf/record/types/pcie_replay_counter_p50.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_replay_counter_base import PCieReplayCounterBase
+
+
+@total_ordering
+class PCieReplayCounterP50(PCieReplayCounterBase):
+    """
+    A record for p50 PCie Replay Counter metric
+    """
+
+    tag = PCieReplayCounterBase.base_tag + "_p50"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p50 PCie Replay Counter"

--- a/genai-perf/genai_perf/record/types/pcie_replay_counter_p75.py
+++ b/genai-perf/genai_perf/record/types/pcie_replay_counter_p75.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_replay_counter_base import PCieReplayCounterBase
+
+
+@total_ordering
+class PCieReplayCounterP75(PCieReplayCounterBase):
+    """
+    A record for p75 PCie Replay Counter metric
+    """
+
+    tag = PCieReplayCounterBase.base_tag + "_p75"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p75 PCie Replay Counter"

--- a/genai-perf/genai_perf/record/types/pcie_replay_counter_p90.py
+++ b/genai-perf/genai_perf/record/types/pcie_replay_counter_p90.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_replay_counter_base import PCieReplayCounterBase
+
+
+@total_ordering
+class PCieReplayCounterP90(PCieReplayCounterBase):
+    """
+    A record for p90 PCie Replay Counter metric
+    """
+
+    tag = PCieReplayCounterBase.base_tag + "_p90"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p90 PCie Replay Counter"

--- a/genai-perf/genai_perf/record/types/pcie_replay_counter_p95.py
+++ b/genai-perf/genai_perf/record/types/pcie_replay_counter_p95.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_replay_counter_base import PCieReplayCounterBase
+
+
+@total_ordering
+class PCieReplayCounterP95(PCieReplayCounterBase):
+    """
+    A record for p95 PCie Replay Counter metric
+    """
+
+    tag = PCieReplayCounterBase.base_tag + "_p95"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p95 PCie Replay Counter"

--- a/genai-perf/genai_perf/record/types/pcie_replay_counter_p99.py
+++ b/genai-perf/genai_perf/record/types/pcie_replay_counter_p99.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_replay_counter_base import PCieReplayCounterBase
+
+
+@total_ordering
+class PCieReplayCounterP99(PCieReplayCounterBase):
+    """
+    A record for p99 PCie Replay Counter metric
+    """
+
+    tag = PCieReplayCounterBase.base_tag + "_p99"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p99 PCie Replay Counter"

--- a/genai-perf/genai_perf/record/types/pcie_replay_counter_std.py
+++ b/genai-perf/genai_perf/record/types/pcie_replay_counter_std.py
@@ -1,0 +1,33 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_replay_counter_base import PCieReplayCounterBase
+
+
+@total_ordering
+class PCieReplayCounterStd(PCieReplayCounterBase):
+    """
+    A record for std PCie Replay Counter metric
+    """
+
+    tag = PCieReplayCounterBase.base_tag + "_std"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Std. PCie Replay Counter"

--- a/genai-perf/genai_perf/record/types/pcie_transmit_throughput_avg.py
+++ b/genai-perf/genai_perf/record/types/pcie_transmit_throughput_avg.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_transmit_throughput_base import (
+    PCieTransmitThroughputBase,
+)
+
+
+@total_ordering
+class PCieTransmitThroughputAvg(PCieTransmitThroughputBase):
+    """
+    A record for avg PCie Transmit Throughput
+    """
+
+    tag = PCieTransmitThroughputBase.base_tag + "_avg"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Avg. PCie Transmit Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_transmit_throughput_base.py
+++ b/genai-perf/genai_perf/record/types/pcie_transmit_throughput_base.py
@@ -14,38 +14,47 @@
 
 from functools import total_ordering
 
-from genai_perf.record.gpu_record import DecreasingGPURecord
+from genai_perf.record.gpu_record import IncreasingGPURecord
 from genai_perf.record.record import ReductionFactor
 
 
 @total_ordering
-class TotalNVLinkCRCDataErrorsBase(DecreasingGPURecord):
+class PCieTransmitThroughputBase(IncreasingGPURecord):
     """
-    A base class for the Total NVLink CRC Data Errors metric.
+    A base class for the PCie Transmit Throughput metric
     """
 
-    base_tag = "total_nvlink_crc_data_errors"
-    reduction_factor = ReductionFactor.NONE
+    base_tag = "pcie_transmit_throughput"
+    reduction_factor = ReductionFactor.BYTES_TO_KB
 
     def __init__(self, value, device_uuid=None, timestamp=0):
         super().__init__(value, device_uuid, timestamp)
 
     @staticmethod
-    def header(aggregation_tag=False):
-        return ("Max " if aggregation_tag else "") + "Total NVLink CRC Data Errors"
+    def aggregation_function():
+        def average(seq):
+            return sum(seq[1:], start=seq[0]) / len(seq)
 
-    def __eq__(self, other: "TotalNVLinkCRCDataErrorsBase") -> bool:  # type: ignore
+        return average
+
+    @staticmethod
+    def header(aggregation_tag=False):
+        return (
+            "Average " if aggregation_tag else ""
+        ) + "PCie Transmit Throughput (KB/s)"
+
+    def __eq__(self, other: "PCieTransmitThroughputBase") -> bool:  # type: ignore
         return self.value() == other.value()
 
-    def __lt__(self, other: "TotalNVLinkCRCDataErrorsBase") -> bool:
-        return other.value() < self.value()
+    def __lt__(self, other: "PCieTransmitThroughputBase") -> bool:
+        return self.value() < other.value()
 
     def __add__(
-        self, other: "TotalNVLinkCRCDataErrorsBase"
-    ) -> "TotalNVLinkCRCDataErrorsBase":
+        self, other: "PCieTransmitThroughputBase"
+    ) -> "PCieTransmitThroughputBase":
         return self.__class__(device_uuid=None, value=(self.value() + other.value()))
 
     def __sub__(
-        self, other: "TotalNVLinkCRCDataErrorsBase"
-    ) -> "TotalNVLinkCRCDataErrorsBase":
-        return self.__class__(device_uuid=None, value=(other.value() - self.value()))
+        self, other: "PCieTransmitThroughputBase"
+    ) -> "PCieTransmitThroughputBase":
+        return self.__class__(device_uuid=None, value=(self.value() - other.value()))

--- a/genai-perf/genai_perf/record/types/pcie_transmit_throughput_max.py
+++ b/genai-perf/genai_perf/record/types/pcie_transmit_throughput_max.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_transmit_throughput_base import (
+    PCieTransmitThroughputBase,
+)
+
+
+@total_ordering
+class PCieTransmitThroughputMax(PCieTransmitThroughputBase):
+    """
+    A record for max PCie Transmit Throughput
+    """
+
+    tag = PCieTransmitThroughputBase.base_tag + "_max"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Max PCie Transmit Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_transmit_throughput_min.py
+++ b/genai-perf/genai_perf/record/types/pcie_transmit_throughput_min.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_transmit_throughput_base import (
+    PCieTransmitThroughputBase,
+)
+
+
+@total_ordering
+class PCieTransmitThroughputMin(PCieTransmitThroughputBase):
+    """
+    A record for min PCie Transmit Throughput
+    """
+
+    tag = PCieTransmitThroughputBase.base_tag + "_min"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Min PCie Transmit Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p1.py
+++ b/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p1.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_transmit_throughput_base import (
+    PCieTransmitThroughputBase,
+)
+
+
+@total_ordering
+class PCieTransmitThroughputP1(PCieTransmitThroughputBase):
+    """
+    A record for p1 PCie Transmit Throughput
+    """
+
+    tag = PCieTransmitThroughputBase.base_tag + "_p1"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p1 PCie Transmit Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p10.py
+++ b/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p10.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_transmit_throughput_base import (
+    PCieTransmitThroughputBase,
+)
+
+
+@total_ordering
+class PCieTransmitThroughputP10(PCieTransmitThroughputBase):
+    """
+    A record for p10 PCie Transmit Throughput
+    """
+
+    tag = PCieTransmitThroughputBase.base_tag + "_p10"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p10 PCie Transmit Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p25.py
+++ b/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p25.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_transmit_throughput_base import (
+    PCieTransmitThroughputBase,
+)
+
+
+@total_ordering
+class PCieTransmitThroughputP25(PCieTransmitThroughputBase):
+    """
+    A record for p25 PCie Transmit Throughput
+    """
+
+    tag = PCieTransmitThroughputBase.base_tag + "_p25"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p25 PCie Transmit Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p5.py
+++ b/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p5.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_transmit_throughput_base import (
+    PCieTransmitThroughputBase,
+)
+
+
+@total_ordering
+class PCieTransmitThroughputP5(PCieTransmitThroughputBase):
+    """
+    A record for p5 PCie Transmit Throughput
+    """
+
+    tag = PCieTransmitThroughputBase.base_tag + "_p5"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p5 PCie Transmit Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p50.py
+++ b/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p50.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_transmit_throughput_base import (
+    PCieTransmitThroughputBase,
+)
+
+
+@total_ordering
+class PCieTransmitThroughputP50(PCieTransmitThroughputBase):
+    """
+    A record for p50 PCie Transmit Throughput
+    """
+
+    tag = PCieTransmitThroughputBase.base_tag + "_p50"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p50 PCie Transmit Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p75.py
+++ b/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p75.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_transmit_throughput_base import (
+    PCieTransmitThroughputBase,
+)
+
+
+@total_ordering
+class PCieTransmitThroughputP75(PCieTransmitThroughputBase):
+    """
+    A record for p75 PCie Transmit Throughput
+    """
+
+    tag = PCieTransmitThroughputBase.base_tag + "_p75"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p75 PCie Transmit Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p90.py
+++ b/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p90.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_transmit_throughput_base import (
+    PCieTransmitThroughputBase,
+)
+
+
+@total_ordering
+class PCieTransmitThroughputP90(PCieTransmitThroughputBase):
+    """
+    A record for p90 PCie Transmit Throughput
+    """
+
+    tag = PCieTransmitThroughputBase.base_tag + "_p90"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p90 PCie Transmit Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p95.py
+++ b/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p95.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_transmit_throughput_base import (
+    PCieTransmitThroughputBase,
+)
+
+
+@total_ordering
+class PCieTransmitThroughputP95(PCieTransmitThroughputBase):
+    """
+    A record for p95 PCie Transmit Throughput
+    """
+
+    tag = PCieTransmitThroughputBase.base_tag + "_p95"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p95 PCie Transmit Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p99.py
+++ b/genai-perf/genai_perf/record/types/pcie_transmit_throughput_p99.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_transmit_throughput_base import (
+    PCieTransmitThroughputBase,
+)
+
+
+@total_ordering
+class PCieTransmitThroughputP99(PCieTransmitThroughputBase):
+    """
+    A record for p99 PCie Transmit Throughput
+    """
+
+    tag = PCieTransmitThroughputBase.base_tag + "_p99"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "p99 PCie Transmit Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/pcie_transmit_throughput_std.py
+++ b/genai-perf/genai_perf/record/types/pcie_transmit_throughput_std.py
@@ -1,0 +1,35 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+
+from genai_perf.record.types.pcie_transmit_throughput_base import (
+    PCieTransmitThroughputBase,
+)
+
+
+@total_ordering
+class PCieTransmitThroughputStd(PCieTransmitThroughputBase):
+    """
+    A record for std PCie Transmit Throughput
+    """
+
+    tag = PCieTransmitThroughputBase.base_tag + "_std"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        super().__init__(value, device_uuid, timestamp)
+
+    @classmethod
+    def header(cls, aggregation_tag=False) -> str:
+        return "Std. PCie Transmit Throughput (KB/s)"

--- a/genai-perf/genai_perf/record/types/power_throttle_duration_base.py
+++ b/genai-perf/genai_perf/record/types/power_throttle_duration_base.py
@@ -31,15 +31,8 @@ class PowerThrottleDurationBase(DecreasingGPURecord):
         super().__init__(value, device_uuid, timestamp)
 
     @staticmethod
-    def aggregation_function():
-        def average(seq):
-            return sum(seq[1:], start=seq[0]) / len(seq)
-
-        return average
-
-    @staticmethod
     def header(aggregation_tag=False):
-        return ("Average " if aggregation_tag else "") + "Power Throttle Duration (us)"
+        return ("Max " if aggregation_tag else "") + "Power Throttle Duration (us)"
 
     def __eq__(self, other: "PowerThrottleDurationBase") -> bool:  # type: ignore
         return self.value() == other.value()

--- a/genai-perf/genai_perf/record/types/retired_pages_dbe_base.py
+++ b/genai-perf/genai_perf/record/types/retired_pages_dbe_base.py
@@ -31,15 +31,8 @@ class RetiredPagesDBEBase(DecreasingGPURecord):
         super().__init__(value, device_uuid, timestamp)
 
     @staticmethod
-    def aggregation_function():
-        def average(seq):
-            return sum(seq[1:], start=seq[0]) / len(seq)
-
-        return average
-
-    @staticmethod
     def header(aggregation_tag=False):
-        return ("Average " if aggregation_tag else "") + "Total ECC DBE Retired Pages"
+        return ("Max " if aggregation_tag else "") + "Total ECC DBE Retired Pages"
 
     def __eq__(self, other: "RetiredPagesDBEBase") -> bool:  # type: ignore
         return self.value() == other.value()

--- a/genai-perf/genai_perf/record/types/retired_pages_sbe_base.py
+++ b/genai-perf/genai_perf/record/types/retired_pages_sbe_base.py
@@ -31,15 +31,8 @@ class RetiredPagesSBEBase(DecreasingGPURecord):
         super().__init__(value, device_uuid, timestamp)
 
     @staticmethod
-    def aggregation_function():
-        def average(seq):
-            return sum(seq[1:], start=seq[0]) / len(seq)
-
-        return average
-
-    @staticmethod
     def header(aggregation_tag=False):
-        return ("Average " if aggregation_tag else "") + "Total ECC SBE Retired Pages"
+        return ("Max " if aggregation_tag else "") + "Total ECC SBE Retired Pages"
 
     def __eq__(self, other: "RetiredPagesSBEBase") -> bool:  # type: ignore
         return self.value() == other.value()

--- a/genai-perf/genai_perf/record/types/thermal_throttle_duration_base.py
+++ b/genai-perf/genai_perf/record/types/thermal_throttle_duration_base.py
@@ -31,17 +31,8 @@ class ThermalThrottleDurationBase(DecreasingGPURecord):
         super().__init__(value, device_uuid, timestamp)
 
     @staticmethod
-    def aggregation_function():
-        def average(seq):
-            return sum(seq[1:], start=seq[0]) / len(seq)
-
-        return average
-
-    @staticmethod
     def header(aggregation_tag=False):
-        return (
-            "Average " if aggregation_tag else ""
-        ) + "Thermal Throttle Duration (us)"
+        return ("Max " if aggregation_tag else "") + "Thermal Throttle Duration (us)"
 
     def __eq__(self, other: "ThermalThrottleDurationBase") -> bool:  # type: ignore
         return self.value() == other.value()

--- a/genai-perf/genai_perf/record/types/total_ecc_dbe_aggregate_base.py
+++ b/genai-perf/genai_perf/record/types/total_ecc_dbe_aggregate_base.py
@@ -31,15 +31,8 @@ class ECCDBEAggregateTotalBase(DecreasingGPURecord):
         super().__init__(value, device_uuid, timestamp)
 
     @staticmethod
-    def aggregation_function():
-        def average(seq):
-            return sum(seq[1:], start=seq[0]) / len(seq)
-
-        return average
-
-    @staticmethod
     def header(aggregation_tag=False):
-        return ("Average " if aggregation_tag else "") + "ECC DBE Aggregate Total"
+        return ("Max " if aggregation_tag else "") + "ECC DBE Aggregate Total"
 
     def __eq__(self, other: "ECCDBEAggregateTotalBase") -> bool:  # type: ignore
         return self.value() == other.value()

--- a/genai-perf/genai_perf/record/types/total_ecc_dbe_volatile_base.py
+++ b/genai-perf/genai_perf/record/types/total_ecc_dbe_volatile_base.py
@@ -31,15 +31,8 @@ class ECCDBEVolatileTotalBase(DecreasingGPURecord):
         super().__init__(value, device_uuid, timestamp)
 
     @staticmethod
-    def aggregation_function():
-        def average(seq):
-            return sum(seq[1:], start=seq[0]) / len(seq)
-
-        return average
-
-    @staticmethod
     def header(aggregation_tag=False):
-        return ("Average " if aggregation_tag else "") + "ECC DBE Volatile Total"
+        return ("Max " if aggregation_tag else "") + "ECC DBE Volatile Total"
 
     def __eq__(self, other: "ECCDBEVolatileTotalBase") -> bool:  # type: ignore
         return self.value() == other.value()

--- a/genai-perf/genai_perf/record/types/total_ecc_sbe_aggregate_base.py
+++ b/genai-perf/genai_perf/record/types/total_ecc_sbe_aggregate_base.py
@@ -31,15 +31,8 @@ class ECCSBEAggregateTotalBase(DecreasingGPURecord):
         super().__init__(value, device_uuid, timestamp)
 
     @staticmethod
-    def aggregation_function():
-        def average(seq):
-            return sum(seq[1:], start=seq[0]) / len(seq)
-
-        return average
-
-    @staticmethod
     def header(aggregation_tag=False):
-        return ("Average " if aggregation_tag else "") + "ECC SBE Aggregate Total"
+        return ("Max " if aggregation_tag else "") + "ECC SBE Aggregate Total"
 
     def __eq__(self, other: "ECCSBEAggregateTotalBase") -> bool:  # type: ignore
         return self.value() == other.value()

--- a/genai-perf/genai_perf/record/types/total_ecc_sbe_volatile_base.py
+++ b/genai-perf/genai_perf/record/types/total_ecc_sbe_volatile_base.py
@@ -31,15 +31,8 @@ class ECCSBEVolatileTotalBase(DecreasingGPURecord):
         super().__init__(value, device_uuid, timestamp)
 
     @staticmethod
-    def aggregation_function():
-        def average(seq):
-            return sum(seq[1:], start=seq[0]) / len(seq)
-
-        return average
-
-    @staticmethod
     def header(aggregation_tag=False):
-        return ("Average " if aggregation_tag else "") + "ECC SBE Volatile Total"
+        return ("Max " if aggregation_tag else "") + "ECC SBE Volatile Total"
 
     def __eq__(self, other: "ECCSBEVolatileTotalBase") -> bool:  # type: ignore
         return self.value() == other.value()

--- a/genai-perf/genai_perf/record/types/total_nvlink_crc_flit_errors_base.py
+++ b/genai-perf/genai_perf/record/types/total_nvlink_crc_flit_errors_base.py
@@ -31,16 +31,9 @@ class TotalNVLinkCCRCFlitErrorsBase(DecreasingGPURecord):
         super().__init__(value, device_uuid, timestamp)
 
     @staticmethod
-    def aggregation_function():
-        def average(seq):
-            return sum(seq[1:], start=seq[0]) / len(seq)
-
-        return average
-
-    @staticmethod
     def header(aggregation_tag=False):
         return (
-            "Average " if aggregation_tag else ""
+            "Max " if aggregation_tag else ""
         ) + "Total NVLink CRC flow-control errors"
 
     def __eq__(self, other: "TotalNVLinkCCRCFlitErrorsBase") -> bool:  # type: ignore

--- a/genai-perf/genai_perf/record/types/xid_last_error_base.py
+++ b/genai-perf/genai_perf/record/types/xid_last_error_base.py
@@ -31,15 +31,8 @@ class XidLastErrorBase(DecreasingGPURecord):
         super().__init__(value, device_uuid, timestamp)
 
     @staticmethod
-    def aggregation_function():
-        def average(seq):
-            return sum(seq[1:], start=seq[0]) / len(seq)
-
-        return average
-
-    @staticmethod
     def header(aggregation_tag=False):
-        return ("Average " if aggregation_tag else "") + "Xid Last Error"
+        return ("Max " if aggregation_tag else "") + "Xid Last Error"
 
     def __eq__(self, other: "XidLastErrorBase") -> bool:  # type: ignore
         return self.value() == other.value()

--- a/genai-perf/genai_perf/telemetry_data/dcgm_telemetry_data_collector.py
+++ b/genai-perf/genai_perf/telemetry_data/dcgm_telemetry_data_collector.py
@@ -63,6 +63,9 @@ class DCGMTelemetryDataCollector(TelemetryDataCollector):
         "DCGM_FI_DEV_RETIRED_DBE": TelemetryMetricName.RETIRED_PAGES_DBE,
         "DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL": TelemetryMetricName.NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL,
         "DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL": TelemetryMetricName.NVLINK_CRC_DATA_ERROR_COUNT_TOTAL,
+        "DCGM_FI_PROF_PCIE_TX_BYTES": TelemetryMetricName.PCIE_TRANSMIT_THROUGHPUT,
+        "DCGM_FI_PROF_PCIE_RX_BYTES": TelemetryMetricName.PCIE_RECEIVE_THROUGHPUT,
+        "DCGM_FI_DEV_PCIE_REPLAY_COUNTER": TelemetryMetricName.PCIE_REPLAY_COUNTER,
     }
 
     def _process_and_update_metrics(self, metrics_data: str) -> None:

--- a/genai-perf/tests/test_collectors/test_dcgm_telemetry_data_collector.py
+++ b/genai-perf/tests/test_collectors/test_dcgm_telemetry_data_collector.py
@@ -71,6 +71,10 @@ def test_process_and_update_metrics_success(collector):
     DCGM_FI_DEV_RETIRED_DBE{gpu="0"} 9
     DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL{gpu="0"} 10
     DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL{gpu="0"} 11
+    DCGM_FI_PROF_PCIE_TX_BYTES{gpu="0"} 1048576
+    DCGM_FI_PROF_PCIE_RX_BYTES{gpu="0"} 2097152
+    DCGM_FI_DEV_PCIE_REPLAY_COUNTER{gpu="0"} 3
+
     """
 
     collector._process_and_update_metrics(sample_metrics)
@@ -100,6 +104,9 @@ def test_process_and_update_metrics_success(collector):
     assert update_call["retired_pages_dbe"]["0"] == [9.0]
     assert update_call["total_nvlink_crc_flit_errors"]["0"] == [10.0]
     assert update_call["total_nvlink_crc_data_errors"]["0"] == [11.0]
+    assert update_call["pcie_transmit_throughput"]["0"] == [1048576.0]
+    assert update_call["pcie_receive_throughput"]["0"] == [2097152.0]
+    assert update_call["pcie_replay_counter"]["0"] == [3.0]
 
 
 def test_process_and_update_metrics_ignores_unmapped_metrics(collector):

--- a/genai-perf/tests/test_metrics/test_telemetry_metrics.py
+++ b/genai-perf/tests/test_metrics/test_telemetry_metrics.py
@@ -73,6 +73,9 @@ class TestTelemetryMetrics:
             retired_pages_dbe={"gpu0": [23.0]},
             total_nvlink_crc_flit_errors={"gpu0": [24.0]},
             total_nvlink_crc_data_errors={"gpu0": [25.0]},
+            pcie_transmit_throughput={"gpu0": [26.0]},
+            pcie_receive_throughput={"gpu0": [27.0]},
+            pcie_replay_counter={"gpu0": [0.0]},
         )
 
         assert telemetry.gpu_power_usage == {"gpu0": [0.0]}
@@ -101,6 +104,9 @@ class TestTelemetryMetrics:
         assert telemetry.retired_pages_dbe == {"gpu0": [23.0]}
         assert telemetry.total_nvlink_crc_flit_errors == {"gpu0": [24.0]}
         assert telemetry.total_nvlink_crc_data_errors == {"gpu0": [25.0]}
+        assert telemetry.pcie_transmit_throughput == {"gpu0": [26.0]}
+        assert telemetry.pcie_receive_throughput == {"gpu0": [27.0]}
+        assert telemetry.pcie_replay_counter == {"gpu0": [0.0]}
 
     def test_update_metrics(self) -> None:
         telemetry = TelemetryMetrics()
@@ -120,17 +126,20 @@ class TestTelemetryMetrics:
             "gpu_memory_free": {"gpu0": [4500.0], "gpu1": [4500.0]},
             "gpu_memory_temperature": {"gpu0": [62.0], "gpu1": [63.0]},
             "gpu_temperature": {"gpu0": [72.0], "gpu1": [73.0]},
-            "total_ecc_sbe_volatile": {"gpu0": [1.0]},
-            "total_ecc_dbe_volatile": {"gpu0": [2.0]},
-            "total_ecc_sbe_aggregate": {"gpu0": [3.0]},
-            "total_ecc_dbe_aggregate": {"gpu0": [4.0]},
-            "xid_last_error": {"gpu0": [5.0]},
-            "power_throttle_duration": {"gpu0": [6.0]},
-            "thermal_throttle_duration": {"gpu0": [7.0]},
-            "retired_pages_sbe": {"gpu0": [8.0]},
-            "retired_pages_dbe": {"gpu0": [9.0]},
-            "total_nvlink_crc_flit_errors": {"gpu0": [10.0]},
-            "total_nvlink_crc_data_errors": {"gpu0": [11.0]},
+            "total_ecc_sbe_volatile": {"gpu0": [1.0], "gpu1": [1.1]},
+            "total_ecc_dbe_volatile": {"gpu0": [2.0], "gpu1": [2.1]},
+            "total_ecc_sbe_aggregate": {"gpu0": [3.0], "gpu1": [3.1]},
+            "total_ecc_dbe_aggregate": {"gpu0": [4.0], "gpu1": [4.1]},
+            "xid_last_error": {"gpu0": [5.0], "gpu1": [5.1]},
+            "power_throttle_duration": {"gpu0": [6.0], "gpu1": [6.1]},
+            "thermal_throttle_duration": {"gpu0": [7.0], "gpu1": [7.1]},
+            "retired_pages_sbe": {"gpu0": [8.0], "gpu1": [8.1]},
+            "retired_pages_dbe": {"gpu0": [9.0], "gpu1": [9.1]},
+            "total_nvlink_crc_flit_errors": {"gpu0": [10.0], "gpu1": [10.1]},
+            "total_nvlink_crc_data_errors": {"gpu0": [11.0], "gpu1": [11.1]},
+            "pcie_transmit_throughput": {"gpu0": [26.0], "gpu1": [26.1]},
+            "pcie_receive_throughput": {"gpu0": [27.0], "gpu1": [27.1]},
+            "pcie_replay_counter": {"gpu0": [0.0], "gpu1": [1.0]},
         }
 
         telemetry.update_metrics(measurement_data)

--- a/genai-perf/tests/test_statistics/test_telemetry_statistics.py
+++ b/genai-perf/tests/test_statistics/test_telemetry_statistics.py
@@ -43,6 +43,8 @@ class TestTelemetryStatistics:
                 "energy_consumption": {"gpu0": [1000000000.0], "gpu1": [2000000000.0]},
                 "total_gpu_memory": {"gpu0": [8000000000.0], "gpu1": [16000000000.0]},
                 "gpu_memory_used": {"gpu0": [4000], "gpu1": [5000]},
+                "pcie_transmit_throughput": {"gpu0": [1024.0], "gpu1": [2048.0]},
+                "pcie_receive_throughput": {"gpu0": [512.0], "gpu1": [4096.0]},
             }
         )
         return telemetry
@@ -93,6 +95,11 @@ class TestTelemetryStatistics:
         assert (
             round(stats_dict["gpu_memory_used"]["gpu1"]["avg"], 2) == 5.24
         )  # 5.24288 GB
+        assert stats_dict["pcie_transmit_throughput"]["gpu0"]["avg"] == 1.0
+        assert stats_dict["pcie_transmit_throughput"]["gpu1"]["avg"] == 2.0
+
+        assert stats_dict["pcie_receive_throughput"]["gpu0"]["avg"] == 0.5
+        assert stats_dict["pcie_receive_throughput"]["gpu1"]["avg"] == 4.0
 
     def test_create_records(self, telemetry_statistics):
         telemetry_statistics._stats_dict = telemetry_statistics.stats_dict


### PR DESCRIPTION
PR to add PCie metrics

### PCIE Metrics
- `pcie_transmit_throughput`
- `pcie_receive_throughput`
- `pcie_replay_counter`

<img width="1210" alt="image" src="https://github.com/user-attachments/assets/58b3e23a-15ed-4e7d-a237-8b4d67b2ccd7" />
