### PR TITLE
Correct batch size text option formatting

### DIFF
--- a/genai-perf/README.md
+++ b/genai-perf/README.md
@@ -682,11 +682,11 @@ Currently only 1 (mono) and 2 (stereo) are supported.
 
 ##### `-b <int>`
 ##### `--batch-size <int>`
-##### `--batch-size-text <int>
+##### `--batch-size-text <int>`
 
 The text batch size of the requests GenAI-Perf should send.
 (default: `1`)
-##### `--batch-size-text <int>
+##### `--batch-size-text <int>`
 
 The text batch size of the requests GenAI-Perf should send.
 (default: `1`)


### PR DESCRIPTION
Fix formatting for batch size text option in README.