### PR TITLE
feat: genai-perf create template with header name option

### DIFF
--- a/genai-perf/genai_perf/config/input/config_command.py
+++ b/genai-perf/genai_perf/config/input/config_command.py
@@ -74,6 +74,11 @@ class ConfigCommand(BaseConfig):
             add_to_template=False,
         )
 
+        self.template_header: Any = ConfigField(
+            default=TopLevelDefaults.TEMPLATE_HEADER,
+            add_to_template=False,
+        )
+
         self.analyze = ConfigAnalyze()
         self.endpoint = ConfigEndPoint()
         self.perf_analyzer = ConfigPerfAnalyzer()
@@ -292,4 +297,4 @@ class ConfigCommand(BaseConfig):
     # Template Creation Methods
     ###########################################################################
     def make_template(self) -> str:
-        return self.create_template(header="", level=0, verbose=self.verbose)
+        return self.create_template(header=self.template_header, level=0, verbose=self.verbose)

--- a/genai-perf/genai_perf/config/input/config_command.py
+++ b/genai-perf/genai_perf/config/input/config_command.py
@@ -110,7 +110,13 @@ class ConfigCommand(BaseConfig):
         skip_inferencing_and_checking: bool = False,
     ) -> None:
         if user_config:
-            for key, value in user_config.items():
+            # Empty header name checks
+            if user_config.get("model_name") is not None:
+                config_items = user_config.items()
+            else:
+                config_items = user_config[list(user_config.keys())[0]].items()
+
+            for key, value in config_items:
                 if key == "model_name" or key == "model_names":
                     self._parse_model_names(value)
                 elif key == "analyze":

--- a/genai-perf/genai_perf/config/input/config_defaults.py
+++ b/genai-perf/genai_perf/config/input/config_defaults.py
@@ -45,6 +45,7 @@ class TopLevelDefaults:
     SUBCOMMAND = Subcommand.CONFIG
     VERBOSE = False
     TEMPLATE_FILENAME = "genai_perf_config.yaml"
+    TEMPLATE_HEADER = "config_template"
 
 
 @dataclass(frozen=True)

--- a/genai-perf/genai_perf/config/input/create_config.py
+++ b/genai-perf/genai_perf/config/input/create_config.py
@@ -68,6 +68,8 @@ class CreateConfig:
 
         if args.file:
             config.template_filename = args.file
+        if args.header:
+            config.template_header = args.header
 
         return config
 

--- a/genai-perf/genai_perf/parser.py
+++ b/genai-perf/genai_perf/parser.py
@@ -268,6 +268,12 @@ def _add_template_args(parser):
         help="The name to the template file that will be created.",
     )
 
+    template_group.add_argument(
+        "--header",
+        type=str,
+        help="The header name to be used in the config template file."
+    )
+
 
 def _add_config_args(parser):
     config_group = parser.add_argument_group("Config")

--- a/genai-perf/tests/test_cli.py
+++ b/genai-perf/tests/test_cli.py
@@ -719,6 +719,16 @@ class TestCLIArguments:
         config = CreateConfig.create(args)
         assert config.template_filename == Path("custom_template.yaml")
 
+    def test_non_default_create_template_header(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "sys.argv",
+            ["genai-perf", "create-template", "--header", "custom_header"],
+        )
+
+        args, _ = parser.parse_args()
+        config = CreateConfig.create(args)
+        assert config.template_header == "custom_header"
+
     @pytest.mark.parametrize(
         "args, expected_error_message",
         [


### PR DESCRIPTION
I used `genai-perf create-template` to create config while finding that the indention is broken. After reading source code, I found that it is because of default empty header name.

I think the indention of default config template is not beautiful, therefore I wrote code for it. 
- Add `--header` for create-template
- Add default header name `config-template`
- Patch config parse (compatible with no header name ones)