### PR TITLE
Mask api keys in genai_perf's logs

### DIFF
--- a/genai-perf/genai_perf/subcommand/subcommand.py
+++ b/genai-perf/genai_perf/subcommand/subcommand.py
@@ -14,6 +14,7 @@
 
 import os
 import subprocess  # nosec
+import re
 from typing import Dict, List, Optional, Tuple
 
 import genai_perf.logging as logging
@@ -95,7 +96,10 @@ class Subcommand:
 
             remove_file(perf_analyzer_config.get_profile_export_file())
             cmd = perf_analyzer_config.create_command()
-            logger.info(f"Running Perf Analyzer : '{' '.join(cmd)}'")
+            
+            # Mask the Authorization token
+            masked_cmd = re.sub(r'(-H Authorization: Bearer )\S+', r'\1********', ' '.join(cmd))
+            logger.info(f"Running Perf Analyzer : '{masked_cmd}'")
 
             if self._config.verbose or self._config.perf_analyzer.verbose:
                 subprocess.run(cmd, check=True, stdout=None)  # nosec


### PR DESCRIPTION
Right now, genai_perf prints unmasked credentials in logs:
```
[2025-07-09 14:34:23] INFO     Running Perf Analyzer : 'perf_analyzer -m meta/llama-3.1-8b-instruct -async     subcommand.py:98
                               --stability-percentage 999 --request-count 10 -i http -u                                               
                               https://integrate.api.nvidia.com --concurrency-range 1 --service-kind openai                           
                               --endpoint v1/chat/completions -H Authorization: Bearer                                                
           printed here -->    <api_key_here> --input-data
                               ...[the rest of the comand]
```
This small PR changes the logging statement to mask the api keys (replace them with asterisks).
Example log after the change:
```
[2025-07-09 22:09:42] INFO     Running Perf Analyzer : 'perf_analyzer -m meta/llama-3.1-8b-instruct --async  subcommand.py:102
                               --stability-percentage 999 --request-count 5 -i http -u                                              
                               https://integrate.api.nvidia.com --concurrency-range 1 --service-kind openai                         
                               --endpoint v1/chat/completions --max-threads=1 -H Authorization: Bearer ********                     
                               --input-data                                                                                         
                               ...[the rest of the comand]
```