### PR TITLE
build: align perf_analyzer and genai-perf wheel metadata on PEP 639

### DIFF
--- a/genai-perf/pyproject.toml
+++ b/genai-perf/pyproject.toml
@@ -28,7 +28,8 @@
 name = "genai-perf"
 readme = "README.md"
 description = "GenAI Perf Analyzer CLI - CLI tool to simplify profiling LLMs and Generative AI models with Perf Analyzer"
-license = {text = "BSD"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 dynamic = ["version"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -78,7 +79,7 @@ genai-perf = "genai_perf.main:main"
 
 # Build
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.27.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,23 +25,30 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [build-system]
-requires = ["setuptools>=42", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling==1.27.0"]
+build-backend = "hatchling.build"
 
 [project]
 name = "perf-analyzer"
 dynamic = ["version"]
 description = "Triton Performance Analyzer"
 readme = "README.md"
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
+# Also pins the wheel to a py3 tag: without it hatchling emits
+# py2.py3-none-any, wrongly advertising Python 2 support.
+requires-python = ">=3.10"
 
-[tool.setuptools.dynamic]
-version = {attr = "perf_analyzer.__version__"}
+[tool.hatch.version]
+path = "src/perf_analyzer/__init__.py"
 
-[tool.setuptools.packages.find]
-where = ["src"]
-
-[tool.setuptools.package-data]
-"perf_analyzer" = ["bin/perf_analyzer"]
+[tool.hatch.build.targets.wheel]
+packages = ["src/perf_analyzer"]
+# bin/perf_analyzer is produced by the CMake build and matched by the
+# "bin/" rule in .gitignore. Hatchling's file selection is VCS-ignore
+# aware, so without listing it as an artifact the compiled binary would
+# be silently dropped from the wheel. See TRI-1775.
+artifacts = ["src/perf_analyzer/bin/perf_analyzer"]
 
 [project.scripts]
 perf_analyzer = "perf_analyzer.cli:main"


### PR DESCRIPTION
#### What does the PR do?

**perf_analyzer**
- Migrates from an unbounded `setuptools>=42` to a pinned hatchling backend.
- Declares `license` + `license-files`; it previously declared no license at all.
- Adds `requires-python = ">=3.10"` — without it hatchling tags the wheel `py2.py3-none-any`, wrongly advertising Python 2.
- Lists `src/perf_analyzer/bin/perf_analyzer` as a wheel artifact.

**genai-perf**
- Replaces the deprecated `license = {text = "BSD"}` with SPDX `BSD-3-Clause`; pins hatchling.

#### Where should the reviewer start?
The `artifacts` entry in `pyproject.toml`.

#### Test plan:
Verified for both: Metadata-Version 2.4, `License-Expression`, `License-File`, unchanged `py3-none-any` tag and entry points, the `perf_analyzer` binary present in the wheel, `twine check` passes.

#### Caveats:
The binary is CMake-generated and matched by the `bin/` rule in `.gitignore`; hatchling file selection is VCS-ignore aware, so without the `artifacts` entry it would be **silently dropped** from the wheel.

#### Related PRs:
- triton-inference-server/core#527
- triton-inference-server/server#8970
- triton-inference-server/client#927
- triton-inference-server/model_analyzer#1038
- triton-inference-server/triton_cli#130

#### Related Issues:
- Resolves: TRI-1775
<sup>
CI (internal): [#67460724](http://tritonserver.local/ci/pipelines/67460724)<br/>
</sup>
