### PR TITLE
Add wheel support for Perf Analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ artifacts/
 
 # Avoid squashing local people's file for now
 /.vscode
+
+# Python setuptools artifacts
+*.egg-info/
+dist/
+bin/

--- a/genai-perf/pyproject.toml
+++ b/genai-perf/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -65,7 +65,7 @@ dependencies = [
   "soundfile",
   "statsmodels",
   "transformers",
-  "tritonclient",
+  "perf-analyzer",
 ]
 
 # CLI Entrypoint

--- a/src/perf_analyzer/__init__.py
+++ b/src/perf_analyzer/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -24,51 +24,4 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[build-system]
-requires = ["setuptools>=42", "wheel"]
-build-backend = "setuptools.build_meta"
-
-[project]
-name = "perf-analyzer"
-dynamic = ["version"]
-description = "Triton Performance Analyzer"
-readme = "README.md"
-
-[tool.setuptools.dynamic]
-version = {attr = "perf_analyzer.__version__"}
-
-[tool.setuptools.packages.find]
-where = ["src"]
-
-[tool.setuptools.package-data]
-"perf_analyzer" = ["bin/perf_analyzer"]
-
-[project.scripts]
-perf_analyzer = "perf_analyzer.cli:main"
-
-[tool.codespell]
-# note: pre-commit passes explicit lists of files here, which this skip file list doesn't override -
-# this is only to allow you to run codespell interactively
-# this also overrides the grpc_generated folder, since it is generated
-skip = "./.git,./.github"
-# ignore short words, and typename parameters like OffsetT
-ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
-# ignore allowed words
-# ignoring atleast to avoid testing::AtLeast from getting flagged
-ignore-words-list = "atleast"
-# use the 'clear' dictionary for unambiguous spelling mistakes
-builtin = "clear"
-# disable warnings about binary files and wrong encoding
-quiet-level = 3
-
-[tool.isort]
-profile = "black"
-use_parentheses = true
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-ensure_newline_before_comments = true
-line_length = 88
-balanced_wrapping = true
-indent = "    "
-skip = ["build"]
+__version__ = "2.58.0dev"

--- a/src/perf_analyzer/cli.py
+++ b/src/perf_analyzer/cli.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -24,51 +24,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[build-system]
-requires = ["setuptools>=42", "wheel"]
-build-backend = "setuptools.build_meta"
+import subprocess
+import sys
+from pathlib import Path
 
-[project]
-name = "perf-analyzer"
-dynamic = ["version"]
-description = "Triton Performance Analyzer"
-readme = "README.md"
 
-[tool.setuptools.dynamic]
-version = {attr = "perf_analyzer.__version__"}
-
-[tool.setuptools.packages.find]
-where = ["src"]
-
-[tool.setuptools.package-data]
-"perf_analyzer" = ["bin/perf_analyzer"]
-
-[project.scripts]
-perf_analyzer = "perf_analyzer.cli:main"
-
-[tool.codespell]
-# note: pre-commit passes explicit lists of files here, which this skip file list doesn't override -
-# this is only to allow you to run codespell interactively
-# this also overrides the grpc_generated folder, since it is generated
-skip = "./.git,./.github"
-# ignore short words, and typename parameters like OffsetT
-ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
-# ignore allowed words
-# ignoring atleast to avoid testing::AtLeast from getting flagged
-ignore-words-list = "atleast"
-# use the 'clear' dictionary for unambiguous spelling mistakes
-builtin = "clear"
-# disable warnings about binary files and wrong encoding
-quiet-level = 3
-
-[tool.isort]
-profile = "black"
-use_parentheses = true
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-ensure_newline_before_comments = true
-line_length = 88
-balanced_wrapping = true
-indent = "    "
-skip = ["build"]
+def main():
+    bin_path = Path(__file__).parent / "bin/perf_analyzer"
+    subprocess.run([bin_path] + sys.argv[1:])


### PR DESCRIPTION
- In an effort to decouple the GenAI-Perf and Perf Analyzer release process from the Triton release process, we propose releasing Perf Analyzer as its own pypi package
- Previously, Perf Analyzer was included in the Triton `tritonclient` pypi package, definitionally coupling Triton with GAP/PA
- This PR adds some necessary support code for allowing a python wheel to be created for Perf Analyzer
- The wheel simply includes the `perf_analyzer` binary and a single wrapper python script that calls it and forwards all arguments