### PR TITLE
fix: wrong handling chunked response in streaming mode and concurrent session

### DIFF
--- a/src/client_backend/client_backend.h
+++ b/src/client_backend/client_backend.h
@@ -678,6 +678,13 @@ class InferResult {
     return Error("InferResult::IsNullResponse() not implemented");
   };
 
+  /// Get stream response bool for this response.
+  /// \return Error object indicating the success or failure.
+  virtual Error IsStreamResponse(bool* is_stream_response) const
+  {
+    return Error("InferReuslt::IsStreamRsponse() not implemented");
+  };
+
   /// Returns the response timestamps of the streaming request.
   /// \return Error object indicating the success or failure.
   virtual Error ResponseTimestamps(

--- a/src/client_backend/openai/openai_client.cc
+++ b/src/client_backend/openai/openai_client.cc
@@ -65,7 +65,7 @@ ChatCompletionRequest::SendResponse(bool is_final, bool is_null)
 {
   final_response_sent_ = is_final;
   response_callback_(new ChatCompletionResult(
-      http_code_, std::move(response_buffer_), is_final, is_null, request_id_));
+      http_code_, std::move(response_buffer_), is_final, is_null, is_stream_, request_id_));
 }
 
 ChatCompletionClient::ChatCompletionClient(

--- a/src/client_backend/openai/openai_client.h
+++ b/src/client_backend/openai/openai_client.h
@@ -40,10 +40,11 @@ class ChatCompletionResult : public InferResult {
  public:
   ChatCompletionResult(
       uint32_t http_code, std::string&& serialized_response, bool is_final,
-      bool is_null, const std::string& request_id)
+      bool is_null, bool is_stream, const std::string& request_id)
       : http_code_(http_code),
         serialized_response_(std::move(serialized_response)),
-        is_final_(is_final), is_null_(is_null), request_id_(request_id)
+        is_final_(is_final), is_null_(is_null), is_stream_(is_stream),
+        request_id_(request_id)
   {
   }
   virtual ~ChatCompletionResult() = default;
@@ -99,11 +100,20 @@ class ChatCompletionResult : public InferResult {
     return Error::Success;
   };
 
+  /// Get stream response bool for this response.
+  /// \return Error object indicating the success or failure.
+  Error IsStreamResponse(bool* is_stream_response) const override
+  {
+    *is_stream_response = is_stream_;
+    return Error::Success;
+  };
+
  private:
   const uint32_t http_code_{200};
   const std::string serialized_response_;
   const bool is_final_{false};
   const bool is_null_{false};
+  const bool is_stream_{false};
   const std::string request_id_;
 };
 

--- a/src/session_concurrency/payload_json_utils.h
+++ b/src/session_concurrency/payload_json_utils.h
@@ -50,6 +50,10 @@ class PayloadJsonUtils {
   static void ValidatePayloadMessages(
       const rapidjson::Document& payload_document);
 
+  static void UpdateContent(
+    rapidjson::Value& item,
+    std::string& buffer,
+    rapidjson::Document::AllocatorType& allocator);
   static void SetPayloadToChatHistory(
       rapidjson::Document& payload_document,
       const rapidjson::Document& chat_history);

--- a/src/session_concurrency/response_json_utils.h
+++ b/src/session_concurrency/response_json_utils.h
@@ -39,6 +39,13 @@ class ResponseJsonUtils {
 
   static const rapidjson::Value& GetMessage(
       const rapidjson::Document& response_document);
+  static const rapidjson::Value& GetDelta(
+      const rapidjson::Document& response_document);
+
+private:
+  static const rapidjson::Value& GetChoices(
+    const rapidjson::Document& response_document,
+    const int choices_index=0);
 };
 
 }  // namespace triton::perfanalyzer


### PR DESCRIPTION
This is a fix for an issue that perf_analyzer failed to proceed chunked responses from the server which is enabled for HTTP SSE.

When specifying `--session-concurrency` and `--service-kind openai` together for input payloads which include `"stream": true`, PA failed during parsing a response which is delta response with a SSE prefix, `data:` like below. Also, after one fix for this parsing issue, another error, `what():  std::future_error: Promise already satisfied`, happened. This was caused because PA doesn't properly consider SSE responses and multi-turn payload from the chat history.

So, this PR fixes these two problems.

```
$ perf_analyzer -m tensorrt_llm_bls --async --stability-percentage 999 --request-count 10 -i http -u ${SERVER_IP}:${SERVER_PORT} --service-kind openai --endpoint v1/chat/completions --input-data artifacts/tensorrt_llm_bls-openai-chat-session_concurrency2/inputs.json --profile-export-file artifacts/tensorrt_llm_bls-openai-chat-session_concurrency2/profile_export.json --session-concurrency 2

 Successfully read data for 1 stream/streams with 32 step/steps.
*** Measurement Settings ***
  Service Kind: OPENAI
  Sending 10 benchmark requests
  Using asynchronous calls for inference

terminate called after throwing an instance of 'std::runtime_error'
  what():  RapidJSON parse error 3. Review JSON for formatting errors:

data: {"id":"cmpl-65fe0899-74b8-11f0-a1f8-89b7d5751a62","choices":[{"delta":{"content":"","function_call":null,"role":"assistant"},"logprobs":null,"finish_reason":null,"index":0}],"created":1754699578,"model":"tensorrt_llm_bls","system_fingerprint":null,"object":"chat.completion.chunk","usage":null}





Aborted (core dumped)
```

FYI. the result with `--concurrency-range` instead of `--session-concurrency` for the same payload excluding `"session_id":` is below. No issue happened.

```
$ perf_analyzer -m tensorrt_llm_bls --async --stability-percentage 999 --request-count 10 -i http -u ${SERVER_IP}:${SERVER_PORT} --service-kind openai --endpoint v1/chat/completions --input-data artifacts/tensorrt_llm_bls-openai-chat-concurrency2/inputs.json --profile-export-file artifacts/tensorrt_llm_bls-openai-chat-concurrency2/profile_export.json --concurrency-range 2
 Successfully read data for 1 stream/streams with 100 step/steps.
*** Measurement Settings ***
  Service Kind: OPENAI
  Sending 10 benchmark requests
  Using asynchronous calls for inference

Request concurrency: 2
  Client:
    Request count: 10
    Throughput: 0.454482 infer/sec
    Avg latency: 3855839 usec (standard deviation 1410191 usec)
    p50 latency: 2925832 usec
    p90 latency: 8296468 usec
    p95 latency: 8383974 usec
    p99 latency: 8383974 usec
    Avg HTTP time: 4028137 usec (send/recv 4010796 usec + response wait 17341 usec)
Inferences/Second vs. Client Average Batch Latency
Concurrency: 2, throughput: 0.454482 infer/sec, latency 3855839 usec
```