### PR TITLE
feat: add multiframe image input support for OpenAI Chat endpoint

### DIFF
--- a/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
+++ b/genai-perf/genai_perf/inputs/converters/openai_chat_completions_converter.py
@@ -44,10 +44,6 @@ class OpenAIChatCompletionsConverter(BaseConverter):
                 raise GenAIPerfException(
                     f"The --batch-size-text flag is not supported for {self.config.endpoint.output_format.to_lowercase()}."
                 )
-            if self.config.input.image.batch_size != InputDefaults.BATCH_SIZE:
-                raise GenAIPerfException(
-                    f"The --batch-size-image flag is not supported for {self.config.endpoint.output_format.to_lowercase()}."
-                )
 
     def convert(
         self,

--- a/genai-perf/tests/test_converters/test_openai_chat_converter.py
+++ b/genai-perf/tests/test_converters/test_openai_chat_converter.py
@@ -349,9 +349,9 @@ class TestOpenAIChatCompletionsConverter:
     @pytest.mark.parametrize(
         "batch_size_image",
         [
+            0,  # no images
             1,
-            2,
-            3,
+            123,
         ],
     )
     def test_convert_multi_modal_with_batched_image(self, batch_size_image):


### PR DESCRIPTION
Enable multiframe image payload for OpenAI Chat endpoint. The request payload for image batch size of >1 will look like:
```
{
    "model": "some-model",
    "messages": [
        {
            "role": "user",
            "content": [
                {
                    "type": "text",
                    "text": "hello world!"
                },
                {
                    "type": "image_url",
                    "image_url": { "url": "..." }
                },
                {
                    "type": "image_url",
                    "image_url": { "url": "..." }
                },
                ...
            ]
        }
    ]
}
```