### PR TITLE
build(deps): Align protobuf and related dependencies with the gRPC v1.81.1 bump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -61,6 +61,7 @@ set(TRITON_REPO_ORGANIZATION "https://github.com/triton-inference-server" CACHE 
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_CLIENT_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
+set(TRITON_THIRD_PARTY_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/third_party repo")
 
 #
 # Install locations
@@ -97,6 +98,7 @@ ExternalProject_Add(
       -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION}
       -DTRITON_CORE_REPO_TAG:STRING=${TRITON_CORE_REPO_TAG}
       -DTRITON_COMMON_REPO_TAG:STRING=${TRITON_COMMON_REPO_TAG}
+      -DTRITON_THIRD_PARTY_REPO_TAG:STRING=${TRITON_THIRD_PARTY_REPO_TAG}
       -DTRITON_ENABLE_CC_HTTP:BOOL=${TRITON_ENABLE_CC_HTTP}
       -DTRITON_ENABLE_CC_GRPC:BOOL=${TRITON_ENABLE_CC_GRPC}
       -DTRITON_ENABLE_PYTHON_HTTP:BOOL=OFF
@@ -159,6 +161,7 @@ if(TRITON_ENABLE_PYTHON_HTTP OR TRITON_ENABLE_PYTHON_GRPC)
         -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION}
         -DTRITON_CORE_REPO_TAG:STRING=${TRITON_CORE_REPO_TAG}
         -DTRITON_COMMON_REPO_TAG:STRING=${TRITON_COMMON_REPO_TAG}
+        -DTRITON_THIRD_PARTY_REPO_TAG:STRING=${TRITON_THIRD_PARTY_REPO_TAG}
         -DTRITON_ENABLE_CC_HTTP:BOOL=OFF
         -DTRITON_ENABLE_CC_GRPC:BOOL=OFF
 	      -DTRITON_ENABLE_EXAMPLES:BOOL=ON

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,8 +53,12 @@ set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/co
 # Install locations
 set(TRITON_THIRD_PARTY_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/third-party-install" CACHE STRING "Location of third-party build")
 
-# Add third party installation to the search path
-set(CMAKE_PREFIX_PATH ${TRITON_THIRD_PARTY_INSTALL_PREFIX} ${CMAKE_PREFIX_PATH})
+# Add third party installation to the search path. The protobuf install
+# tree is listed as its own prefix so that the utf8_range package config
+# it nests (required by protobuf-config since protobuf v33) is found.
+set(CMAKE_PREFIX_PATH
+    ${TRITON_THIRD_PARTY_INSTALL_PREFIX}
+    "${TRITON_THIRD_PARTY_INSTALL_PREFIX}/protobuf" ${CMAKE_PREFIX_PATH})
 
 # Triton CC Client Libraries
 find_library(TRITON_HTTP_STATIC_LIB

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,16 @@ cmake_minimum_required (VERSION 3.31.8)
 
 project(perf-analyzer LANGUAGES C CXX)
 
+# Compile every target at the same standard the third-party stack was
+# built with. The abseil install pins its options (e.g. C++20
+# std-ordering types) to the standard used at build time, so targets
+# that fall back to the compiler default standard fail to compile
+# against its headers.
+if(TRITON_MIN_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD ${TRITON_MIN_CXX_STANDARD})
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
 #
 # Perf Analyzer Options
 #

--- a/src/client_backend/tensorflow_serving/tfserve_client_backend.cc
+++ b/src/client_backend/tensorflow_serving/tfserve_client_backend.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2026, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -67,7 +67,7 @@ TFServeClientBackend::ModelMetadata(
   std::string metadata;
   ::google::protobuf::util::JsonPrintOptions options;
   options.preserve_proto_field_names = true;
-  options.always_print_primitive_fields = true;
+  options.always_print_fields_with_no_presence = true;
   ::google::protobuf::util::MessageToJsonString(
       metadata_proto, &metadata, options);
 

--- a/src/client_backend/triton/triton_client_backend.cc
+++ b/src/client_backend/triton/triton_client_backend.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -190,7 +190,7 @@ TritonClientBackend::ModelMetadata(
     std::string metadata;
     ::google::protobuf::util::JsonPrintOptions options;
     options.preserve_proto_field_names = true;
-    options.always_print_primitive_fields = true;
+    options.always_print_fields_with_no_presence = true;
     ::google::protobuf::util::MessageToJsonString(
         model_metadata_proto, &metadata, options);
 
@@ -218,7 +218,7 @@ TritonClientBackend::ModelConfig(
     std::string config;
     ::google::protobuf::util::JsonPrintOptions options;
     options.preserve_proto_field_names = true;
-    options.always_print_primitive_fields = true;
+    options.always_print_fields_with_no_presence = true;
     ::google::protobuf::util::MessageToJsonString(
         model_config_proto, &config, options);
 


### PR DESCRIPTION
#### What does the PR do?
Fixes the nightly build against the gRPC v1.81.1 / protobuf v33 third_party bump:
- Define a `TRITON_THIRD_PARTY_REPO_TAG` cache variable and forward it to the cc-clients and python-clients ExternalProject builds. Previously the client sub-builds fell back to their default third_party tag and picked up a revision incompatible with the rest of the build.
- Add the protobuf install tree as an extra `CMAKE_PREFIX_PATH` entry so the `utf8_range` package config nested inside it (required by protobuf v33's package config, pulled in transitively via `gRPCConfig`) resolves during perf-analyzer configure.
- Set `CMAKE_CXX_STANDARD` project-wide from `TRITON_MIN_CXX_STANDARD` (default 20). The abseil install pins its options to the standard used at build time (C++20 selects the `std::` ordering types); the client-backend object libraries previously compiled at the compiler default (`gnu++17`) and failed against the pinned abseil headers.
- Adapt to the protobuf v33 API: `JsonPrintOptions::always_print_primitive_fields` was removed — use its replacement `always_print_fields_with_no_presence` (triton and TFS client backends).

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Related PRs:
- triton-inference-server/client#908
- triton-inference-server/common#160
- triton-inference-server/core#516
- triton-inference-server/server#8888
- triton-inference-server/third_party#79

#### Where should the reviewer start?
- `CMakeLists.txt` — `TRITON_THIRD_PARTY_REPO_TAG` cache var and its forwarding to both sub-builds

#### Test plan:
Nightly build pipeline on internal GitLab CI.

- CI Pipeline ID: 58489960

#### Caveats:
None.

#### Background
The gRPC v1.81.1 / protobuf v33 update in triton-inference-server/third_party#76 broke the nightly build across the Triton repos; this PR chain repairs it.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Resolves: TRI-1608

<sup>
CI (internal): [#58489960](http://tritonserver.local/ci/pipelines/58489960)<br/>
</sup>

