### PR TITLE
Get rid of --service-kind in genai-perf README

### DIFF
--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -426,7 +426,6 @@ Example genai-perf command to run the generated payload:
 genai-perf profile \
     --tokenizer deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
     -m deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
-    --service-kind openai \
     --endpoint-type chat \
     --url http://localhost:8000 \
     --streaming \


### PR DESCRIPTION
When executing the genai-perf test with reference to the README, it will report an error that service-kind is an unrecognized argument. The error details is as follows:

> usage: genai-perf [-h] [--version] {config,profile,analyze,create-template,process-export-files} ...
genai-perf: error: unrecognized arguments: --service-kind openai

After analysis, it is known that the service-kind argument has been removed through (https://github.com/triton-inference-server/perf_analyzer/pull/355)


