### PR TITLE
fix: do not modify first token if tokenizer.bos_token_id is none

### DIFF
--- a/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
+++ b/genai-perf/genai_perf/inputs/retrievers/synthetic_prompt_generator.py
@@ -192,8 +192,9 @@ class SyntheticPromptGenerator:
                 # and insert the bos token at the beginning. Length is maintained and
                 # the prompt generates the expected number of tokens.
                 prompt_tokens = cls._generate_prompt_tokens(size_to_use)
-                prompt_tokens.pop(0)
-                prompt_tokens.insert(0, tokenizer.bos_token_id())
+                if tokenizer.bos_token_id is not None:
+                    prompt_tokens.pop(0)
+                    prompt_tokens.insert(0, tokenizer.bos_token_id)
                 cls._cache[hash_index] = prompt_tokens
             final_prompt.extend(cls._cache[hash_index])
         prompt = tokenizer.decode(final_prompt, skip_special_tokens=False)


### PR DESCRIPTION
Qwen/Qwen2.5-0.5B-Instruct tokenizer.bos_token_id is None. 
However, genai-perf assumes it is not None and uses to replace the first token of the final prompt.
Since the first token is None, tokenizer.decode() raises failures.
To fix it, we need to add if tokenizer.bos_token_id() check before replacing first token.
Verified the fix works.
